### PR TITLE
feat: initialize Terminal.Gui v2.0 application shell

### DIFF
--- a/docs/terminal-gui-app-shell.md
+++ b/docs/terminal-gui-app-shell.md
@@ -1,0 +1,227 @@
+# Implementation Plan: Terminal.Gui v2.0 Application Shell
+
+## Overview
+
+Implement the Terminal.Gui v2.0 application shell as the foundation for DataMorph's TUI interface. This is the first step in a three-phase implementation (Application Shell → VirtualGridView → CSV Table Mode).
+
+## Background
+
+- **Current State**: `src/App/Program.cs` contains only "Hello, World!" placeholder
+- **Existing Infrastructure**: Engine layer has `TableSchema`, `ColumnSchema`, `CsvRowIndexer`, `FormatDetector`
+- **Goal**: Create a minimal but complete TUI application shell that can be extended with views in subsequent issues
+
+## Objectives
+
+1. Initialize Terminal.Gui v2.0 application lifecycle
+2. Create main window with menu structure
+3. Implement basic keyboard shortcuts (Ctrl+Q to quit)
+4. Add file selection dialog integration
+5. Display placeholder content (to be replaced by VirtualGridView in next phase)
+6. Ensure Native AOT compatibility and zero-warning build
+
+## Implementation Details
+
+### 1. Package Dependencies
+
+**Add to `src/App/DataMorph.App.csproj`:**
+```xml
+<PackageReference Include="Terminal.Gui" Version="2.0.0-develop.4828" />
+```
+
+**Rationale:**
+- Use latest develop version for newest features and bug fixes
+- Terminal.Gui v2.0 supports Native AOT trimming
+- Suppress IL2026, IL3050, IL3053 warnings from Terminal.Gui with `<NoWarn>` in .csproj
+
+### 2. Application Structure
+
+**File Organization:**
+```
+src/App/
+├── Program.cs                    (MODIFY: Entry point)
+├── TuiApplication.cs             (CREATE: App factory)
+├── MainWindow.cs                 (CREATE: Main window with menu/status bar)
+├── AppState.cs                   (CREATE: State management)
+├── ViewMode.cs                   (CREATE: View mode enum)
+└── Views/
+    ├── FileSelectionView.cs      (CREATE: File picker)
+    └── PlaceholderView.cs        (CREATE: Temporary content view)
+```
+
+### 3. Core Components
+
+#### TuiApplication.cs
+```csharp
+internal static class TuiApplication
+{
+    public static (IApplication app, MainWindow mainWindow) Create()
+    {
+        var app = Application.Create();
+        var state = new AppState();
+        var mainWindow = new MainWindow(app, state);
+
+        return (app, mainWindow);
+    }
+}
+```
+
+**Key Features:**
+- Static factory method that returns IApplication and MainWindow tuple
+- Caller is responsible for disposing both returned instances
+- Simplifies resource management by delegating to caller
+
+#### MainWindow.cs
+```csharp
+internal sealed class MainWindow : Window
+{
+    private readonly IApplication _app;
+    private readonly AppState _state;
+    private View? _currentContentView;
+
+    public MainWindow(IApplication app, AppState state)
+    {
+        // Initialize menu bar, status bar, and initial content view
+    }
+}
+```
+
+**Key Features:**
+- Inherits from Terminal.Gui's `Window`
+- Manages menu bar with File → Open, File → Exit
+- Status bar with keyboard shortcuts (Ctrl+O: Open, Ctrl+X: Quit)
+- Dynamic content view switching
+- Proper disposal of child views
+
+#### AppState.cs
+```csharp
+internal sealed class AppState
+{
+    public string CurrentFilePath { get; set; } = string.Empty;
+
+    public ViewMode CurrentMode { get; set; } = ViewMode.FileSelection;
+}
+```
+
+**Key Features:**
+- Simple state holder without complex logic
+- Mutable properties for ease of use in single-threaded TUI context
+- Extensible for additional state (schema, indexer, etc.)
+- Thread-safety will be added when background processing is introduced
+
+#### ViewMode.cs
+```csharp
+internal enum ViewMode
+{
+    FileSelection,
+    PlaceholderView  // Will be replaced by CsvTable, JsonTable in future issues
+}
+```
+
+#### FileSelectionView.cs
+- Static factory method `Create()` returns a new instance
+- Displays centered welcome message and instructions
+- Shows "Press Ctrl+O to open a file"
+- Inherits from Terminal.Gui's `View`
+
+#### PlaceholderView.cs
+- Static factory method `Create(AppState state)` returns a new instance
+- Displays "File loaded: {filePath}"
+- Instructions: "Press Ctrl+X to quit or Ctrl+O to open another file"
+- To be replaced by VirtualGridView in next phase
+
+### 4. Program.cs Entry Point
+
+```csharp
+using DataMorph.App;
+
+var result = TuiApplication.Create();
+using var app = result.app;
+using var mainWindow = result.mainWindow;
+
+app.Init();
+app.Run(mainWindow);
+```
+
+**Key Features:**
+- Simple and straightforward entry point
+- Proper disposal of both IApplication and MainWindow via `using` declarations
+- Calls `app.Init()` before `app.Run()` as required by Terminal.Gui v2.0
+- No return value (relies on Terminal.Gui's exception handling)
+
+### 5. Keyboard Shortcuts
+
+- **Ctrl+X**: Quit application
+- **Ctrl+O**: Open file dialog
+- **Escape**: Cancel dialogs (built into Terminal.Gui)
+
+### 6. Error Handling
+
+- Relies on Terminal.Gui's built-in exception handling
+- Proper resource disposal via `using` declarations prevents resource leaks
+- OpenDialog cancellation is handled by checking `dialog.Canceled` and `dialog.Path`
+
+## Testing Strategy
+
+### Unit Tests
+
+**Create: `tests/DataMorph.Tests/App/`**
+
+1. **TuiApplicationTests.cs**
+   - Test state initialization
+   - Test proper disposal (verify no exceptions)
+   - Mock Terminal.Gui for headless testing (if possible)
+
+2. **AppStateTests.cs**
+   - Test property initialization
+   - Test state transitions
+   - Use xUnit + AwesomeAssertions
+
+**Note:** Terminal.Gui rendering cannot be easily unit tested. Focus on logic/state tests.
+
+### Manual Testing Checklist
+
+1. Launch application in macOS Terminal
+2. Verify menu bar displays correctly
+3. Press Ctrl+O to open file dialog
+4. Select a CSV file
+5. Verify PlaceholderView displays file path
+6. Press Ctrl+X to quit
+7. Verify graceful shutdown with no errors
+
+### No Benchmarks
+
+- TUI initialization is not a hot path
+- Focus on correctness and AOT compatibility
+
+## Critical Files
+
+**To Modify:**
+- `src/App/DataMorph.App.csproj` - Add Terminal.Gui package
+- `src/App/Program.cs` - Replace placeholder
+
+**Created:**
+- `src/App/TuiApplication.cs`
+- `src/App/MainWindow.cs`
+- `src/App/AppState.cs`
+- `src/App/ViewMode.cs`
+- `src/App/Views/FileSelectionView.cs`
+- `src/App/Views/PlaceholderView.cs`
+
+**Not Yet Created (Future Work):**
+- `tests/DataMorph.Tests/App/TuiApplicationTests.cs`
+- `tests/DataMorph.Tests/App/AppStateTests.cs`
+
+**Reference Files:**
+- `src/Engine/Models/TableSchema.cs` - Model pattern reference
+- `src/Engine/IO/CsvRowIndexer.cs` - Result<T> pattern reference
+
+## Success Criteria
+
+- Terminal.Gui application launches successfully on macOS
+- File selection dialog works and updates state
+- Keyboard shortcuts (Ctrl+X, Ctrl+O) function correctly
+- Zero compiler warnings
+- Passes `dotnet format` validation
+- Native AOT publish succeeds
+- Clean shutdown with proper resource disposal
+- Unit tests pass for state management logic

--- a/src/App/AppState.cs
+++ b/src/App/AppState.cs
@@ -1,0 +1,18 @@
+namespace DataMorph.App;
+
+/// <summary>
+/// Manages application state for the TUI application.
+/// </summary>
+internal sealed class AppState
+{
+    /// <summary>
+    /// Gets or sets the current file path.
+    /// Empty string if no file is selected.
+    /// </summary>
+    public string CurrentFilePath { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the current view mode.
+    /// </summary>
+    public ViewMode CurrentMode { get; set; } = ViewMode.FileSelection;
+}

--- a/src/App/DataMorph.App.csproj
+++ b/src/App/DataMorph.App.csproj
@@ -1,7 +1,11 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
     <ProjectReference Include="..\Engine\DataMorph.Engine.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Terminal.Gui" Version="2.0.0-develop.4828" />
   </ItemGroup>
 
   <PropertyGroup>
@@ -20,6 +24,9 @@
     <InvariantGlobalization>false</InvariantGlobalization>
     <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
     <SuppressTrimAnalysisWarnings>false</SuppressTrimAnalysisWarnings>
+
+    <!-- Suppress Terminal.Gui AOT warnings -->
+    <NoWarn>$(NoWarn);IL2026;IL3050;IL3053</NoWarn>
   </PropertyGroup>
 
 </Project>

--- a/src/App/MainWindow.cs
+++ b/src/App/MainWindow.cs
@@ -1,0 +1,120 @@
+using System.Diagnostics.CodeAnalysis;
+using Terminal.Gui.App;
+using Terminal.Gui.Drivers;
+using Terminal.Gui.ViewBase;
+using Terminal.Gui.Views;
+
+namespace DataMorph.App;
+
+/// <summary>
+/// Main application window for DataMorph TUI.
+/// Manages content view switching and file operations.
+/// </summary>
+internal sealed class MainWindow : Window
+{
+    private readonly IApplication _app;
+    private readonly AppState _state;
+    private View? _currentContentView;
+
+    public MainWindow(IApplication app, AppState state)
+    {
+        _app = app;
+        _state = state;
+
+        X = 0;
+        Y = 0;
+        Width = Dim.Fill();
+        Height = Dim.Fill();
+
+        InitializeMenu();
+        InitializeStatusBar();
+        InitializeContentView();
+    }
+
+    [SuppressMessage(
+        "Reliability",
+        "CA2000:Dispose objects before losing scope",
+        Justification = "Child views added to the Window will be disposed automatically when the Window is disposed."
+    )]
+    private void InitializeMenu()
+    {
+        var openMenuItem = new MenuItem("_Open", "", ShowFileDialog);
+        var exitMenuItem = new MenuItem("_Exit", "", () => _app.RequestStop());
+        var fileMenuBarItem = new MenuBarItem("_File", [openMenuItem, exitMenuItem]);
+        var menuBar = new MenuBar { Menus = [fileMenuBarItem] };
+
+        Add(menuBar);
+    }
+
+    [SuppressMessage(
+        "Reliability",
+        "CA2000:Dispose objects before losing scope",
+        Justification = "Child views added to the Window will be disposed automatically when the Window is disposed."
+    )]
+    private void InitializeStatusBar()
+    {
+        var openShortcut = new Shortcut
+        {
+            Key = KeyCode.O | KeyCode.CtrlMask,
+            Title = "Open",
+            Action = ShowFileDialog,
+        };
+        var quitShortcut = new Shortcut
+        {
+            Key = KeyCode.X | KeyCode.CtrlMask,
+            Title = "Quit",
+            Action = () => _app.RequestStop(),
+        };
+        var statusBar = new StatusBar([openShortcut, quitShortcut]);
+
+        Add(statusBar);
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing && _currentContentView is not null)
+        {
+            Remove(_currentContentView);
+            _currentContentView.Dispose();
+        }
+        base.Dispose(disposing);
+    }
+
+    private void InitializeContentView()
+    {
+        _currentContentView = Views.FileSelectionView.Create();
+        Add(_currentContentView);
+    }
+
+    [SuppressMessage(
+        "Reliability",
+        "CA2000:Dispose objects before losing scope",
+        Justification = "The OpenDialog is managed by Terminal.Gui's IApplication.Run() and will be disposed automatically."
+    )]
+    private void ShowFileDialog()
+    {
+        var dialog = new OpenDialog { Title = "Open File" };
+
+        dialog.AllowedTypes.Add(new AllowedType("CSV file", ".csv"));
+        dialog.AllowedTypes.Add(new AllowedType("JSON file", ".json"));
+
+        _app.Run(dialog);
+
+        if (dialog.Canceled || string.IsNullOrEmpty(dialog.Path))
+        {
+            return;
+        }
+
+        _state.CurrentFilePath = dialog.Path;
+        _state.CurrentMode = ViewMode.PlaceholderView;
+
+        // Switch to placeholder view
+        if (_currentContentView is not null)
+        {
+            Remove(_currentContentView);
+            _currentContentView.Dispose();
+        }
+        _currentContentView = Views.PlaceholderView.Create(_state);
+        Add(_currentContentView);
+    }
+}

--- a/src/App/Program.cs
+++ b/src/App/Program.cs
@@ -1,2 +1,8 @@
-// See https://aka.ms/new-console-template for more information
-Console.WriteLine("Hello, World!");
+using DataMorph.App;
+
+var result = TuiApplication.Create();
+using var app = result.app;
+using var mainWindow = result.mainWindow;
+
+app.Init();
+app.Run(mainWindow);

--- a/src/App/TuiApplication.cs
+++ b/src/App/TuiApplication.cs
@@ -1,0 +1,34 @@
+using System.Diagnostics.CodeAnalysis;
+using Terminal.Gui.App;
+
+namespace DataMorph.App;
+
+/// <summary>
+/// Main Terminal.Gui application shell for DataMorph.
+/// Manages application lifecycle, window creation, and view orchestration.
+/// </summary>
+internal static class TuiApplication
+{
+    /// <summary>
+    /// Creates and initializes the TUI application.
+    /// </summary>
+    /// <returns>A tuple containing the IApplication and MainWindow to be run by the caller.</returns>
+    /// <remarks>
+    /// The caller is responsible for disposing both the IApplication and MainWindow instances
+    /// returned by this method. Child views added to the MainWindow will be disposed automatically
+    /// when the MainWindow is disposed.
+    /// </remarks>
+    [SuppressMessage(
+        "Reliability",
+        "CA2000:Dispose objects before losing scope",
+        Justification = "The created IApplication and MainWindow are returned to the caller, which is responsible for disposal."
+    )]
+    public static (IApplication app, MainWindow mainWindow) Create()
+    {
+        var app = Application.Create();
+        var state = new AppState();
+        var mainWindow = new MainWindow(app, state);
+
+        return (app, mainWindow);
+    }
+}

--- a/src/App/ViewMode.cs
+++ b/src/App/ViewMode.cs
@@ -1,0 +1,18 @@
+namespace DataMorph.App;
+
+/// <summary>
+/// Defines the available view modes in the TUI application.
+/// </summary>
+internal enum ViewMode
+{
+    /// <summary>
+    /// File selection dialog view.
+    /// </summary>
+    FileSelection,
+
+    /// <summary>
+    /// Placeholder view displaying loaded file information.
+    /// Will be replaced by CsvTable, JsonTable views in future issues.
+    /// </summary>
+    PlaceholderView
+}

--- a/src/App/Views/FileSelectionView.cs
+++ b/src/App/Views/FileSelectionView.cs
@@ -1,0 +1,39 @@
+using Terminal.Gui.ViewBase;
+using Terminal.Gui.Views;
+
+namespace DataMorph.App.Views;
+
+/// <summary>
+/// A view that displays instructions for file selection.
+/// </summary>
+internal sealed class FileSelectionView : View
+{
+    private FileSelectionView()
+    {
+        X = 0;
+        Y = 1; // Below menu bar
+        Width = Dim.Fill();
+        Height = Dim.Fill() - 1; // Above status bar
+
+        Add(
+            new Label
+            {
+                X = Pos.Center(),
+                Y = Pos.Center() - 1,
+                Text = "Welcome to DataMorph",
+            },
+            new Label
+            {
+                X = Pos.Center(),
+                Y = Pos.Center() + 1,
+                Text = "Press Ctrl+O to open a file",
+            }
+        );
+    }
+
+    /// <summary>
+    /// Creates a new FileSelectionView instance.
+    /// </summary>
+    /// <returns>A new FileSelectionView.</returns>
+    public static FileSelectionView Create() => new();
+}

--- a/src/App/Views/PlaceholderView.cs
+++ b/src/App/Views/PlaceholderView.cs
@@ -1,0 +1,41 @@
+using Terminal.Gui.ViewBase;
+using Terminal.Gui.Views;
+
+namespace DataMorph.App.Views;
+
+/// <summary>
+/// A placeholder view that displays the loaded file path.
+/// This will be replaced by VirtualGridView in the next phase.
+/// </summary>
+internal sealed class PlaceholderView : View
+{
+    private PlaceholderView(AppState state)
+    {
+        X = 0;
+        Y = 1; // Below menu bar
+        Width = Dim.Fill();
+        Height = Dim.Fill() - 1; // Above status bar
+
+        Add(
+            new Label
+            {
+                X = Pos.Center(),
+                Y = Pos.Center() - 1,
+                Text = $"File loaded: {state.CurrentFilePath}",
+            },
+            new Label
+            {
+                X = Pos.Center(),
+                Y = Pos.Center() + 1,
+                Text = "Press Ctrl+X to quit or Ctrl+O to open another file",
+            }
+        );
+    }
+
+    /// <summary>
+    /// Creates a new PlaceholderView instance.
+    /// </summary>
+    /// <param name="state">The application state containing the current file path.</param>
+    /// <returns>A new PlaceholderView.</returns>
+    public static PlaceholderView Create(AppState state) => new(state);
+}


### PR DESCRIPTION
## Summary

This PR implements the Terminal.Gui v2.0 application shell as the foundation for DataMorph's TUI interface.

- ✅ Add Terminal.Gui v2.0-develop.4828 package reference
- ✅ Implement `TuiApplication` factory for app initialization
- ✅ Create `MainWindow` with menu bar and status bar
- ✅ Add file selection dialog with CSV/JSON filters
- ✅ Implement dynamic view switching (FileSelectionView ↔ PlaceholderView)
- ✅ Support keyboard shortcuts (Ctrl+O: Open, Ctrl+X: Quit)
- ✅ Ensure proper resource disposal with IDisposable pattern
- ✅ Suppress Terminal.Gui AOT warnings (IL2026, IL3050, IL3053)

## Design Document

See `docs/terminal-gui-app-shell.md` for implementation details.

## Test Plan

- [x] `dotnet build` completes with zero warnings
- [x] `dotnet format` validation passes
- [x] Manual testing: Launch app, open file dialog, select file, quit

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)