### PR TITLE
refactor: Reorganize CSV files into Csv/ subdirectory

### DIFF
--- a/src/App/MainWindow.cs
+++ b/src/App/MainWindow.cs
@@ -1,6 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using DataMorph.App.Schema;
-using DataMorph.Engine.IO;
+using DataMorph.Engine.IO.Csv;
 using DataMorph.Engine.Models;
 using Terminal.Gui.App;
 using Terminal.Gui.Drivers;
@@ -137,7 +137,7 @@ internal sealed class MainWindow : Window
 
     private async Task LoadCsvFileAsync(string filePath)
     {
-        var indexer = new CsvDataRowIndexer(filePath);
+        var indexer = new DataRowIndexer(filePath);
         _ = Task.Run(indexer.BuildIndex);
 
         var schemaScanner = new IncrementalSchemaScanner(filePath);
@@ -221,7 +221,7 @@ internal sealed class MainWindow : Window
         Add(_currentContentView);
     }
 
-    private void SwitchToTableView(CsvDataRowIndexer indexer, TableSchema schema)
+    private void SwitchToTableView(DataRowIndexer indexer, TableSchema schema)
     {
         _state.CurrentMode = ViewMode.CsvTable;
 

--- a/src/App/Schema/IncrementalSchemaScanner.cs
+++ b/src/App/Schema/IncrementalSchemaScanner.cs
@@ -1,4 +1,4 @@
-using DataMorph.Engine.IO;
+using DataMorph.Engine.IO.Csv;
 using DataMorph.Engine.Models;
 using nietras.SeparatedValues;
 
@@ -36,7 +36,7 @@ internal sealed class IncrementalSchemaScanner
         {
             var rows = ReadRows(0, InitialScanCount);
             var columnNames = ReadColumnNames();
-            var scanResult = CsvSchemaScanner.ScanSchema(columnNames, rows, InitialScanCount);
+            var scanResult = SchemaScanner.ScanSchema(columnNames, rows, InitialScanCount);
 
             if (scanResult.IsFailure)
             {
@@ -93,7 +93,7 @@ internal sealed class IncrementalSchemaScanner
                     break;
                 }
 
-                var refineResult = CsvSchemaScanner.RefineSchema(refinedSchema, row);
+                var refineResult = SchemaScanner.RefineSchema(refinedSchema, row);
                 if (refineResult.IsSuccess)
                 {
                     refinedSchema = refineResult.Value;

--- a/src/App/Views/VirtualTableSource.cs
+++ b/src/App/Views/VirtualTableSource.cs
@@ -1,4 +1,4 @@
-using DataMorph.Engine.IO;
+using DataMorph.Engine.IO.Csv;
 using DataMorph.Engine.Models;
 using Terminal.Gui.Views;
 
@@ -6,19 +6,19 @@ namespace DataMorph.App.Views;
 
 /// <summary>
 /// Provides virtual table data source for Terminal.Gui's TableView.
-/// Delegates to CsvDataRowCache for efficient row retrieval.
+/// Delegates to DataRowCache for efficient row retrieval.
 /// </summary>
 internal sealed class VirtualTableSource : ITableSource
 {
-    private readonly CsvDataRowCache _cache;
+    private readonly DataRowCache _cache;
     private readonly TableSchema _schema;
     private readonly string[] _columnNames;
 
-    public VirtualTableSource(CsvDataRowIndexer indexer, TableSchema schema)
+    public VirtualTableSource(DataRowIndexer indexer, TableSchema schema)
     {
         _schema = schema;
         _columnNames = [.. _schema.Columns.Select(c => c.Name)];
-        _cache = new CsvDataRowCache(indexer, _schema.ColumnCount);
+        _cache = new DataRowCache(indexer, _schema.ColumnCount);
     }
 
     public int Rows => _cache.TotalRows;

--- a/src/Engine/IO/Csv/DataRowCache.cs
+++ b/src/Engine/IO/Csv/DataRowCache.cs
@@ -1,27 +1,27 @@
-namespace DataMorph.Engine.IO;
+namespace DataMorph.Engine.IO.Csv;
 
 /// <summary>
 /// Manages a sliding window cache of CSV data rows for efficient virtual scrolling.
 /// Uses ReadOnlyMemory for memory-efficient column storage.
 /// </summary>
-public sealed class CsvDataRowCache
+public sealed class DataRowCache
 {
     private const int DefaultCacheSize = 200;
-    private readonly CsvDataRowIndexer _indexer;
-    private readonly CsvDataRowReader _reader;
+    private readonly DataRowIndexer _indexer;
+    private readonly DataRowReader _reader;
     private readonly int _columnCount;
     private readonly int _cacheSize;
     private readonly Dictionary<int, CsvDataRow> _cache = [];
     private int _cacheStartRow = -1;
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="CsvDataRowCache"/> class.
+    /// Initializes a new instance of the <see cref="DataRowCache"/> class.
     /// </summary>
     /// <param name="indexer">The CSV row indexer for obtaining byte offsets.</param>
     /// <param name="columnCount">The number of columns in the CSV.</param>
     /// <param name="cacheSize">The size of the sliding window cache (default: 200).</param>
-    public CsvDataRowCache(
-        CsvDataRowIndexer indexer,
+    public DataRowCache(
+        DataRowIndexer indexer,
         int columnCount,
         int cacheSize = DefaultCacheSize
     )
@@ -30,7 +30,7 @@ public sealed class CsvDataRowCache
         _columnCount = columnCount;
         _cacheSize = cacheSize;
         ArgumentNullException.ThrowIfNull(indexer);
-        _reader = new CsvDataRowReader(indexer.FilePath, columnCount);
+        _reader = new DataRowReader(indexer.FilePath, columnCount);
     }
 
     /// <summary>

--- a/src/Engine/IO/Csv/DataRowIndexer.cs
+++ b/src/Engine/IO/Csv/DataRowIndexer.cs
@@ -1,12 +1,12 @@
 using System.Buffers;
 
-namespace DataMorph.Engine.IO;
+namespace DataMorph.Engine.IO.Csv;
 
 /// <summary>
 /// Indexes CSV data rows (excluding header) for efficient random access.
 /// Supports comma-delimited CSV with RFC 4180 quoted field handling.
 /// </summary>
-public sealed class CsvDataRowIndexer
+public sealed class DataRowIndexer
 {
     private readonly Lock _lock = new();
     private readonly string _filePath;
@@ -25,11 +25,11 @@ public sealed class CsvDataRowIndexer
     private long _totalRows;
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="CsvDataRowIndexer"/> class.
+    /// Initializes a new instance of the <see cref="DataRowIndexer"/> class.
     /// </summary>
     /// <param name="filePath">The path to the CSV file to index.</param>
     /// <exception cref="ArgumentException">Thrown if <paramref name="filePath"/> is null or whitespace.</exception>
-    public CsvDataRowIndexer(string filePath)
+    public DataRowIndexer(string filePath)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(filePath);
         _filePath = filePath;

--- a/src/Engine/IO/Csv/DataRowReader.cs
+++ b/src/Engine/IO/Csv/DataRowReader.cs
@@ -1,12 +1,12 @@
 using nietras.SeparatedValues;
 
-namespace DataMorph.Engine.IO;
+namespace DataMorph.Engine.IO.Csv;
 
 /// <summary>
 /// Low-level CSV row reader that reads raw CSV data from a file stream.
 /// Returns rows as read-only lists of ReadOnlyMemory for memory efficiency.
 /// </summary>
-public sealed class CsvDataRowReader(string filePath, int columnCount)
+public sealed class DataRowReader(string filePath, int columnCount)
 {
     private readonly string _filePath = filePath;
     private readonly int _columnCount = columnCount;

--- a/src/Engine/IO/Csv/SchemaScanner.cs
+++ b/src/Engine/IO/Csv/SchemaScanner.cs
@@ -1,13 +1,13 @@
 using DataMorph.Engine.Models;
 using DataMorph.Engine.Types;
 
-namespace DataMorph.Engine.IO;
+namespace DataMorph.Engine.IO.Csv;
 
 /// <summary>
 /// Scans CSV data to infer schema (header + column types).
 /// Analyzes a single row to determine column types.
 /// </summary>
-public static class CsvSchemaScanner
+public static class SchemaScanner
 {
     /// <summary>
     /// Scans initial CSV rows (up to 200) and returns the inferred schema for faster stabilization.
@@ -96,10 +96,10 @@ public static class CsvSchemaScanner
             var valueSpan = columnValue.Span;
 
             // Determine nullable status (if value is empty or whitespace-only)
-            var isNullable = CsvTypeInferrer.IsEmptyOrWhitespace(valueSpan);
+            var isNullable = TypeInferrer.IsEmptyOrWhitespace(valueSpan);
 
             // Infer type from the value
-            var columnType = CsvTypeInferrer.InferType(valueSpan);
+            var columnType = TypeInferrer.InferType(valueSpan);
 
             // Generate column name if empty
             var finalColumnName = string.IsNullOrWhiteSpace(columnName)
@@ -148,7 +148,7 @@ public static class CsvSchemaScanner
             var valueSpan = columnValue.Span;
 
             // Update nullable status for empty or whitespace values
-            if (CsvTypeInferrer.IsEmptyOrWhitespace(valueSpan))
+            if (TypeInferrer.IsEmptyOrWhitespace(valueSpan))
             {
                 // Use Copy-on-Write pattern with WithMarkedNullable
                 updatedColumns[i] = columnSchema.WithMarkedNullable();
@@ -156,7 +156,7 @@ public static class CsvSchemaScanner
             }
 
             // Infer type for this value
-            var inferredType = CsvTypeInferrer.InferType(valueSpan);
+            var inferredType = TypeInferrer.InferType(valueSpan);
 
             // Update column type using Copy-on-Write pattern
             var updatedSchema = columnSchema.WithUpdatedType(inferredType);

--- a/src/Engine/IO/Csv/TypeInferrer.cs
+++ b/src/Engine/IO/Csv/TypeInferrer.cs
@@ -1,13 +1,13 @@
 using System.Globalization;
 using DataMorph.Engine.Types;
 
-namespace DataMorph.Engine.IO;
+namespace DataMorph.Engine.IO.Csv;
 
 /// <summary>
 /// Infers column type from char data.
 /// Designed to work with CsvDataRow (IReadOnlyList&lt;ReadOnlyMemory&lt;char&gt;&gt;).
 /// </summary>
-public static class CsvTypeInferrer
+public static class TypeInferrer
 {
     /// <summary>
     /// Infers the most specific type for a char span.

--- a/tests/DataMorph.Tests/IO/Csv/DataRowCacheTests.cs
+++ b/tests/DataMorph.Tests/IO/Csv/DataRowCacheTests.cs
@@ -1,13 +1,13 @@
 using AwesomeAssertions;
-using DataMorph.Engine.IO;
+using DataMorph.Engine.IO.Csv;
 
-namespace DataMorph.Tests.IO;
+namespace DataMorph.Tests.IO.Csv;
 
-public sealed class CsvDataRowCacheTests : IDisposable
+public sealed class DataRowCacheTests : IDisposable
 {
     private readonly string _testFilePath;
 
-    public CsvDataRowCacheTests()
+    public DataRowCacheTests()
     {
         _testFilePath = Path.Combine(Path.GetTempPath(), $"csvRowCache_{Guid.NewGuid()}.csv");
     }
@@ -37,9 +37,9 @@ public sealed class CsvDataRowCacheTests : IDisposable
         // Arrange
         var csvContent = "col1,col2,col3\nval1,val2,val3\nval4,val5,val6\nval7,val8,val9";
         File.WriteAllText(_testFilePath, csvContent);
-        var indexer = new CsvDataRowIndexer(_testFilePath);
+        var indexer = new DataRowIndexer(_testFilePath);
         indexer.BuildIndex();
-        var cache = new CsvDataRowCache(indexer, columnCount: 3, cacheSize: 10);
+        var cache = new DataRowCache(indexer, columnCount: 3, cacheSize: 10);
 
         // Act
         var row = cache.GetRow(0);
@@ -54,9 +54,9 @@ public sealed class CsvDataRowCacheTests : IDisposable
         // Arrange
         var csvContent = "col1,col2\nval1,val2\nval3,val4\nval5,val6";
         File.WriteAllText(_testFilePath, csvContent);
-        var indexer = new CsvDataRowIndexer(_testFilePath);
+        var indexer = new DataRowIndexer(_testFilePath);
         indexer.BuildIndex();
-        var cache = new CsvDataRowCache(indexer, columnCount: 2, cacheSize: 10);
+        var cache = new DataRowCache(indexer, columnCount: 2, cacheSize: 10);
 
         // Act - Request same row multiple times
         var row1 = cache.GetRow(0);
@@ -75,9 +75,9 @@ public sealed class CsvDataRowCacheTests : IDisposable
         // Arrange
         var csvContent = "col1,col2\nval1,val2";
         File.WriteAllText(_testFilePath, csvContent);
-        var indexer = new CsvDataRowIndexer(_testFilePath);
+        var indexer = new DataRowIndexer(_testFilePath);
         indexer.BuildIndex();
-        var cache = new CsvDataRowCache(indexer, columnCount: 2);
+        var cache = new DataRowCache(indexer, columnCount: 2);
 
         // Act
         var row = cache.GetRow(-1);
@@ -92,9 +92,9 @@ public sealed class CsvDataRowCacheTests : IDisposable
         // Arrange
         var csvContent = "col1,col2\nval1,val2";
         File.WriteAllText(_testFilePath, csvContent);
-        var indexer = new CsvDataRowIndexer(_testFilePath);
+        var indexer = new DataRowIndexer(_testFilePath);
         indexer.BuildIndex();
-        var cache = new CsvDataRowCache(indexer, columnCount: 2);
+        var cache = new DataRowCache(indexer, columnCount: 2);
 
         // Act
         var row = cache.GetRow(100);
@@ -114,9 +114,9 @@ public sealed class CsvDataRowCacheTests : IDisposable
         }
 
         File.WriteAllText(_testFilePath, string.Join("\n", lines));
-        var indexer = new CsvDataRowIndexer(_testFilePath);
+        var indexer = new DataRowIndexer(_testFilePath);
         indexer.BuildIndex();
-        var cache = new CsvDataRowCache(indexer, columnCount: 2, cacheSize: 5);
+        var cache = new DataRowCache(indexer, columnCount: 2, cacheSize: 5);
 
         // Act - Request rows outside the initial cache window
         var row0 = cache.GetRow(0);
@@ -135,11 +135,11 @@ public sealed class CsvDataRowCacheTests : IDisposable
         // Arrange
         var csvContent = "col1,col2\nval1,val2\nval3,val4\nval5,val6\nval7,val8";
         File.WriteAllText(_testFilePath, csvContent);
-        var indexer = new CsvDataRowIndexer(_testFilePath);
+        var indexer = new DataRowIndexer(_testFilePath);
         indexer.BuildIndex();
-        var cache = new CsvDataRowCache(indexer, columnCount: 2);
+        var cache = new DataRowCache(indexer, columnCount: 2);
 
-        // Act & Assert - CsvDataRowIndexer counts data rows excluding header
+        // Act & Assert - DataRowIndexer counts data rows excluding header
         cache.TotalRows.Should().Be(4);
     }
 
@@ -149,9 +149,9 @@ public sealed class CsvDataRowCacheTests : IDisposable
         // Arrange
         var csvContent = "col1,col2,col3\nval1,val2\nval3";
         File.WriteAllText(_testFilePath, csvContent);
-        var indexer = new CsvDataRowIndexer(_testFilePath);
+        var indexer = new DataRowIndexer(_testFilePath);
         indexer.BuildIndex();
-        var cache = new CsvDataRowCache(indexer, columnCount: 3);
+        var cache = new DataRowCache(indexer, columnCount: 3);
 
         // Act & Assert
         // Sep.Reader enforces strict column count matching by default
@@ -164,9 +164,9 @@ public sealed class CsvDataRowCacheTests : IDisposable
     {
         // Arrange - Only header row
         File.WriteAllText(_testFilePath, "col1,col2");
-        var indexer = new CsvDataRowIndexer(_testFilePath);
+        var indexer = new DataRowIndexer(_testFilePath);
         indexer.BuildIndex();
-        var cache = new CsvDataRowCache(indexer, columnCount: 2);
+        var cache = new DataRowCache(indexer, columnCount: 2);
 
         // Act & Assert - No data rows exist (only header), so TotalRows should be 0
         // row 0 is out of bounds (no data rows)

--- a/tests/DataMorph.Tests/IO/Csv/DataRowIndexerBenchmarks.cs
+++ b/tests/DataMorph.Tests/IO/Csv/DataRowIndexerBenchmarks.cs
@@ -1,21 +1,21 @@
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Jobs;
-using DataMorph.Engine.IO;
+using DataMorph.Engine.IO.Csv;
 
-namespace DataMorph.Tests.IO;
+namespace DataMorph.Tests.IO.Csv;
 
 [SimpleJob(RuntimeMoniker.Net80)]
 [SimpleJob(RuntimeMoniker.NativeAot80)]
 [MemoryDiagnoser]
 [HideColumns("Error", "StdDev", "Median", "RatioSD")]
-public class CsvDataRowIndexerBenchmarks : IDisposable
+public class DataRowIndexerBenchmarks : IDisposable
 {
     private readonly string _smallFilePath;
     private readonly string _mediumFilePath;
     private readonly string _largeFilePath;
     private readonly string _complexFilePath;
 
-    public CsvDataRowIndexerBenchmarks()
+    public DataRowIndexerBenchmarks()
     {
         // Small file: 1,000 rows (~50 KB)
         _smallFilePath = Path.Combine(Path.GetTempPath(), $"bench_csv_small_{Guid.NewGuid()}.csv");
@@ -71,35 +71,35 @@ public class CsvDataRowIndexerBenchmarks : IDisposable
     [Benchmark(Description = "Small CSV (1K rows, ~50KB)")]
     public void IndexSmallCsv()
     {
-        var indexer = new CsvDataRowIndexer(_smallFilePath);
+        var indexer = new DataRowIndexer(_smallFilePath);
         indexer.BuildIndex();
     }
 
     [Benchmark(Description = "Medium CSV (100K rows, ~5MB)")]
     public void IndexMediumCsv()
     {
-        var indexer = new CsvDataRowIndexer(_mediumFilePath);
+        var indexer = new DataRowIndexer(_mediumFilePath);
         indexer.BuildIndex();
     }
 
     [Benchmark(Description = "Large CSV (1M rows, ~50MB)")]
     public void IndexLargeCsv()
     {
-        var indexer = new CsvDataRowIndexer(_largeFilePath);
+        var indexer = new DataRowIndexer(_largeFilePath);
         indexer.BuildIndex();
     }
 
     [Benchmark(Description = "Complex CSV with quoted fields (10K rows)")]
     public void IndexComplexCsvWithQuotedFields()
     {
-        var indexer = new CsvDataRowIndexer(_complexFilePath);
+        var indexer = new DataRowIndexer(_complexFilePath);
         indexer.BuildIndex();
     }
 
     [Benchmark(Description = "GetCheckPoint for row 50,000")]
     public void GetCheckpointMediumFile()
     {
-        var indexer = new CsvDataRowIndexer(_mediumFilePath);
+        var indexer = new DataRowIndexer(_mediumFilePath);
         indexer.BuildIndex();
         _ = indexer.GetCheckPoint(50_000);
     }
@@ -107,7 +107,7 @@ public class CsvDataRowIndexerBenchmarks : IDisposable
     [Benchmark(Description = "GetCheckPoint for row 500,000")]
     public void GetCheckpointLargeFile()
     {
-        var indexer = new CsvDataRowIndexer(_largeFilePath);
+        var indexer = new DataRowIndexer(_largeFilePath);
         indexer.BuildIndex();
         _ = indexer.GetCheckPoint(500_000);
     }

--- a/tests/DataMorph.Tests/IO/Csv/DataRowIndexerTests.BuildIndex.cs
+++ b/tests/DataMorph.Tests/IO/Csv/DataRowIndexerTests.BuildIndex.cs
@@ -1,9 +1,9 @@
 using AwesomeAssertions;
-using DataMorph.Engine.IO;
+using DataMorph.Engine.IO.Csv;
 
-namespace DataMorph.Tests.IO;
+namespace DataMorph.Tests.IO.Csv;
 
-public sealed partial class CsvDataRowIndexerTests
+public sealed partial class DataRowIndexerTests
 {
     [Fact]
     public void BuildIndex_WithSimpleCsv_IndexesAllRows()
@@ -11,7 +11,7 @@ public sealed partial class CsvDataRowIndexerTests
         // Arrange
         var content = "header1,header2,header3\nvalue1,value2,value3\nvalue4,value5,value6";
         File.WriteAllText(_testFilePath, content);
-        var indexer = new CsvDataRowIndexer(_testFilePath);
+        var indexer = new DataRowIndexer(_testFilePath);
 
         // Act
         indexer.BuildIndex();
@@ -27,7 +27,7 @@ public sealed partial class CsvDataRowIndexerTests
         var content =
             "name,description,price\n\"Smith, John\",\"A product, with comma\",100\n\"Doe, Jane\",Normal,200";
         File.WriteAllText(_testFilePath, content);
-        var indexer = new CsvDataRowIndexer(_testFilePath);
+        var indexer = new DataRowIndexer(_testFilePath);
 
         // Act
         indexer.BuildIndex();
@@ -43,7 +43,7 @@ public sealed partial class CsvDataRowIndexerTests
         var content =
             "name,description\n\"John\",\"Line1\nLine2\nLine3\"\n\"Jane\",\"Single line\"";
         File.WriteAllText(_testFilePath, content);
-        var indexer = new CsvDataRowIndexer(_testFilePath);
+        var indexer = new DataRowIndexer(_testFilePath);
 
         // Act
         indexer.BuildIndex();
@@ -59,7 +59,7 @@ public sealed partial class CsvDataRowIndexerTests
         var content =
             "name,quote\n\"John\",\"He said \"\"Hello\"\"\"\n\"Jane\",\"She said \"\"Hi\"\"\"";
         File.WriteAllText(_testFilePath, content);
-        var indexer = new CsvDataRowIndexer(_testFilePath);
+        var indexer = new DataRowIndexer(_testFilePath);
 
         // Act
         indexer.BuildIndex();
@@ -74,7 +74,7 @@ public sealed partial class CsvDataRowIndexerTests
         // Arrange
         var content = "header1,header2\r\nvalue1,value2\r\nvalue3,value4";
         File.WriteAllText(_testFilePath, content);
-        var indexer = new CsvDataRowIndexer(_testFilePath);
+        var indexer = new DataRowIndexer(_testFilePath);
 
         // Act
         indexer.BuildIndex();
@@ -89,7 +89,7 @@ public sealed partial class CsvDataRowIndexerTests
         // Arrange
         var content = "header1,header2\nvalue1,value2\r\nvalue3,value4\nvalue5,value6";
         File.WriteAllText(_testFilePath, content);
-        var indexer = new CsvDataRowIndexer(_testFilePath);
+        var indexer = new DataRowIndexer(_testFilePath);
 
         // Act
         indexer.BuildIndex();
@@ -103,7 +103,7 @@ public sealed partial class CsvDataRowIndexerTests
     {
         // Arrange
         File.WriteAllText(_testFilePath, string.Empty);
-        var indexer = new CsvDataRowIndexer(_testFilePath);
+        var indexer = new DataRowIndexer(_testFilePath);
 
         // Act
         indexer.BuildIndex();
@@ -117,7 +117,7 @@ public sealed partial class CsvDataRowIndexerTests
     {
         // Arrange
         File.WriteAllText(_testFilePath, "header1,header2,header3");
-        var indexer = new CsvDataRowIndexer(_testFilePath);
+        var indexer = new DataRowIndexer(_testFilePath);
 
         // Act
         indexer.BuildIndex();
@@ -132,7 +132,7 @@ public sealed partial class CsvDataRowIndexerTests
         // Arrange
         var content = "header1,header2\nvalue1,value2\nvalue3,value4\n";
         File.WriteAllText(_testFilePath, content);
-        var indexer = new CsvDataRowIndexer(_testFilePath);
+        var indexer = new DataRowIndexer(_testFilePath);
 
         // Act
         indexer.BuildIndex();
@@ -149,7 +149,7 @@ public sealed partial class CsvDataRowIndexerTests
             "name,address,notes\n\"Smith, John\",\"123 Main St\nApt 4\",\"Has a cat\"\n\"Doe, Jane\",\"456 \"\"Oak\"\" Avenue\",\"Likes \"\"pizza\"\"\"\nNormal,Simple,Data";
 
         File.WriteAllText(_testFilePath, content);
-        var indexer = new CsvDataRowIndexer(_testFilePath);
+        var indexer = new DataRowIndexer(_testFilePath);
 
         // Act
         indexer.BuildIndex();
@@ -164,7 +164,7 @@ public sealed partial class CsvDataRowIndexerTests
         // Arrange
         var content = "名前,説明\n太郎,\"日本語, テスト\"\n花子,シンプル";
         File.WriteAllText(_testFilePath, content);
-        var indexer = new CsvDataRowIndexer(_testFilePath);
+        var indexer = new DataRowIndexer(_testFilePath);
 
         // Act
         indexer.BuildIndex();
@@ -179,7 +179,7 @@ public sealed partial class CsvDataRowIndexerTests
         // Arrange
         var content = "\n\n\n";
         File.WriteAllText(_testFilePath, content);
-        var indexer = new CsvDataRowIndexer(_testFilePath);
+        var indexer = new DataRowIndexer(_testFilePath);
 
         // Act
         indexer.BuildIndex();
@@ -194,7 +194,7 @@ public sealed partial class CsvDataRowIndexerTests
         // Arrange
         var content = "col1,col2,col3\nval1,\"\",val3\nval4,\"\",val6";
         File.WriteAllText(_testFilePath, content);
-        var indexer = new CsvDataRowIndexer(_testFilePath);
+        var indexer = new DataRowIndexer(_testFilePath);
 
         // Act
         indexer.BuildIndex();
@@ -211,7 +211,7 @@ public sealed partial class CsvDataRowIndexerTests
         lines.AddRange(Enumerable.Range(1, 1001).Select(i => $"value{i:D4},data{i:D4}"));
         File.WriteAllText(_testFilePath, string.Join("\n", lines));
 
-        var indexer = new CsvDataRowIndexer(_testFilePath);
+        var indexer = new DataRowIndexer(_testFilePath);
 
         // Act
         indexer.BuildIndex();
@@ -228,7 +228,7 @@ public sealed partial class CsvDataRowIndexerTests
         var content = $"col1,col2\n\"{longValue}\",normal";
         File.WriteAllText(_testFilePath, content);
 
-        var indexer = new CsvDataRowIndexer(_testFilePath);
+        var indexer = new DataRowIndexer(_testFilePath);
 
         // Act
         indexer.BuildIndex();

--- a/tests/DataMorph.Tests/IO/Csv/DataRowIndexerTests.GetCheckPoint.cs
+++ b/tests/DataMorph.Tests/IO/Csv/DataRowIndexerTests.GetCheckPoint.cs
@@ -1,9 +1,9 @@
 using AwesomeAssertions;
-using DataMorph.Engine.IO;
+using DataMorph.Engine.IO.Csv;
 
-namespace DataMorph.Tests.IO;
+namespace DataMorph.Tests.IO.Csv;
 
-public sealed partial class CsvDataRowIndexerTests
+public sealed partial class DataRowIndexerTests
 {
     [Fact]
     public void GetCheckPoint_WithRowLessThanCheckpoint_ReturnsFirstCheckpoint()
@@ -14,7 +14,7 @@ public sealed partial class CsvDataRowIndexerTests
         lines.AddRange(Enumerable.Range(1, 500).Select(i => $"v{i:D3},d{i:D3}"));
         File.WriteAllText(_testFilePath, string.Join("\n", lines) + "\n");
 
-        var indexer = new CsvDataRowIndexer(_testFilePath);
+        var indexer = new DataRowIndexer(_testFilePath);
         indexer.BuildIndex();
 
         // Act
@@ -34,7 +34,7 @@ public sealed partial class CsvDataRowIndexerTests
         lines.AddRange(Enumerable.Range(1, 1500).Select(i => $"v{i:D4},d{i:D4}"));
         File.WriteAllText(_testFilePath, string.Join("\n", lines) + "\n");
 
-        var indexer = new CsvDataRowIndexer(_testFilePath);
+        var indexer = new DataRowIndexer(_testFilePath);
         indexer.BuildIndex();
 
         // Act
@@ -56,7 +56,7 @@ public sealed partial class CsvDataRowIndexerTests
         lines.AddRange(Enumerable.Range(1, 1200).Select(i => $"v{i:D4},d{i:D4}"));
         File.WriteAllText(_testFilePath, string.Join("\n", lines) + "\n");
 
-        var indexer = new CsvDataRowIndexer(_testFilePath);
+        var indexer = new DataRowIndexer(_testFilePath);
         indexer.BuildIndex();
 
         // Act
@@ -80,7 +80,7 @@ public sealed partial class CsvDataRowIndexerTests
         lines.AddRange(Enumerable.Range(1, 2000).Select(i => $"v{i:D4},d{i:D4}"));
         File.WriteAllText(_testFilePath, string.Join("\n", lines) + "\n");
 
-        var indexer = new CsvDataRowIndexer(_testFilePath);
+        var indexer = new DataRowIndexer(_testFilePath);
         indexer.BuildIndex();
 
         // Verify TotalRows is 2000 (header excluded, only data rows)
@@ -104,7 +104,7 @@ public sealed partial class CsvDataRowIndexerTests
     {
         // Arrange
         File.WriteAllText(_testFilePath, "col1,col2\nval1,val2\nval3,val4");
-        var indexer = new CsvDataRowIndexer(_testFilePath);
+        var indexer = new DataRowIndexer(_testFilePath);
         indexer.BuildIndex();
 
         // Act
@@ -121,7 +121,7 @@ public sealed partial class CsvDataRowIndexerTests
     {
         // Arrange
         File.WriteAllText(_testFilePath, "col1,col2\nval1,val2\nval3,val4");
-        var indexer = new CsvDataRowIndexer(_testFilePath);
+        var indexer = new DataRowIndexer(_testFilePath);
         indexer.BuildIndex();
 
         // Act
@@ -141,7 +141,7 @@ public sealed partial class CsvDataRowIndexerTests
         lines.AddRange(Enumerable.Range(1, 2000).Select(i => $"v{i:D4},d{i:D4}"));
         File.WriteAllText(_testFilePath, string.Join("\n", lines));
 
-        var indexer = new CsvDataRowIndexer(_testFilePath);
+        var indexer = new DataRowIndexer(_testFilePath);
         indexer.BuildIndex();
 
         // Act: Request row 1000 (exactly checkpoint interval)
@@ -159,7 +159,7 @@ public sealed partial class CsvDataRowIndexerTests
     {
         // Arrange
         File.WriteAllText(_testFilePath, "col1,col2\nval1,val2\nval3,val4");
-        var indexer = new CsvDataRowIndexer(_testFilePath);
+        var indexer = new DataRowIndexer(_testFilePath);
 
         // Act (before BuildIndex)
         var (byteOffset, rowOffset) = indexer.GetCheckPoint(100);
@@ -177,7 +177,7 @@ public sealed partial class CsvDataRowIndexerTests
         lines.AddRange(Enumerable.Range(1, 5000).Select(i => $"v{i:D4},d{i:D4}"));
         File.WriteAllText(_testFilePath, string.Join("\n", lines));
 
-        var indexer = new CsvDataRowIndexer(_testFilePath);
+        var indexer = new DataRowIndexer(_testFilePath);
 
         // Act: Start indexing in background
         var indexingTask = Task.Run(() => indexer.BuildIndex());

--- a/tests/DataMorph.Tests/IO/Csv/DataRowIndexerTests.cs
+++ b/tests/DataMorph.Tests/IO/Csv/DataRowIndexerTests.cs
@@ -1,13 +1,13 @@
 using AwesomeAssertions;
-using DataMorph.Engine.IO;
+using DataMorph.Engine.IO.Csv;
 
-namespace DataMorph.Tests.IO;
+namespace DataMorph.Tests.IO.Csv;
 
-public sealed partial class CsvDataRowIndexerTests : IDisposable
+public sealed partial class DataRowIndexerTests : IDisposable
 {
     private readonly string _testFilePath;
 
-    public CsvDataRowIndexerTests()
+    public DataRowIndexerTests()
     {
         _testFilePath = Path.Combine(Path.GetTempPath(), $"csvRowIndexer_{Guid.NewGuid()}.csv");
     }
@@ -24,7 +24,7 @@ public sealed partial class CsvDataRowIndexerTests : IDisposable
     public void Constructor_WithNullFilePath_ThrowsArgumentException()
     {
         // Act & Assert
-        var act = () => new CsvDataRowIndexer(null!);
+        var act = () => new DataRowIndexer(null!);
         act.Should()
             .Throw<ArgumentException>()
             .WithMessage("Value cannot be null.*")
@@ -35,7 +35,7 @@ public sealed partial class CsvDataRowIndexerTests : IDisposable
     public void Constructor_WithEmptyFilePath_ThrowsArgumentException()
     {
         // Act & Assert
-        var act = () => new CsvDataRowIndexer(string.Empty);
+        var act = () => new DataRowIndexer(string.Empty);
         act.Should().Throw<ArgumentException>();
     }
 
@@ -43,7 +43,7 @@ public sealed partial class CsvDataRowIndexerTests : IDisposable
     public void Constructor_WithWhitespaceFilePath_ThrowsArgumentException()
     {
         // Act & Assert
-        var act = () => new CsvDataRowIndexer("   ");
+        var act = () => new DataRowIndexer("   ");
         act.Should().Throw<ArgumentException>();
     }
 
@@ -52,7 +52,7 @@ public sealed partial class CsvDataRowIndexerTests : IDisposable
     {
         // Arrange
         File.WriteAllText(_testFilePath, "col1,col2\nval1,val2");
-        var indexer = new CsvDataRowIndexer(_testFilePath);
+        var indexer = new DataRowIndexer(_testFilePath);
 
         // Act & Assert
         indexer.TotalRows.Should().Be(0);
@@ -65,7 +65,7 @@ public sealed partial class CsvDataRowIndexerTests : IDisposable
         var nonExistentPath = Path.Combine(Path.GetTempPath(), $"nonexistent_{Guid.NewGuid()}.csv");
 
         // Act & Assert (constructor should not throw for non-existent file)
-        var indexer = new CsvDataRowIndexer(nonExistentPath);
+        var indexer = new DataRowIndexer(nonExistentPath);
         indexer.FilePath.Should().Be(nonExistentPath);
         indexer.TotalRows.Should().Be(0);
     }

--- a/tests/DataMorph.Tests/IO/Csv/DataRowReaderTests.cs
+++ b/tests/DataMorph.Tests/IO/Csv/DataRowReaderTests.cs
@@ -1,13 +1,13 @@
 using AwesomeAssertions;
-using DataMorph.Engine.IO;
+using DataMorph.Engine.IO.Csv;
 
-namespace DataMorph.Tests.IO;
+namespace DataMorph.Tests.IO.Csv;
 
-public sealed class CsvDataRowReaderTests : IDisposable
+public sealed class DataRowReaderTests : IDisposable
 {
     private readonly string _testFilePath;
 
-    public CsvDataRowReaderTests()
+    public DataRowReaderTests()
     {
         _testFilePath = Path.Combine(Path.GetTempPath(), $"csvRowReader_{Guid.NewGuid()}.csv");
     }
@@ -37,7 +37,7 @@ public sealed class CsvDataRowReaderTests : IDisposable
         // Arrange
         var csvContent = "col1,col2,col3\nval1,val2,val3\nval4,val5,val6\nval7,val8,val9";
         File.WriteAllText(_testFilePath, csvContent);
-        var reader = new CsvDataRowReader(_testFilePath, columnCount: 3);
+        var reader = new DataRowReader(_testFilePath, columnCount: 3);
         var offsetAfterHeader = csvContent.IndexOf('\n', StringComparison.Ordinal) + 1;
 
         // Act - Skip header by using offset, then start reading data rows
@@ -55,7 +55,7 @@ public sealed class CsvDataRowReaderTests : IDisposable
         // Arrange
         var csvContent = "col1,col2\nval1,val2";
         File.WriteAllText(_testFilePath, csvContent);
-        var reader = new CsvDataRowReader(_testFilePath, columnCount: 2);
+        var reader = new DataRowReader(_testFilePath, columnCount: 2);
         var offsetAfterHeader = csvContent.IndexOf('\n', StringComparison.Ordinal) + 1;
 
         // Act - Use offset after header for consistency, but negative offset should still return empty
@@ -71,7 +71,7 @@ public sealed class CsvDataRowReaderTests : IDisposable
         // Arrange
         var csvContent = "col1,col2\nval1,val2";
         File.WriteAllText(_testFilePath, csvContent);
-        var reader = new CsvDataRowReader(_testFilePath, columnCount: 2);
+        var reader = new DataRowReader(_testFilePath, columnCount: 2);
         var offsetAfterHeader = csvContent.IndexOf('\n', StringComparison.Ordinal) + 1;
 
         // Act
@@ -87,7 +87,7 @@ public sealed class CsvDataRowReaderTests : IDisposable
         // Arrange
         var csvContent = "col1,col2,col3\nval1,val2\nval3";
         File.WriteAllText(_testFilePath, csvContent);
-        var reader = new CsvDataRowReader(_testFilePath, columnCount: 3);
+        var reader = new DataRowReader(_testFilePath, columnCount: 3);
         var offsetAfterHeader = csvContent.IndexOf('\n', StringComparison.Ordinal) + 1;
 
         // Act & Assert
@@ -102,7 +102,7 @@ public sealed class CsvDataRowReaderTests : IDisposable
         // Arrange
         var csvContent = "col1,col2\nval1,val2\nval3,val4\nval5,val6";
         File.WriteAllText(_testFilePath, csvContent);
-        var reader = new CsvDataRowReader(_testFilePath, columnCount: 2);
+        var reader = new DataRowReader(_testFilePath, columnCount: 2);
         var offsetAfterHeader = csvContent.IndexOf('\n', StringComparison.Ordinal) + 1;
 
         // Act - When reading from offset after header, the first line at that offset is treated as data (HasHeader = false)
@@ -120,7 +120,7 @@ public sealed class CsvDataRowReaderTests : IDisposable
         // Arrange
         var csvContent = "col1,col2\nval1,val2\nval3,val4\nval5,val6\nval7,val8";
         File.WriteAllText(_testFilePath, csvContent);
-        var reader = new CsvDataRowReader(_testFilePath, columnCount: 2);
+        var reader = new DataRowReader(_testFilePath, columnCount: 2);
         var offsetAfterHeader = csvContent.IndexOf('\n', StringComparison.Ordinal) + 1;
 
         // Act - Skip header by using offset, then skip additional rows
@@ -137,7 +137,7 @@ public sealed class CsvDataRowReaderTests : IDisposable
     {
         // Arrange
         var nonExistentPath = Path.Combine(Path.GetTempPath(), $"nonexistent_{Guid.NewGuid()}.csv");
-        var reader = new CsvDataRowReader(nonExistentPath, columnCount: 2);
+        var reader = new DataRowReader(nonExistentPath, columnCount: 2);
 
         // Act
         var rows = reader.ReadRows(byteOffset: 0, rowsToSkip: 0, rowsToRead: 10);
@@ -152,7 +152,7 @@ public sealed class CsvDataRowReaderTests : IDisposable
         // Arrange
         var csvContent = "col1,col2\nval1,val2\nval3,val4";
         File.WriteAllText(_testFilePath, csvContent);
-        var reader = new CsvDataRowReader(_testFilePath, columnCount: 2);
+        var reader = new DataRowReader(_testFilePath, columnCount: 2);
         var offsetAfterHeader = csvContent.IndexOf('\n', StringComparison.Ordinal) + 1;
 
         // Act - Request 100 rows but only 2 data rows available

--- a/tests/DataMorph.Tests/IO/Csv/SchemaScannerTests.RefineSchema.cs
+++ b/tests/DataMorph.Tests/IO/Csv/SchemaScannerTests.RefineSchema.cs
@@ -1,11 +1,11 @@
 using AwesomeAssertions;
-using DataMorph.Engine.IO;
+using DataMorph.Engine.IO.Csv;
 using DataMorph.Engine.Models;
 using DataMorph.Engine.Types;
 
-namespace DataMorph.Tests.IO;
+namespace DataMorph.Tests.IO.Csv;
 
-public sealed partial class CsvSchemaScannerTests
+public sealed partial class SchemaScannerTests
 {
     [Fact]
     public void RefineSchema_CallsMarkNullableOnly_WhenNonNullableColumnHasEmptyValue()
@@ -24,7 +24,7 @@ public sealed partial class CsvSchemaScannerTests
         var row = new[] { "".AsMemory() };
 
         // Act
-        var result = CsvSchemaScanner.RefineSchema(schema, row);
+        var result = SchemaScanner.RefineSchema(schema, row);
 
         // Assert
         result.IsSuccess.Should().BeTrue();
@@ -54,7 +54,7 @@ public sealed partial class CsvSchemaScannerTests
         var row = new[] { "123".AsMemory() };
 
         // Act
-        var result = CsvSchemaScanner.RefineSchema(schema, row);
+        var result = SchemaScanner.RefineSchema(schema, row);
 
         // Assert
         result.IsFailure.Should().BeTrue();
@@ -68,7 +68,7 @@ public sealed partial class CsvSchemaScannerTests
         var row = new[] { "123".AsMemory() };
 
         // Act & Assert
-        Action action = () => CsvSchemaScanner.RefineSchema(null!, row);
+        Action action = () => SchemaScanner.RefineSchema(null!, row);
         action.Should().Throw<ArgumentNullException>();
     }
 
@@ -86,7 +86,7 @@ public sealed partial class CsvSchemaScannerTests
         ]);
 
         // Act & Assert
-        Action action = () => CsvSchemaScanner.RefineSchema(schema, null!);
+        Action action = () => SchemaScanner.RefineSchema(schema, null!);
         action.Should().Throw<ArgumentNullException>();
     }
 
@@ -107,7 +107,7 @@ public sealed partial class CsvSchemaScannerTests
         var row = new[] { "123".AsMemory() };
 
         // Act
-        var result = CsvSchemaScanner.RefineSchema(schema, row);
+        var result = SchemaScanner.RefineSchema(schema, row);
 
         // Assert
         result.IsSuccess.Should().BeTrue();
@@ -134,7 +134,7 @@ public sealed partial class CsvSchemaScannerTests
         var row = new[] { "".AsMemory() }; // empty value
 
         // Act
-        var result = CsvSchemaScanner.RefineSchema(schema, row);
+        var result = SchemaScanner.RefineSchema(schema, row);
 
         // Assert
         result.IsSuccess.Should().BeTrue();
@@ -160,7 +160,7 @@ public sealed partial class CsvSchemaScannerTests
         var row = new[] { "123.45".AsMemory() }; // parsable as floating point
 
         // Act
-        var result = CsvSchemaScanner.RefineSchema(schema, row);
+        var result = SchemaScanner.RefineSchema(schema, row);
 
         // Assert
         result.IsSuccess.Should().BeTrue();
@@ -205,7 +205,7 @@ public sealed partial class CsvSchemaScannerTests
         };
 
         // Act
-        var result = CsvSchemaScanner.RefineSchema(schema, row);
+        var result = SchemaScanner.RefineSchema(schema, row);
 
         // Assert
         result.IsSuccess.Should().BeTrue();

--- a/tests/DataMorph.Tests/IO/Csv/SchemaScannerTests.ScanSchema.cs
+++ b/tests/DataMorph.Tests/IO/Csv/SchemaScannerTests.ScanSchema.cs
@@ -1,11 +1,11 @@
 using System.Globalization;
 using AwesomeAssertions;
-using DataMorph.Engine.IO;
+using DataMorph.Engine.IO.Csv;
 using DataMorph.Engine.Types;
 
-namespace DataMorph.Tests.IO;
+namespace DataMorph.Tests.IO.Csv;
 
-public sealed partial class CsvSchemaScannerTests
+public sealed partial class SchemaScannerTests
 {
     [Fact]
     public void ScanSchema_SimpleCsvWithMixedTypes_ReturnsCorrectSchema()
@@ -22,7 +22,7 @@ public sealed partial class CsvSchemaScannerTests
             "2024-01-15".AsMemory(),
         };
         // Act
-        var result = CsvSchemaScanner.ScanSchema(columnNames, [row]);
+        var result = SchemaScanner.ScanSchema(columnNames, [row]);
 
         // Assert
         result.IsSuccess.Should().BeTrue();
@@ -52,7 +52,7 @@ public sealed partial class CsvSchemaScannerTests
         };
 
         // Act
-        var result = CsvSchemaScanner.ScanSchema(columnNames, [row]);
+        var result = SchemaScanner.ScanSchema(columnNames, [row]);
 
         // Assert
         result.IsSuccess.Should().BeTrue();
@@ -84,7 +84,7 @@ public sealed partial class CsvSchemaScannerTests
         };
 
         // Act
-        var result = CsvSchemaScanner.ScanSchema(columnNames, [row]);
+        var result = SchemaScanner.ScanSchema(columnNames, [row]);
 
         // Assert
         result.IsSuccess.Should().BeTrue();
@@ -111,7 +111,7 @@ public sealed partial class CsvSchemaScannerTests
         var row = new[] { "1".AsMemory(), "test".AsMemory(), "Alice".AsMemory() };
 
         // Act
-        var result = CsvSchemaScanner.ScanSchema(columnNames, [row]);
+        var result = SchemaScanner.ScanSchema(columnNames, [row]);
 
         // Assert
         result.IsSuccess.Should().BeTrue();
@@ -139,7 +139,7 @@ public sealed partial class CsvSchemaScannerTests
         var row = Array.Empty<ReadOnlyMemory<char>>();
 
         // Act
-        var result = CsvSchemaScanner.ScanSchema(columnNames, [row]);
+        var result = SchemaScanner.ScanSchema(columnNames, [row]);
 
         // Assert
         result.IsFailure.Should().BeTrue();
@@ -159,7 +159,7 @@ public sealed partial class CsvSchemaScannerTests
         };
 
         // Act
-        var result = CsvSchemaScanner.ScanSchema(columnNames, [row]);
+        var result = SchemaScanner.ScanSchema(columnNames, [row]);
 
         // Assert
         result.IsFailure.Should().BeTrue();
@@ -179,7 +179,7 @@ public sealed partial class CsvSchemaScannerTests
         }; // No data rows
 
         // Act
-        var result = CsvSchemaScanner.ScanSchema(columnNames, [row]);
+        var result = SchemaScanner.ScanSchema(columnNames, [row]);
 
         // Assert
         result.IsSuccess.Should().BeTrue();
@@ -214,7 +214,7 @@ public sealed partial class CsvSchemaScannerTests
         };
 
         // Act
-        var result = CsvSchemaScanner.ScanSchema(columnNames, [row]);
+        var result = SchemaScanner.ScanSchema(columnNames, [row]);
 
         // Assert
         result.IsSuccess.Should().BeTrue();
@@ -255,7 +255,7 @@ public sealed partial class CsvSchemaScannerTests
         };
 
         // Act
-        var result = CsvSchemaScanner.ScanSchema(columnNames, [row]);
+        var result = SchemaScanner.ScanSchema(columnNames, [row]);
 
         // Assert
         result.IsSuccess.Should().BeTrue();
@@ -292,7 +292,7 @@ public sealed partial class CsvSchemaScannerTests
         };
 
         // Act
-        var result = CsvSchemaScanner.ScanSchema(columnNames, [row]);
+        var result = SchemaScanner.ScanSchema(columnNames, [row]);
 
         // Assert
         result.IsSuccess.Should().BeTrue();
@@ -329,7 +329,7 @@ public sealed partial class CsvSchemaScannerTests
         };
 
         // Act
-        var result = CsvSchemaScanner.ScanSchema(columnNames, [row]);
+        var result = SchemaScanner.ScanSchema(columnNames, [row]);
 
         // Assert
         result.IsSuccess.Should().BeTrue();
@@ -360,7 +360,7 @@ public sealed partial class CsvSchemaScannerTests
         var columnNames = new[] { "numeric_string" };
         var row = new[] { "1".AsMemory() };
 
-        var result = CsvSchemaScanner.ScanSchema(columnNames, [row]);
+        var result = SchemaScanner.ScanSchema(columnNames, [row]);
 
         result.IsSuccess.Should().BeTrue();
         var schema = result.Value;
@@ -378,7 +378,7 @@ public sealed partial class CsvSchemaScannerTests
         var columnNames = new[] { "integer" };
         var row = new[] { "123".AsMemory() };
 
-        var result = CsvSchemaScanner.ScanSchema(columnNames, [row]);
+        var result = SchemaScanner.ScanSchema(columnNames, [row]);
 
         result.IsSuccess.Should().BeTrue();
         var schema = result.Value;
@@ -396,7 +396,7 @@ public sealed partial class CsvSchemaScannerTests
         var row = new[] { "1".AsMemory() };
 
         // Act & Assert
-        Action action = () => CsvSchemaScanner.ScanSchema(columnNames, [row], initialScanCount: -1);
+        Action action = () => SchemaScanner.ScanSchema(columnNames, [row], initialScanCount: -1);
         action.Should().Throw<ArgumentOutOfRangeException>();
     }
 
@@ -408,10 +408,10 @@ public sealed partial class CsvSchemaScannerTests
         var row = new[] { "1".AsMemory() };
 
         // Act & Assert
-        Action action1 = () => CsvSchemaScanner.ScanSchema(null!, [row]);
+        Action action1 = () => SchemaScanner.ScanSchema(null!, [row]);
         action1.Should().Throw<ArgumentNullException>();
 
-        Action action2 = () => CsvSchemaScanner.ScanSchema(columnNames, null!);
+        Action action2 = () => SchemaScanner.ScanSchema(columnNames, null!);
         action2.Should().Throw<ArgumentNullException>();
     }
 
@@ -437,7 +437,7 @@ public sealed partial class CsvSchemaScannerTests
             .ToList();
 
         // Act
-        var result = CsvSchemaScanner.ScanSchema(columnNames, rows, initialScanCount: 200);
+        var result = SchemaScanner.ScanSchema(columnNames, rows, initialScanCount: 200);
 
         // Assert
         result.IsSuccess.Should().BeTrue();
@@ -458,7 +458,7 @@ public sealed partial class CsvSchemaScannerTests
             .ToList();
 
         // Act
-        var result = CsvSchemaScanner.ScanSchema(columnNames, rows, initialScanCount: 200);
+        var result = SchemaScanner.ScanSchema(columnNames, rows, initialScanCount: 200);
 
         // Assert
         result.IsSuccess.Should().BeTrue();
@@ -477,7 +477,7 @@ public sealed partial class CsvSchemaScannerTests
             .ToList();
 
         // Act - limit with custom initial scan count of 50
-        var result = CsvSchemaScanner.ScanSchema(columnNames, rows, initialScanCount: 50);
+        var result = SchemaScanner.ScanSchema(columnNames, rows, initialScanCount: 50);
 
         // Assert
         result.IsSuccess.Should().BeTrue();

--- a/tests/DataMorph.Tests/IO/Csv/SchemaScannerTests.cs
+++ b/tests/DataMorph.Tests/IO/Csv/SchemaScannerTests.cs
@@ -2,9 +2,9 @@ using AwesomeAssertions;
 using DataMorph.Engine.Models;
 using DataMorph.Engine.Types;
 
-namespace DataMorph.Tests.IO;
+namespace DataMorph.Tests.IO.Csv;
 
-public sealed partial class CsvSchemaScannerTests
+public sealed partial class SchemaScannerTests
 {
     private static void AssertColumn(
         TableSchema schema,

--- a/tests/DataMorph.Tests/IO/Csv/TypeInferrerTests.cs
+++ b/tests/DataMorph.Tests/IO/Csv/TypeInferrerTests.cs
@@ -1,10 +1,10 @@
 using AwesomeAssertions;
-using DataMorph.Engine.IO;
+using DataMorph.Engine.IO.Csv;
 using DataMorph.Engine.Types;
 
-namespace DataMorph.Tests.IO;
+namespace DataMorph.Tests.IO.Csv;
 
-public sealed class CsvTypeInferrerTests
+public sealed class TypeInferrerTests
 {
     [Theory]
     [InlineData("true", true)]
@@ -17,7 +17,7 @@ public sealed class CsvTypeInferrerTests
     [InlineData("  false  ", false)]
     public void TryParseBoolean_ValidValues_ReturnsTrue(string input, bool expected)
     {
-        CsvTypeInferrer.TryParseBoolean(input.AsSpan(), out var result).Should().BeTrue();
+        TypeInferrer.TryParseBoolean(input.AsSpan(), out var result).Should().BeTrue();
         result.Should().Be(expected);
     }
 
@@ -33,7 +33,7 @@ public sealed class CsvTypeInferrerTests
     [InlineData("   ")]
     public void TryParseBoolean_InvalidValues_ReturnsFalse(string input)
     {
-        CsvTypeInferrer.TryParseBoolean(input.AsSpan(), out _).Should().BeFalse();
+        TypeInferrer.TryParseBoolean(input.AsSpan(), out _).Should().BeFalse();
     }
 
     [Theory]
@@ -48,7 +48,7 @@ public sealed class CsvTypeInferrerTests
     [InlineData("-9223372036854775808", long.MinValue)]
     public void TryParseWholeNumber_ValidValues_ReturnsTrue(string input, long expected)
     {
-        CsvTypeInferrer.TryParseWholeNumber(input.AsSpan(), out var result).Should().BeTrue();
+        TypeInferrer.TryParseWholeNumber(input.AsSpan(), out var result).Should().BeTrue();
         result.Should().Be(expected);
     }
 
@@ -62,7 +62,7 @@ public sealed class CsvTypeInferrerTests
     [InlineData("   ")]
     public void TryParseWholeNumber_InvalidValues_ReturnsFalse(string input)
     {
-        CsvTypeInferrer.TryParseWholeNumber(input.AsSpan(), out _).Should().BeFalse();
+        TypeInferrer.TryParseWholeNumber(input.AsSpan(), out _).Should().BeFalse();
     }
 
     [Theory]
@@ -76,7 +76,7 @@ public sealed class CsvTypeInferrerTests
     [InlineData("  3.14  ", 3.14)]
     public void TryParseFloatingPoint_ValidValues_ReturnsTrue(string input, double expected)
     {
-        CsvTypeInferrer.TryParseFloatingPoint(input.AsSpan(), out var result).Should().BeTrue();
+        TypeInferrer.TryParseFloatingPoint(input.AsSpan(), out var result).Should().BeTrue();
         result.Should().Be(expected);
     }
 
@@ -87,7 +87,7 @@ public sealed class CsvTypeInferrerTests
     [InlineData("   ")]
     public void TryParseFloatingPoint_InvalidValues_ReturnsFalse(string input)
     {
-        CsvTypeInferrer.TryParseFloatingPoint(input.AsSpan(), out _).Should().BeFalse();
+        TypeInferrer.TryParseFloatingPoint(input.AsSpan(), out _).Should().BeFalse();
     }
 
     [Theory]
@@ -96,7 +96,7 @@ public sealed class CsvTypeInferrerTests
     [InlineData("-Infinity")]
     public void TryParseFloatingPoint_SpecialValues_ReturnsTrue(string input)
     {
-        CsvTypeInferrer.TryParseFloatingPoint(input.AsSpan(), out _).Should().BeTrue();
+        TypeInferrer.TryParseFloatingPoint(input.AsSpan(), out _).Should().BeTrue();
     }
 
     [Theory]
@@ -115,7 +115,7 @@ public sealed class CsvTypeInferrerTests
         DateTimeKind kind
     )
     {
-        CsvTypeInferrer.TryParseTimestamp(input.AsSpan(), out var result).Should().BeTrue();
+        TypeInferrer.TryParseTimestamp(input.AsSpan(), out var result).Should().BeTrue();
         var expected = new DateTime(year, month, day, hour, minute, second, kind);
         result.Date.Should().Be(expected.Date);
     }
@@ -128,7 +128,7 @@ public sealed class CsvTypeInferrerTests
     [InlineData("   ")]
     public void TryParseTimestamp_InvalidValues_ReturnsFalse(string input)
     {
-        CsvTypeInferrer.TryParseTimestamp(input.AsSpan(), out _).Should().BeFalse();
+        TypeInferrer.TryParseTimestamp(input.AsSpan(), out _).Should().BeFalse();
     }
 
     [Theory]
@@ -140,7 +140,7 @@ public sealed class CsvTypeInferrerTests
     [InlineData("123", false)]
     public void IsEmptyOrWhitespace_DetectsCorrectly(string input, bool expected)
     {
-        CsvTypeInferrer.IsEmptyOrWhitespace(input.AsSpan()).Should().Be(expected);
+        TypeInferrer.IsEmptyOrWhitespace(input.AsSpan()).Should().Be(expected);
     }
 
     [Theory]
@@ -149,7 +149,7 @@ public sealed class CsvTypeInferrerTests
     [InlineData("TRUE", ColumnType.Boolean)]
     public void InferType_PrioritizesBoolean(string input, ColumnType expected)
     {
-        CsvTypeInferrer.InferType(input.AsSpan()).Should().Be(expected);
+        TypeInferrer.InferType(input.AsSpan()).Should().Be(expected);
     }
 
     [Theory]
@@ -158,7 +158,7 @@ public sealed class CsvTypeInferrerTests
     [InlineData("0", ColumnType.WholeNumber)]
     public void InferType_PrioritizesWholeNumberOverFloatingPoint(string input, ColumnType expected)
     {
-        CsvTypeInferrer.InferType(input.AsSpan()).Should().Be(expected);
+        TypeInferrer.InferType(input.AsSpan()).Should().Be(expected);
     }
 
     [Theory]
@@ -169,7 +169,7 @@ public sealed class CsvTypeInferrerTests
     [InlineData("NaN", ColumnType.FloatingPoint)]
     public void InferType_DetectsFloatingPoint(string input, ColumnType expected)
     {
-        CsvTypeInferrer.InferType(input.AsSpan()).Should().Be(expected);
+        TypeInferrer.InferType(input.AsSpan()).Should().Be(expected);
     }
 
     [Theory]
@@ -178,7 +178,7 @@ public sealed class CsvTypeInferrerTests
     [InlineData("1/15/2024", ColumnType.Timestamp)]
     public void InferType_DetectsTimestamp(string input, ColumnType expected)
     {
-        CsvTypeInferrer.InferType(input.AsSpan()).Should().Be(expected);
+        TypeInferrer.InferType(input.AsSpan()).Should().Be(expected);
     }
 
     [Theory]
@@ -190,6 +190,6 @@ public sealed class CsvTypeInferrerTests
     [InlineData("   ", ColumnType.Text)]
     public void InferType_FallbackToText(string input, ColumnType expected)
     {
-        CsvTypeInferrer.InferType(input.AsSpan()).Should().Be(expected);
+        TypeInferrer.InferType(input.AsSpan()).Should().Be(expected);
     }
 }


### PR DESCRIPTION
## Summary

- Moved CSV-related IO classes into the `IO/Csv/` subdirectory
- Removed the `Csv` prefix from class names (e.g., `CsvDataRowCache` → `DataRowCache`)
- Updated corresponding tests and benchmarks to match the new structure

## Changes

- `IO/CsvDataRowCache.cs` → `IO/Csv/DataRowCache.cs`
- `IO/CsvDataRowIndexer.cs` → `IO/Csv/DataRowIndexer.cs`
- `IO/CsvDataRowReader.cs` → `IO/Csv/DataRowReader.cs`
- `IO/CsvSchemaScanner.cs` → `IO/Csv/SchemaScanner.cs`
- `IO/CsvTypeInferrer.cs` → `IO/Csv/TypeInferrer.cs`
- Renamed and relocated corresponding test and benchmark files accordingly

🤖 Generated with [Claude Code](https://claude.com/claude-code)