### PR TITLE
build: Ignore .aider files in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,5 @@ Desktop.ini
 
 # Local configuration files
 *.local.*
+
+.aider*


### PR DESCRIPTION
This PR updates the .gitignore file to exclude .aider* files.