### PR TITLE
Add workflow_dispatch trigger to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+  workflow_dispatch:
 
 jobs:
   build-and-test:


### PR DESCRIPTION
## Summary
- Add `workflow_dispatch` trigger to CI workflow to enable manual execution from GitHub Actions UI

## Changes
- Updated `.github/workflows/ci.yml` to include `workflow_dispatch` trigger

## Test plan
- [ ] Merge this PR
- [ ] Navigate to Actions tab → CI workflow
- [ ] Verify "Run workflow" button appears
- [ ] Test manual workflow execution

🤖 Generated with [Claude Code](https://claude.com/claude-code)