### PR TITLE
Add Specify configuration for project documentation

### DIFF
--- a/.specify/config.yaml
+++ b/.specify/config.yaml
@@ -6,8 +6,5 @@ spec_dir: "docs"
 # Path to the task management file
 task_file: "TASKS.md"
 
-# LLM model settings for synchronization (optional)
-# model: "claude-3-5-sonnet-20241022"
-
 # Project root directory
 root_dir: "."


### PR DESCRIPTION
## Summary
- Add Specify configuration file to establish documentation structure
- Configure docs directory for specifications, design docs, and guidelines
- Set up task management file path (TASKS.md)

## Test plan
- [ ] Verify .specify/config.yaml is properly formatted
- [ ] Confirm spec_dir points to correct documentation directory
- [ ] Test that Specify can read the configuration

🤖 Generated with [Claude Code](https://claude.com/claude-code)