### PR TITLE
refactor: Rename JsonLines types to Row prefix

### DIFF
--- a/src/App/Views/JsonLinesTreeView.cs
+++ b/src/App/Views/JsonLinesTreeView.cs
@@ -14,7 +14,7 @@ internal sealed class JsonLinesTreeView : TreeView
 {
     private const int InitialLoadCount = 50;
 
-    private readonly JsonLineByteCache _cache;
+    private readonly RowByteCache _cache;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="JsonLinesTreeView"/> class.
@@ -22,7 +22,7 @@ internal sealed class JsonLinesTreeView : TreeView
     /// <param name="indexer">The row indexer for the JSON Lines file.</param>
     public JsonLinesTreeView(RowIndexer indexer)
     {
-        _cache = new JsonLineByteCache(indexer);
+        _cache = new RowByteCache(indexer);
         LoadInitialRootNodes();
 
         ObjectActivated += OnObjectActivated;

--- a/src/Engine/IO/JsonLines/RowByteCache.cs
+++ b/src/Engine/IO/JsonLines/RowByteCache.cs
@@ -4,27 +4,27 @@ namespace DataMorph.Engine.IO.JsonLines;
 /// Manages a sliding window cache of JSON line bytes for efficient virtual scrolling.
 /// Uses ReadOnlyMemory&lt;byte&gt; for memory-efficient line storage.
 /// </summary>
-public sealed class JsonLineByteCache : IDisposable
+public sealed class RowByteCache : IDisposable
 {
     private const int DefaultCacheSize = 200;
     private readonly RowIndexer _indexer;
-    private readonly JsonLineReader _reader;
+    private readonly RowReader _reader;
     private readonly int _cacheSize;
     private readonly Dictionary<int, ReadOnlyMemory<byte>> _cache = [];
     private int _cacheStartRow = -1;
     private bool _disposed;
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="JsonLineByteCache"/> class.
+    /// Initializes a new instance of the <see cref="RowByteCache"/> class.
     /// </summary>
     /// <param name="indexer">The row indexer for obtaining byte offsets.</param>
     /// <param name="cacheSize">The size of the sliding window cache (default: 200).</param>
-    public JsonLineByteCache(RowIndexer indexer, int cacheSize = DefaultCacheSize)
+    public RowByteCache(RowIndexer indexer, int cacheSize = DefaultCacheSize)
     {
         ArgumentNullException.ThrowIfNull(indexer);
         _indexer = indexer;
         _cacheSize = cacheSize;
-        _reader = new JsonLineReader(indexer.FilePath);
+        _reader = new RowReader(indexer.FilePath);
     }
 
     /// <summary>

--- a/src/Engine/IO/JsonLines/RowIndexer.cs
+++ b/src/Engine/IO/JsonLines/RowIndexer.cs
@@ -55,7 +55,7 @@ public sealed class RowIndexer
             FileShare.Read
         );
         var buffer = ArrayPool<byte>.Shared.Rent(BufferSize);
-        var scanner = new JsonLinesScanner();
+        var scanner = new RowScanner();
 
         try
         {
@@ -126,7 +126,7 @@ public sealed class RowIndexer
         ReadOnlySpan<byte> buffer,
         ref long fileOffset,
         ref long rowCount,
-        ref JsonLinesScanner scanner
+        ref RowScanner scanner
     )
     {
         var position = 0;

--- a/src/Engine/IO/JsonLines/RowReader.cs
+++ b/src/Engine/IO/JsonLines/RowReader.cs
@@ -7,17 +7,17 @@ namespace DataMorph.Engine.IO.JsonLines;
 /// Reads JSON line bytes from a file using indexed byte offsets.
 /// Returns raw JSON bytes per line (not TreeNode) to maintain Engine/App layer separation.
 /// </summary>
-public sealed class JsonLineReader : IDisposable
+public sealed class RowReader : IDisposable
 {
     private readonly MmapService _mmap;
     private bool _disposed;
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="JsonLineReader"/> class.
+    /// Initializes a new instance of the <see cref="RowReader"/> class.
     /// </summary>
     /// <param name="filePath">Path to the JSON Lines file.</param>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="filePath"/> is null.</exception>
-    public JsonLineReader(string filePath)
+    public RowReader(string filePath)
     {
         ArgumentNullException.ThrowIfNull(filePath);
 
@@ -53,7 +53,7 @@ public sealed class JsonLineReader : IDisposable
         var currentOffset = byteOffset;
         var skipped = 0;
 
-        var scanner = new JsonLinesScanner();
+        var scanner = new RowScanner();
 
         // Skip lines if needed
         while (skipped < linesToSkip)
@@ -181,7 +181,7 @@ public sealed class JsonLineReader : IDisposable
 
     private (bool lineCompleted, int bytesConsumed) FindNextLineLength(
         long startOffset,
-        ref JsonLinesScanner scanner
+        ref RowScanner scanner
     )
     {
         const int maxSearch = 1024 * 1024; // Search up to 1 MB

--- a/src/Engine/IO/JsonLines/RowScanner.cs
+++ b/src/Engine/IO/JsonLines/RowScanner.cs
@@ -27,7 +27,7 @@ namespace DataMorph.Engine.IO.JsonLines;
 ///    - We use vectorized SearchValues for initial byte scanning and minimal branching in hot paths.
 ///    - The state machine is optimized for the common case (no escapes) while handling edge cases correctly.
 /// </summary>
-public ref struct JsonLinesScanner
+public ref struct RowScanner
 {
     private static readonly SearchValues<byte> _newlineAndQuote = SearchValues.Create("\n\""u8);
 
@@ -35,10 +35,10 @@ public ref struct JsonLinesScanner
     private bool _escaped;
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="JsonLinesScanner"/> struct.
+    /// Initializes a new instance of the <see cref="RowScanner"/> struct.
     /// The scanner starts in a non-quoted state with no escape sequences.
     /// </summary>
-    public JsonLinesScanner()
+    public RowScanner()
     {
         _inQuotes = false;
         _escaped = false;

--- a/tests/DataMorph.Tests/IO/JsonLines/RowByteCacheBenchmarks.cs
+++ b/tests/DataMorph.Tests/IO/JsonLines/RowByteCacheBenchmarks.cs
@@ -6,7 +6,7 @@ namespace DataMorph.Tests.IO.JsonLines;
 
 [MemoryDiagnoser]
 [SimpleJob(RuntimeMoniker.NativeAot80)]
-public sealed class JsonLineByteCacheBenchmarks : IDisposable
+public sealed class RowByteCacheBenchmarks : IDisposable
 {
     private readonly string _testFilePath;
     private readonly RowIndexer _indexer;
@@ -16,7 +16,7 @@ public sealed class JsonLineByteCacheBenchmarks : IDisposable
     [Params(100, 200, 500)]
     public int CacheSize { get; set; }
 
-    public JsonLineByteCacheBenchmarks()
+    public RowByteCacheBenchmarks()
     {
         // Arrange - Create test data
         _testFilePath = Path.GetTempFileName();
@@ -37,7 +37,7 @@ public sealed class JsonLineByteCacheBenchmarks : IDisposable
     [Benchmark]
     public void Access_RandomPattern_CacheHit50()
     {
-        var cache = new JsonLineByteCache(_indexer, CacheSize);
+        var cache = new RowByteCache(_indexer, CacheSize);
         var totalLines = _indexer.TotalRows;
 
         // Random access pattern (approximately 50% cache hit rate)
@@ -65,7 +65,7 @@ public sealed class JsonLineByteCacheBenchmarks : IDisposable
     [Benchmark]
     public void Access_SequentialPattern_CacheHit90()
     {
-        var cache = new JsonLineByteCache(_indexer, CacheSize);
+        var cache = new RowByteCache(_indexer, CacheSize);
         var totalLines = _indexer.TotalRows;
 
         // Sequential access pattern (approximately 90% cache hit rate)
@@ -84,7 +84,7 @@ public sealed class JsonLineByteCacheBenchmarks : IDisposable
     [Benchmark]
     public void Access_RepeatedSameLine_CacheHit100()
     {
-        var cache = new JsonLineByteCache(_indexer, CacheSize);
+        var cache = new RowByteCache(_indexer, CacheSize);
 
         // Repeated access to the same line (100% cache hit rate)
         for (var i = 0; i < 1000; i++)
@@ -100,7 +100,7 @@ public sealed class JsonLineByteCacheBenchmarks : IDisposable
     public void Access_VaryingCacheSizes()
     {
         // Performance measurement with various cache sizes
-        var cache = new JsonLineByteCache(_indexer, CacheSize);
+        var cache = new RowByteCache(_indexer, CacheSize);
         var totalLines = _indexer.TotalRows;
 
         // Mixed access pattern
@@ -118,7 +118,7 @@ public sealed class JsonLineByteCacheBenchmarks : IDisposable
     [Benchmark]
     public void Access_LargeFile_10kLines()
     {
-        var cache = new JsonLineByteCache(_indexer, CacheSize);
+        var cache = new RowByteCache(_indexer, CacheSize);
 
         // Random access with large file
         for (var i = 0; i < 200; i++)
@@ -149,7 +149,7 @@ public sealed class JsonLineByteCacheBenchmarks : IDisposable
             var indexer = new RowIndexer(largeFilePath);
             indexer.BuildIndex();
 
-            using var cache = new JsonLineByteCache(indexer, CacheSize);
+            using var cache = new RowByteCache(indexer, CacheSize);
 
             // Random access with large file
             for (var i = 0; i < 100; i++)
@@ -169,7 +169,7 @@ public sealed class JsonLineByteCacheBenchmarks : IDisposable
     public void InitializeCache_FirstTime()
     {
         // Measure cache initialization cost
-        var cache = new JsonLineByteCache(_indexer, CacheSize);
+        var cache = new RowByteCache(_indexer, CacheSize);
 
         // Initial access
         var bytes = cache.GetLineBytes(0);
@@ -182,10 +182,10 @@ public sealed class JsonLineByteCacheBenchmarks : IDisposable
     public void InitializeCache_AfterDisposal()
     {
         // Measure reinitialization cost after disposal
-        var cache1 = new JsonLineByteCache(_indexer, CacheSize);
+        var cache1 = new RowByteCache(_indexer, CacheSize);
         cache1.Dispose();
 
-        var cache2 = new JsonLineByteCache(_indexer, CacheSize);
+        var cache2 = new RowByteCache(_indexer, CacheSize);
         var bytes = cache2.GetLineBytes(0);
         _ = bytes.Length;
 

--- a/tests/DataMorph.Tests/IO/JsonLines/RowByteCacheTests.cs
+++ b/tests/DataMorph.Tests/IO/JsonLines/RowByteCacheTests.cs
@@ -3,13 +3,13 @@ using DataMorph.Engine.IO.JsonLines;
 
 namespace DataMorph.Tests.IO.JsonLines;
 
-public sealed partial class JsonLineByteCacheTests : IDisposable
+public sealed partial class RowByteCacheTests : IDisposable
 {
     private readonly string _testFilePath;
     private readonly RowIndexer _indexer;
     private bool _disposed;
 
-    public JsonLineByteCacheTests()
+    public RowByteCacheTests()
     {
         // Arrange
         _testFilePath = Path.GetTempFileName();
@@ -40,7 +40,7 @@ public sealed partial class JsonLineByteCacheTests : IDisposable
     public void GetLineBytes_WithinCachedRange_ReturnsCachedBytes()
     {
         // Arrange
-        using var cache = new JsonLineByteCache(_indexer, cacheSize: 5);
+        using var cache = new RowByteCache(_indexer, cacheSize: 5);
         var expectedLine2 = "{\"id\":2,\"name\":\"Bob\"}"u8.ToArray();
 
         // Act - Get line 2 (within cache)
@@ -57,7 +57,7 @@ public sealed partial class JsonLineByteCacheTests : IDisposable
     public void GetLineBytes_OutsideCachedRange_UpdatesCacheWindow()
     {
         // Arrange
-        using var cache = new JsonLineByteCache(_indexer, cacheSize: 5);
+        using var cache = new RowByteCache(_indexer, cacheSize: 5);
         var expectedLine1 = "{\"id\":1,\"name\":\"Alice\"}"u8.ToArray();
         var expectedLine8 = "{\"id\":8,\"name\":\"Henry\"}"u8.ToArray();
 
@@ -75,7 +75,7 @@ public sealed partial class JsonLineByteCacheTests : IDisposable
     public void GetLineBytes_FirstLineRequested_CachesFromBeginning()
     {
         // Arrange
-        using var cache = new JsonLineByteCache(_indexer, cacheSize: 3);
+        using var cache = new RowByteCache(_indexer, cacheSize: 3);
         var expectedLine1 = "{\"id\":1,\"name\":\"Alice\"}"u8.ToArray();
         var expectedLine2 = "{\"id\":2,\"name\":\"Bob\"}"u8.ToArray();
         var expectedLine3 = "{\"id\":3,\"name\":\"Charlie\"}"u8.ToArray();
@@ -95,7 +95,7 @@ public sealed partial class JsonLineByteCacheTests : IDisposable
     public void GetLineBytes_LastLineRequested_CachesToEnd()
     {
         // Arrange
-        using var cache = new JsonLineByteCache(_indexer, cacheSize: 3);
+        using var cache = new RowByteCache(_indexer, cacheSize: 3);
         var totalLines = _indexer.TotalRows;
         var lastLineIndex = (int)totalLines - 1;
         var expectedLastLine = "{\"id\":10,\"name\":\"Jack\"}"u8.ToArray();
@@ -122,7 +122,7 @@ public sealed partial class JsonLineByteCacheTests : IDisposable
             // Act
             var act = () =>
             {
-                using var cache = new JsonLineByteCache(indexer);
+                using var cache = new RowByteCache(indexer);
             };
 
             // Assert
@@ -140,7 +140,7 @@ public sealed partial class JsonLineByteCacheTests : IDisposable
     public void GetLineBytes_NegativeIndex_ReturnsEmpty(int invalidIndex)
     {
         // Arrange
-        using var cache = new JsonLineByteCache(_indexer);
+        using var cache = new RowByteCache(_indexer);
 
         // Act
         var result = cache.GetLineBytes(invalidIndex);
@@ -155,7 +155,7 @@ public sealed partial class JsonLineByteCacheTests : IDisposable
     public void GetLineBytes_IndexEqualToOrGreaterThanTotalLines_ReturnsEmpty(int overflowIndex)
     {
         // Arrange
-        using var cache = new JsonLineByteCache(_indexer);
+        using var cache = new RowByteCache(_indexer);
 
         // Act
         var result = cache.GetLineBytes(overflowIndex);
@@ -168,7 +168,7 @@ public sealed partial class JsonLineByteCacheTests : IDisposable
     public void UpdateCache_RequestedAtCacheCenter_KeepsExistingCache()
     {
         // Arrange
-        using var cache = new JsonLineByteCache(_indexer, cacheSize: 5);
+        using var cache = new RowByteCache(_indexer, cacheSize: 5);
 
         // First access to line 2 (cache window: 0-4)
         cache.GetLineBytes(1);
@@ -187,7 +187,7 @@ public sealed partial class JsonLineByteCacheTests : IDisposable
     public void UpdateCache_RequestedNearWindowEdge_ShiftsCacheWindow()
     {
         // Arrange
-        using var cache = new JsonLineByteCache(_indexer, cacheSize: 5);
+        using var cache = new RowByteCache(_indexer, cacheSize: 5);
         var expectedLine4 = "{\"id\":4,\"name\":\"David\"}"u8.ToArray();
         var expectedLine8 = "{\"id\":8,\"name\":\"Henry\"}"u8.ToArray();
 
@@ -209,7 +209,7 @@ public sealed partial class JsonLineByteCacheTests : IDisposable
     {
         // Arrange
         var largeCacheSize = 20; // Larger than total lines
-        using var cache = new JsonLineByteCache(_indexer, cacheSize: largeCacheSize);
+        using var cache = new RowByteCache(_indexer, cacheSize: largeCacheSize);
 
         // Act - Get first and last lines
         var firstLine = cache.GetLineBytes(0).ToArray();
@@ -227,7 +227,7 @@ public sealed partial class JsonLineByteCacheTests : IDisposable
     public void Dispose_AfterAccess_PreventsFurtherAccess()
     {
         // Arrange
-        using var cache = new JsonLineByteCache(_indexer);
+        using var cache = new RowByteCache(_indexer);
         cache.GetLineBytes(0); // Normal access
 
         // Act
@@ -242,7 +242,7 @@ public sealed partial class JsonLineByteCacheTests : IDisposable
     public void GetLineBytes_AfterDisposal_ThrowsObjectDisposedException()
     {
         // Arrange
-        using var cache = new JsonLineByteCache(_indexer);
+        using var cache = new RowByteCache(_indexer);
         cache.Dispose();
 
         // Act
@@ -257,7 +257,7 @@ public sealed partial class JsonLineByteCacheTests : IDisposable
     {
         // Arrange
         var cacheSize = 5;
-        using var cache = new JsonLineByteCache(_indexer, cacheSize: cacheSize);
+        using var cache = new RowByteCache(_indexer, cacheSize: cacheSize);
 
         // First access initializes cache (lines 0-4)
         cache.GetLineBytes(0);
@@ -274,7 +274,7 @@ public sealed partial class JsonLineByteCacheTests : IDisposable
     public void UpdateCache_MultipleOverlaps_ProperlyInvalidatesOldEntries()
     {
         // Arrange
-        using var cache = new JsonLineByteCache(_indexer, cacheSize: 4);
+        using var cache = new RowByteCache(_indexer, cacheSize: 4);
 
         // First cache (lines 0-3)
         cache.GetLineBytes(0);

--- a/tests/DataMorph.Tests/IO/JsonLines/RowReaderTests.cs
+++ b/tests/DataMorph.Tests/IO/JsonLines/RowReaderTests.cs
@@ -4,12 +4,12 @@ using DataMorph.Engine.IO.JsonLines;
 
 namespace DataMorph.Tests.IO.JsonLines;
 
-public sealed class JsonLineReaderTests : IDisposable
+public sealed class RowReaderTests : IDisposable
 {
     private readonly string _testFilePath;
     private bool _disposed;
 
-    public JsonLineReaderTests()
+    public RowReaderTests()
     {
         _testFilePath = Path.GetTempFileName();
     }
@@ -35,7 +35,7 @@ public sealed class JsonLineReaderTests : IDisposable
         string? filePath = null;
 
         // Act
-        var act = () => new JsonLineReader(filePath!);
+        var act = () => new RowReader(filePath!);
 
         // Assert
         act.Should().Throw<ArgumentNullException>();
@@ -46,7 +46,7 @@ public sealed class JsonLineReaderTests : IDisposable
     {
         // Arrange
         WriteTestContent("{\"id\":1}\n");
-        using var reader = new JsonLineReader(_testFilePath);
+        using var reader = new RowReader(_testFilePath);
 
         // Act
         var lines = reader.ReadLineBytes(byteOffset: 0, linesToSkip: 0, linesToRead: 1);
@@ -62,7 +62,7 @@ public sealed class JsonLineReaderTests : IDisposable
     {
         // Arrange
         WriteTestContent("{\"a\":1}\n{\"b\":2}\n{\"c\":3}\n");
-        using var reader = new JsonLineReader(_testFilePath);
+        using var reader = new RowReader(_testFilePath);
 
         // Act
         var lines = reader.ReadLineBytes(byteOffset: 0, linesToSkip: 0, linesToRead: 3);
@@ -79,7 +79,7 @@ public sealed class JsonLineReaderTests : IDisposable
     {
         // Arrange
         WriteTestContent("{\"skip\":0}\n{\"read\":1}\n{\"read\":2}\n");
-        using var reader = new JsonLineReader(_testFilePath);
+        using var reader = new RowReader(_testFilePath);
 
         // Act
         var lines = reader.ReadLineBytes(byteOffset: 0, linesToSkip: 1, linesToRead: 2);
@@ -95,7 +95,7 @@ public sealed class JsonLineReaderTests : IDisposable
     {
         // Arrange
         WriteTestContent("{\"a\":1}\n{\"b\":2}\n{\"c\":3}\n");
-        using var reader = new JsonLineReader(_testFilePath);
+        using var reader = new RowReader(_testFilePath);
 
         // Act
         var lines = reader.ReadLineBytes(byteOffset: 0, linesToSkip: 0, linesToRead: 2);
@@ -113,7 +113,7 @@ public sealed class JsonLineReaderTests : IDisposable
         WriteTestContent("");
 
         // Act
-        var act = () => new JsonLineReader(_testFilePath);
+        var act = () => new RowReader(_testFilePath);
 
         // Assert
         act.Should().Throw<InvalidOperationException>();
@@ -124,7 +124,7 @@ public sealed class JsonLineReaderTests : IDisposable
     {
         // Arrange
         WriteTestContent("invalid json\n");
-        using var reader = new JsonLineReader(_testFilePath);
+        using var reader = new RowReader(_testFilePath);
 
         // Act
         var act = () => reader.ReadLineBytes(byteOffset: 0, linesToSkip: 0, linesToRead: 1);
@@ -138,7 +138,7 @@ public sealed class JsonLineReaderTests : IDisposable
     {
         // Arrange
         WriteTestContent("{\"test\":1}\n");
-        var reader = new JsonLineReader(_testFilePath);
+        var reader = new RowReader(_testFilePath);
         reader.Dispose();
 
         // Act
@@ -153,7 +153,7 @@ public sealed class JsonLineReaderTests : IDisposable
     {
         // Arrange
         WriteTestContent("{\"a\":1}\n");
-        using var reader = new JsonLineReader(_testFilePath);
+        using var reader = new RowReader(_testFilePath);
         long largeOffset = 1000; // beyond file size
 
         // Act
@@ -169,7 +169,7 @@ public sealed class JsonLineReaderTests : IDisposable
         // Arrange
         // Incomplete JSON line without newline at EOF
         WriteTestContent("{\"incomplete\":");
-        using var reader = new JsonLineReader(_testFilePath);
+        using var reader = new RowReader(_testFilePath);
 
         // Act
         var lines = reader.ReadLineBytes(byteOffset: 0, linesToSkip: 0, linesToRead: 1);

--- a/tests/DataMorph.Tests/IO/JsonLines/RowScannerTests.cs
+++ b/tests/DataMorph.Tests/IO/JsonLines/RowScannerTests.cs
@@ -3,7 +3,7 @@ using AwesomeAssertions;
 
 namespace DataMorph.Engine.IO.JsonLines.Tests;
 
-public sealed class JsonLinesScannerTests
+public sealed class RowScannerTests
 {
     [Fact]
     public void FindNextLineLength_EmptySpan_ReturnsFalseAndZero()
@@ -12,7 +12,7 @@ public sealed class JsonLinesScannerTests
         var span = ReadOnlySpan<byte>.Empty;
 
         // Act
-        var scanner = new JsonLinesScanner();
+        var scanner = new RowScanner();
         var (lineCompleted, bytesConsumed) = scanner.FindNextLineLength(span);
 
         // Assert
@@ -28,7 +28,7 @@ public sealed class JsonLinesScannerTests
         var span = new ReadOnlySpan<byte>(line);
 
         // Act
-        var scanner = new JsonLinesScanner();
+        var scanner = new RowScanner();
         var (lineCompleted, bytesConsumed) = scanner.FindNextLineLength(span);
 
         // Assert
@@ -44,7 +44,7 @@ public sealed class JsonLinesScannerTests
         var span = new ReadOnlySpan<byte>(input);
 
         // Act
-        var scanner = new JsonLinesScanner();
+        var scanner = new RowScanner();
         var (lineCompleted, bytesConsumed) = scanner.FindNextLineLength(span);
 
         // Assert
@@ -61,7 +61,7 @@ public sealed class JsonLinesScannerTests
         var span = new ReadOnlySpan<byte>(input);
 
         // Act
-        var scanner = new JsonLinesScanner();
+        var scanner = new RowScanner();
         var (lineCompleted, bytesConsumed) = scanner.FindNextLineLength(span);
 
         // Assert
@@ -79,7 +79,7 @@ public sealed class JsonLinesScannerTests
         var span = new ReadOnlySpan<byte>(input);
 
         // Act
-        var scanner = new JsonLinesScanner();
+        var scanner = new RowScanner();
         var (lineCompleted, bytesConsumed) = scanner.FindNextLineLength(span);
 
         // Assert
@@ -97,7 +97,7 @@ public sealed class JsonLinesScannerTests
         var span = new ReadOnlySpan<byte>(input);
 
         // Act
-        var scanner = new JsonLinesScanner();
+        var scanner = new RowScanner();
         var (lineCompleted, bytesConsumed) = scanner.FindNextLineLength(span);
 
         // Assert
@@ -114,7 +114,7 @@ public sealed class JsonLinesScannerTests
         var span = new ReadOnlySpan<byte>(input);
 
         // Act
-        var scanner = new JsonLinesScanner();
+        var scanner = new RowScanner();
         var (lineCompleted, bytesConsumed) = scanner.FindNextLineLength(span);
 
         // Assert
@@ -130,7 +130,7 @@ public sealed class JsonLinesScannerTests
         var span = new ReadOnlySpan<byte>(input);
 
         // Act
-        var scanner = new JsonLinesScanner();
+        var scanner = new RowScanner();
         var (lineCompleted, bytesConsumed) = scanner.FindNextLineLength(span);
 
         // Assert
@@ -147,7 +147,7 @@ public sealed class JsonLinesScannerTests
         var span = new ReadOnlySpan<byte>(input);
 
         // Act
-        var scanner = new JsonLinesScanner();
+        var scanner = new RowScanner();
         var (lineCompleted, bytesConsumed) = scanner.FindNextLineLength(span);
 
         // Assert
@@ -163,7 +163,7 @@ public sealed class JsonLinesScannerTests
         var span = new ReadOnlySpan<byte>(input);
 
         // Act
-        var scanner = new JsonLinesScanner();
+        var scanner = new RowScanner();
         var (lineCompleted, bytesConsumed) = scanner.FindNextLineLength(span);
 
         // Assert
@@ -187,7 +187,7 @@ public sealed class JsonLinesScannerTests
         var span = new ReadOnlySpan<byte>(input);
 
         // Act
-        var scanner = new JsonLinesScanner();
+        var scanner = new RowScanner();
         var (lineCompleted, bytesConsumed) = scanner.FindNextLineLength(span);
 
         // Assert
@@ -200,7 +200,7 @@ public sealed class JsonLinesScannerTests
     {
         // Arrange: First buffer with opening quote only
         var buffer1 = Encoding.UTF8.GetBytes("\"long value");
-        var scanner = new JsonLinesScanner();
+        var scanner = new RowScanner();
 
         // Act (First buffer)
         var (lineCompleted1, bytesConsumed1) = scanner.FindNextLineLength(buffer1);
@@ -225,7 +225,7 @@ public sealed class JsonLinesScannerTests
     {
         // Arrange: First buffer with partial escape sequence
         var buffer1 = Encoding.UTF8.GetBytes("{\"path\":\"C:\\\\");
-        var scanner = new JsonLinesScanner();
+        var scanner = new RowScanner();
 
         // Act (First buffer)
         var (lineCompleted1, bytesConsumed1) = scanner.FindNextLineLength(buffer1);
@@ -260,7 +260,7 @@ public sealed class JsonLinesScannerTests
         var span = new ReadOnlySpan<byte>(input);
 
         // Act
-        var scanner = new JsonLinesScanner();
+        var scanner = new RowScanner();
         var (lineCompleted, bytesConsumed) = scanner.FindNextLineLength(span);
 
         // Assert
@@ -276,7 +276,7 @@ public sealed class JsonLinesScannerTests
         var span = new ReadOnlySpan<byte>(input);
 
         // Act
-        var scanner = new JsonLinesScanner();
+        var scanner = new RowScanner();
         var (lineCompleted, bytesConsumed) = scanner.FindNextLineLength(span);
 
         // Assert
@@ -292,7 +292,7 @@ public sealed class JsonLinesScannerTests
         var span = new ReadOnlySpan<byte>(input);
 
         // Act
-        var scanner = new JsonLinesScanner();
+        var scanner = new RowScanner();
         var (lineCompleted, bytesConsumed) = scanner.FindNextLineLength(span);
 
         // Assert
@@ -308,7 +308,7 @@ public sealed class JsonLinesScannerTests
         var span = new ReadOnlySpan<byte>(input);
 
         // Act
-        var scanner = new JsonLinesScanner();
+        var scanner = new RowScanner();
         var (lineCompleted, bytesConsumed) = scanner.FindNextLineLength(span);
 
         // Assert
@@ -323,7 +323,7 @@ public sealed class JsonLinesScannerTests
         var buffer1 = Encoding.UTF8.GetBytes("{\"text\":\"partial");
         var buffer2 = Encoding.UTF8.GetBytes(" value\"}\n");
 
-        var scanner = new JsonLinesScanner();
+        var scanner = new RowScanner();
 
         // Act (first buffer)
         var (lineCompleted1, bytesConsumed1) = scanner.FindNextLineLength(buffer1);
@@ -348,7 +348,7 @@ public sealed class JsonLinesScannerTests
         var longValue = new string('a', bufferSize * 3); // 3x buffer size
         var buffer1 = Encoding.UTF8.GetBytes($"{{\"id\":1,\"data\":\"{longValue}");
         var buffer2 = Encoding.UTF8.GetBytes($"\"}}\n");
-        var scanner = new JsonLinesScanner();
+        var scanner = new RowScanner();
 
         // Act: Process first buffer (partial data)
         var (lineCompleted1, consumed1) = scanner.FindNextLineLength(buffer1);
@@ -374,7 +374,7 @@ public sealed class JsonLinesScannerTests
         // Arrange: Create JSON with escape sequence spanning buffers
         var buffer1 = Encoding.UTF8.GetBytes("{\"data\":\"value\\");
         var buffer2 = Encoding.UTF8.GetBytes("n\"}\n");
-        var scanner = new JsonLinesScanner();
+        var scanner = new RowScanner();
 
         // Act: Process first buffer (ends with escape character)
         var (lineCompleted1, consumed1) = scanner.FindNextLineLength(buffer1);
@@ -397,7 +397,7 @@ public sealed class JsonLinesScannerTests
         // Arrange
         var input = Encoding.UTF8.GetBytes("{}\n");
         var span = new ReadOnlySpan<byte>(input);
-        var scanner = new JsonLinesScanner();
+        var scanner = new RowScanner();
 
         // Act
         var (lineCompleted, bytesConsumed) = scanner.FindNextLineLength(span);
@@ -413,7 +413,7 @@ public sealed class JsonLinesScannerTests
         // Arrange
         var input = Encoding.UTF8.GetBytes("{\"name\":\"John\"}\r\n");
         var span = new ReadOnlySpan<byte>(input);
-        var scanner = new JsonLinesScanner();
+        var scanner = new RowScanner();
 
         // Act
         var (lineCompleted, bytesConsumed) = scanner.FindNextLineLength(span);
@@ -429,7 +429,7 @@ public sealed class JsonLinesScannerTests
         // Arrange
         var buffer1 = Encoding.UTF8.GetBytes("{\"text\":\"value\\");
         var buffer2 = Encoding.UTF8.GetBytes("\"more text\"}\n");
-        var scanner = new JsonLinesScanner();
+        var scanner = new RowScanner();
 
         // Act (First buffer)
         var (lineCompleted1, consumed1) = scanner.FindNextLineLength(buffer1);
@@ -458,7 +458,7 @@ public sealed class JsonLinesScannerTests
         // Arrange
         var input = Encoding.UTF8.GetBytes(inputString);
         var span = new ReadOnlySpan<byte>(input);
-        var scanner = new JsonLinesScanner();
+        var scanner = new RowScanner();
 
         // Act
         var (lineCompleted, bytesConsumed) = scanner.FindNextLineLength(span);
@@ -474,7 +474,7 @@ public sealed class JsonLinesScannerTests
         // Arrange
         var input = Encoding.UTF8.GetBytes("{\"path\":\"C:\\\\\\\\\\\\\"}\n");
         var span = new ReadOnlySpan<byte>(input);
-        var scanner = new JsonLinesScanner();
+        var scanner = new RowScanner();
 
         // Act
         var (lineCompleted, bytesConsumed) = scanner.FindNextLineLength(span);
@@ -490,7 +490,7 @@ public sealed class JsonLinesScannerTests
         // Arrange
         var buffer1 = Encoding.UTF8.GetBytes("{\"text\":\"partial");
         var buffer2 = Encoding.UTF8.GetBytes("\"}\n");
-        var scanner = new JsonLinesScanner();
+        var scanner = new RowScanner();
 
         // Act (First buffer)
         var (lineCompleted1, consumed1) = scanner.FindNextLineLength(buffer1);
@@ -513,7 +513,7 @@ public sealed class JsonLinesScannerTests
         // Arrange
         var input = Encoding.UTF8.GetBytes("{\"text\":\"\\\"\\\\\\/\\b\\f\\n\\r\\t\\u0020\"}\n");
         var span = new ReadOnlySpan<byte>(input);
-        var scanner = new JsonLinesScanner();
+        var scanner = new RowScanner();
 
         // Act
         var (lineCompleted, bytesConsumed) = scanner.FindNextLineLength(span);
@@ -537,7 +537,7 @@ public sealed class JsonLinesScannerTests
         // Arrange
         var input = Encoding.UTF8.GetBytes(inputString);
         var span = new ReadOnlySpan<byte>(input);
-        var scanner = new JsonLinesScanner();
+        var scanner = new RowScanner();
 
         // Act
         var (lineCompleted, bytesConsumed) = scanner.FindNextLineLength(span);


### PR DESCRIPTION
## Summary

- Renamed `JsonLineByteCache` → `RowByteCache`, `JsonLineReader` → `RowReader`, `JsonLinesScanner` → `RowScanner` in `src/Engine/IO/JsonLines/`
- Updated all references in `RowIndexer.cs` and `JsonLinesTreeView.cs`
- Renamed corresponding test and benchmark files accordingly
- Aligns with the `DataRow` prefix convention used in the `Csv` directory, and is consistent with the existing `RowIndexer` naming