### PR TITLE
Add *.local.* pattern to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,6 @@ ScaffoldingReadMe.txt
 Thumbs.db
 ehthumbs.db
 Desktop.ini
+
+# Local configuration files
+*.local.*


### PR DESCRIPTION
## Summary
- Add `*.local.*` pattern to .gitignore to exclude local configuration files from version control
- This allows developers to maintain local-specific settings (e.g., `appsettings.local.json`) without accidentally committing them

## Test plan
- [x] Verify .gitignore pattern is correctly added
- [ ] Confirm files matching `*.local.*` are ignored by git status

🤖 Generated with [Claude Code](https://claude.com/claude-code)