### PR TITLE
test: migrate from FluentAssertions to AwesomeAssertions

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -20,8 +20,8 @@ paths:
 
 ## Assertions
 
-### FluentAssertions
-- Use **FluentAssertions** for general logic and high-level behavioral tests
+### AwesomeAssertions
+- Use **AwesomeAssertions** for general logic and high-level behavioral tests
 - Provides more readable and expressive assertions
 - Example: `result.Should().Be(expected);`
 

--- a/docs/development_guidelines.md
+++ b/docs/development_guidelines.md
@@ -58,8 +58,8 @@
 
 ## 3. Testing
 - **Framework**: Use **xUnit** as the primary testing framework.
-- **Assertions**: 
-    - Use **FluentAssertions** for general logic and high-level behavioral tests.
+- **Assertions**:
+    - Use **AwesomeAssertions** for general logic and high-level behavioral tests.
     - Use **Standard xUnit Asserts** for tests that are explicitly intended to run under **Native AOT** environments.
 - **Performance Testing**:
     - **BenchmarkDotNet** is mandatory for core engine components (`MmapService`, `RowIndexer`, `Parser`).

--- a/docs/mmap-service-plan.md
+++ b/docs/mmap-service-plan.md
@@ -118,7 +118,7 @@ tests/DataMorph.Tests/IO/
 
 **File:** `tests/DataMorph.Tests/IO/MmapServiceTests.cs`
 
-**Framework:** xUnit with FluentAssertions
+**Framework:** xUnit with AwesomeAssertions
 
 **Test cases:**
 
@@ -252,7 +252,7 @@ Disposal (5 tests):
 
 **Quality:**
 - ✓ Complete XML documentation for all public members
-- ✓ 24 comprehensive unit tests with FluentAssertions
+- ✓ 24 comprehensive unit tests with AwesomeAssertions
 - ✓ Includes overflow protection test cases
 - ✓ Performance benchmarks with BenchmarkDotNet
 - ✓ Native AOT compatible (no unsafe code)

--- a/tests/DataMorph.Tests/DataMorph.Tests.csproj
+++ b/tests/DataMorph.Tests/DataMorph.Tests.csproj
@@ -15,7 +15,7 @@
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
-    <PackageReference Include="FluentAssertions" Version="8.8.0" />
+    <PackageReference Include="AwesomeAssertions" Version="9.3.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />

--- a/tests/DataMorph.Tests/IO/FormatDetectorTests.cs
+++ b/tests/DataMorph.Tests/IO/FormatDetectorTests.cs
@@ -1,7 +1,7 @@
 using System.Text;
+using AwesomeAssertions;
 using DataMorph.Engine.IO;
 using DataMorph.Engine.Types;
-using FluentAssertions;
 
 namespace DataMorph.Tests.IO;
 

--- a/tests/DataMorph.Tests/IO/MmapServiceTests.cs
+++ b/tests/DataMorph.Tests/IO/MmapServiceTests.cs
@@ -1,6 +1,6 @@
 using System.Text;
+using AwesomeAssertions;
 using DataMorph.Engine.IO;
-using FluentAssertions;
 
 namespace DataMorph.Tests.IO;
 

--- a/tests/DataMorph.Tests/IO/PipelinesEngineTests.cs
+++ b/tests/DataMorph.Tests/IO/PipelinesEngineTests.cs
@@ -1,7 +1,7 @@
 using System.IO.Pipelines;
 using System.Text;
+using AwesomeAssertions;
 using DataMorph.Engine.IO;
-using FluentAssertions;
 
 namespace DataMorph.Tests.IO;
 

--- a/tests/DataMorph.Tests/IO/RowIndexerTests.cs
+++ b/tests/DataMorph.Tests/IO/RowIndexerTests.cs
@@ -1,5 +1,5 @@
+using AwesomeAssertions;
 using DataMorph.Engine.IO;
-using FluentAssertions;
 
 namespace DataMorph.Tests.IO;
 

--- a/tests/DataMorph.Tests/Models/RecipeSerializationTests.cs
+++ b/tests/DataMorph.Tests/Models/RecipeSerializationTests.cs
@@ -1,8 +1,8 @@
 using System.Text.Json;
+using AwesomeAssertions;
 using DataMorph.Engine.Models;
 using DataMorph.Engine.Models.Actions;
 using DataMorph.Engine.Types;
-using FluentAssertions;
 
 namespace DataMorph.Tests.Models;
 

--- a/tests/DataMorph.Tests/Models/SchemaSerializationTests.cs
+++ b/tests/DataMorph.Tests/Models/SchemaSerializationTests.cs
@@ -1,7 +1,7 @@
 using System.Text.Json;
+using AwesomeAssertions;
 using DataMorph.Engine.Models;
 using DataMorph.Engine.Types;
-using FluentAssertions;
 
 namespace DataMorph.Tests.Models;
 


### PR DESCRIPTION
## Summary
- Migrated test project from FluentAssertions 8.8.0 to AwesomeAssertions 9.3.0
- Updated all test files to use AwesomeAssertions namespace
- Updated documentation to reflect the new assertion library

## Changes
### Dependencies
- Updated `DataMorph.Tests.csproj` to reference AwesomeAssertions 9.3.0

### Test Files (6 files)
- `RecipeSerializationTests.cs`
- `SchemaSerializationTests.cs`
- `RowIndexerTests.cs`
- `FormatDetectorTests.cs`
- `PipelinesEngineTests.cs`
- `MmapServiceTests.cs`

### Documentation
- `docs/development_guidelines.md`
- `docs/mmap-service-plan.md`
- `.claude/rules/testing.md`

## Test Results
- ✅ All 127 tests pass
- ✅ Zero warnings
- ✅ Code style compliant (`dotnet format`)

## Notes
AwesomeAssertions is a community-maintained fork of FluentAssertions with an Apache 2.0 license. The API is fully compatible, requiring only namespace changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)