### PR TITLE
feat: implement RecipeManager with YAML serialization support

### DIFF
--- a/.claude/rules/csharp-standards.md
+++ b/.claude/rules/csharp-standards.md
@@ -34,6 +34,18 @@ paths:
 - Prefer **immutable by default**: data should flow through transformations rather than being mutated in place
 - Mutable fields and mutable properties require justification; flag any that can be made immutable without meaningful cost
 
+## Pure Functions
+- Prefer **pure functions**: a method should compute and return its result rather than mutate state through `ref` or `out` parameters
+- Return a tuple or a dedicated result type instead of using `ref`/`out` to propagate computed values back to the caller
+
+### `out` parameters
+- Use `out` **only** when implementing a `TryParse`-style method — i.e., when the method returns `bool` to signal success and needs to hand back a parsed value on success
+- Do NOT use `out` for any other purpose; returning a `Result<T>` or tuple is always preferable
+
+### `ref` parameters
+- Use `ref` **only** as a performance optimization: when a large value-type (`struct`) would otherwise be copied repeatedly on every call, passing it by `ref` avoids that overhead
+- Do NOT use `ref` to return computed values or to simulate multiple return values — use tuples or result types instead
+
 ## Structure & Complexity (STRICT)
 
 ### Class Size
@@ -67,6 +79,7 @@ paths:
 ## Naming
 - Follow standard .NET Naming Guidelines
 - **Consistency with existing code**: if existing types follow a naming convention (e.g., a specific suffix or prefix), new types must follow the same pattern — flag any new class, interface, or member whose name breaks the established convention in its namespace or layer
+- **ValueTuple element names**: use **camelCase** (e.g., `(string key, string value)`, `(int count, bool found)`). Tuple elements are destructured into local variables, so camelCase aligns with the local variable naming convention
 
 ## Project and Directory Placement
 - Every class must reside in the project that matches its abstraction layer (`Engine` for core logic, `App` for TUI/presentation, `Tests` for test code)

--- a/docs/design_recipe_manager.md
+++ b/docs/design_recipe_manager.md
@@ -48,7 +48,7 @@ actions:
 
 | Element | Rule |
 |---------|------|
-| Top-level fields | `name`, `description` (omit if null), `lastModified` (omit if null), `actions` |
+| Top-level fields | `name` (required, non-empty), `description` (omit if null), `lastModified` (omit if null), `actions` |
 | Field order | Always: `name` → `description` → `lastModified` → `actions` |
 | String values | Always wrapped in `"..."`. Internal `"` is escaped as `\"`. |
 | Enum values | Written as the C# enum name, **unquoted** (e.g., `WholeNumber`, `Equals`). |

--- a/src/App/MainWindow.cs
+++ b/src/App/MainWindow.cs
@@ -1,4 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
+using DataMorph.Engine.Models;
+using DataMorph.Engine.Recipes;
 using Terminal.Gui.App;
 using Terminal.Gui.Drivers;
 using Terminal.Gui.ViewBase;
@@ -17,6 +19,7 @@ internal sealed class MainWindow : Window
     private readonly AppState _state;
     private readonly FileLoader _fileLoader;
     private readonly ViewManager _viewManager;
+    private readonly RecipeManager _recipeManager = new();
 
     public MainWindow(IApplication app, AppState state)
     {
@@ -44,8 +47,10 @@ internal sealed class MainWindow : Window
     private void InitializeMenu()
     {
         var openMenuItem = new MenuItem("_Open", "", async () => await ShowFileDialogAsync());
+        var saveRecipeMenuItem = new MenuItem("_Save Recipe", "", async () => await HandleSaveRecipeAsync());
+        var loadRecipeMenuItem = new MenuItem("_Load Recipe", "", async () => await HandleLoadRecipeAsync());
         var exitMenuItem = new MenuItem("_Exit", "", () => _app.RequestStop());
-        var fileMenuBarItem = new MenuBarItem("_File", [openMenuItem, exitMenuItem]);
+        var fileMenuBarItem = new MenuBarItem("_File", [openMenuItem, saveRecipeMenuItem, loadRecipeMenuItem, exitMenuItem]);
         var menuBar = new MenuBar { Menus = [fileMenuBarItem] };
 
         Add(menuBar);
@@ -64,13 +69,19 @@ internal sealed class MainWindow : Window
             Title = "Open",
             Action = async () => await ShowFileDialogAsync(),
         };
+        var saveRecipeShortcut = new Shortcut
+        {
+            Key = KeyCode.S | KeyCode.CtrlMask,
+            Title = "Save Recipe",
+            Action = async () => await HandleSaveRecipeAsync(),
+        };
         var quitShortcut = new Shortcut
         {
             Key = KeyCode.X | KeyCode.CtrlMask,
             Title = "Quit",
             Action = () => _app.RequestStop(),
         };
-        var statusBar = new StatusBar([openShortcut, quitShortcut]);
+        var statusBar = new StatusBar([openShortcut, saveRecipeShortcut, quitShortcut]);
 
         Add(statusBar);
     }
@@ -127,6 +138,82 @@ internal sealed class MainWindow : Window
         {
             _viewManager.SwitchToJsonLinesTree(_state.JsonLinesIndexer);
         }
+    }
+
+    [SuppressMessage(
+        "Reliability",
+        "CA2000:Dispose objects before losing scope",
+        Justification = "The OpenDialog is managed by Terminal.Gui's IApplication.Run() and will be disposed automatically."
+    )]
+    private async Task HandleSaveRecipeAsync()
+    {
+        if (_state.CurrentMode is not (ViewMode.CsvTable or ViewMode.JsonLinesTable or ViewMode.JsonLinesTree))
+        {
+            return;
+        }
+
+        if (string.IsNullOrEmpty(_state.CurrentFilePath))
+        {
+            return;
+        }
+
+        var dialog = new OpenDialog { Title = "Save Recipe" };
+        dialog.AllowedTypes.Add(new AllowedType("YAML file", ".yaml"));
+
+        _app.Run(dialog);
+
+        if (dialog.Canceled || string.IsNullOrEmpty(dialog.Path))
+        {
+            return;
+        }
+
+        var recipe = new Recipe
+        {
+            Name = Path.GetFileNameWithoutExtension(_state.CurrentFilePath),
+            Actions = _state.ActionStack,
+            LastModified = DateTimeOffset.UtcNow,
+        };
+
+        var result = await _recipeManager.SaveAsync(recipe, dialog.Path);
+
+        if (result.IsFailure)
+        {
+            _viewManager.ShowError(result.Error);
+        }
+    }
+
+    [SuppressMessage(
+        "Reliability",
+        "CA2000:Dispose objects before losing scope",
+        Justification = "The OpenDialog is managed by Terminal.Gui's IApplication.Run() and will be disposed automatically."
+    )]
+    private async Task HandleLoadRecipeAsync()
+    {
+        if (string.IsNullOrEmpty(_state.CurrentFilePath))
+        {
+            return;
+        }
+
+        var dialog = new OpenDialog { Title = "Load Recipe" };
+        dialog.AllowedTypes.Add(new AllowedType("YAML file", ".yaml"));
+
+        _app.Run(dialog);
+
+        if (dialog.Canceled || string.IsNullOrEmpty(dialog.Path))
+        {
+            return;
+        }
+
+        var result = await _recipeManager.LoadAsync(dialog.Path);
+
+        if (result.IsFailure)
+        {
+            _viewManager.ShowError(result.Error);
+            return;
+        }
+
+        _state.ActionStack = result.Value.Actions;
+        _viewManager.RefreshCurrentTableView();
     }
 
     private async Task HandleToggleAsync()

--- a/src/Engine/Recipes/IRecipeManager.cs
+++ b/src/Engine/Recipes/IRecipeManager.cs
@@ -1,0 +1,20 @@
+using DataMorph.Engine.Models;
+
+namespace DataMorph.Engine.Recipes;
+
+/// <summary>
+/// Defines the contract for loading and saving recipes to disk.
+/// </summary>
+public interface IRecipeManager
+{
+    /// <summary>
+    /// Loads a recipe from a YAML file.
+    /// </summary>
+    ValueTask<Result<Recipe>> LoadAsync(string filePath, CancellationToken ct = default);
+
+    /// <summary>
+    /// Saves a recipe to a YAML file.
+    /// Overwrites the file if it already exists.
+    /// </summary>
+    ValueTask<Result> SaveAsync(Recipe recipe, string filePath, CancellationToken ct = default);
+}

--- a/src/Engine/Recipes/MorphActionParser.cs
+++ b/src/Engine/Recipes/MorphActionParser.cs
@@ -1,0 +1,112 @@
+using DataMorph.Engine.Models.Actions;
+using DataMorph.Engine.Types;
+
+namespace DataMorph.Engine.Recipes;
+
+/// <summary>
+/// Constructs <see cref="MorphAction"/> instances from parsed field dictionaries.
+/// Field values are expected to be already unquoted.
+/// </summary>
+internal sealed class MorphActionParser
+{
+    /// <summary>
+    /// Parses a field dictionary into a <see cref="MorphAction"/>.
+    /// Returns a failure result if required fields are missing or invalid.
+    /// </summary>
+    internal static Result<MorphAction> ParseAction(Dictionary<string, string> fields)
+    {
+        return fields.TryGetValue("type", out var type)
+            ? type switch
+            {
+                "rename" => ParseRenameAction(fields),
+                "delete" => ParseDeleteAction(fields),
+                "cast" => ParseCastAction(fields),
+                "filter" => ParseFilterAction(fields),
+                _ => Results.Failure<MorphAction>($"Unknown action type: '{type}'"),
+            }
+            : Results.Failure<MorphAction>("Missing action type");
+    }
+
+    private static Result<MorphAction> ParseRenameAction(Dictionary<string, string> fields)
+    {
+        if (!fields.TryGetValue("oldName", out var oldName))
+        {
+            return Results.Failure<MorphAction>("Missing required field 'oldName' for rename action");
+        }
+
+        if (!fields.TryGetValue("newName", out var newName))
+        {
+            return Results.Failure<MorphAction>("Missing required field 'newName' for rename action");
+        }
+
+        return Results.Success<MorphAction>(new RenameColumnAction
+        {
+            OldName = oldName,
+            NewName = newName,
+        });
+    }
+
+    private static Result<MorphAction> ParseDeleteAction(Dictionary<string, string> fields)
+    {
+        if (!fields.TryGetValue("columnName", out var columnName))
+        {
+            return Results.Failure<MorphAction>("Missing required field 'columnName' for delete action");
+        }
+
+        return Results.Success<MorphAction>(new DeleteColumnAction { ColumnName = columnName });
+    }
+
+    private static Result<MorphAction> ParseCastAction(Dictionary<string, string> fields)
+    {
+        if (!fields.TryGetValue("columnName", out var columnName))
+        {
+            return Results.Failure<MorphAction>("Missing required field 'columnName' for cast action");
+        }
+
+        if (!fields.TryGetValue("targetType", out var targetTypeStr))
+        {
+            return Results.Failure<MorphAction>("Missing required field 'targetType' for cast action");
+        }
+
+        if (!Enum.TryParse<ColumnType>(targetTypeStr, ignoreCase: false, out var targetType))
+        {
+            return Results.Failure<MorphAction>($"Invalid enum value for targetType: '{targetTypeStr}'");
+        }
+
+        return Results.Success<MorphAction>(new CastColumnAction
+        {
+            ColumnName = columnName,
+            TargetType = targetType,
+        });
+    }
+
+    private static Result<MorphAction> ParseFilterAction(Dictionary<string, string> fields)
+    {
+        if (!fields.TryGetValue("columnName", out var columnName))
+        {
+            return Results.Failure<MorphAction>("Missing required field 'columnName' for filter action");
+        }
+
+        if (!fields.TryGetValue("operator", out var operatorStr))
+        {
+            return Results.Failure<MorphAction>("Missing required field 'operator' for filter action");
+        }
+
+        if (!fields.TryGetValue("value", out var filterValue))
+        {
+            return Results.Failure<MorphAction>("Missing required field 'value' for filter action");
+        }
+
+        if (!Enum.TryParse<FilterOperator>(operatorStr, ignoreCase: false, out var filterOperator))
+        {
+            return Results.Failure<MorphAction>($"Invalid enum value for operator: '{operatorStr}'");
+        }
+
+        return Results.Success<MorphAction>(new FilterAction
+        {
+            ColumnName = columnName,
+            Operator = filterOperator,
+            Value = filterValue,
+        });
+    }
+}

--- a/src/Engine/Recipes/ParseState.cs
+++ b/src/Engine/Recipes/ParseState.cs
@@ -1,0 +1,22 @@
+namespace DataMorph.Engine.Recipes;
+
+/// <summary>
+/// Represents the state of the YAML parser during deserialization.
+/// </summary>
+internal enum ParseState
+{
+    /// <summary>
+    /// Parsing top-level key: value pairs.
+    /// </summary>
+    Root,
+
+    /// <summary>
+    /// Encountered actions: or actions: []; ready for list items.
+    /// </summary>
+    Actions,
+
+    /// <summary>
+    /// Accumulating key: value pairs for the current action item.
+    /// </summary>
+    ActionItem
+}

--- a/src/Engine/Recipes/RecipeManager.cs
+++ b/src/Engine/Recipes/RecipeManager.cs
@@ -1,0 +1,63 @@
+using System.Text;
+using DataMorph.Engine.Models;
+
+namespace DataMorph.Engine.Recipes;
+
+/// <summary>
+/// Persists and restores <see cref="Recipe"/> objects as human-readable YAML files.
+/// </summary>
+public sealed class RecipeManager : IRecipeManager
+{
+    /// <inheritdoc/>
+    public async ValueTask<Result<Recipe>> LoadAsync(string filePath, CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(filePath);
+
+        if (!File.Exists(filePath))
+        {
+            return Results.Failure<Recipe>($"File not found: {filePath}");
+        }
+
+        try
+        {
+            var yaml = await File.ReadAllTextAsync(filePath, Encoding.UTF8, ct).ConfigureAwait(false);
+            return RecipeYamlParser.Parse(yaml);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (IOException ex)
+        {
+            return Results.Failure<Recipe>(ex.Message);
+        }
+    }
+
+    /// <inheritdoc/>
+    public async ValueTask<Result> SaveAsync(Recipe recipe, string filePath, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(recipe);
+        ArgumentException.ThrowIfNullOrWhiteSpace(filePath);
+
+        var yaml = RecipeYamlSerializer.Serialize(recipe);
+
+        try
+        {
+            await File.WriteAllTextAsync(
+                filePath,
+                yaml,
+                new UTF8Encoding(encoderShouldEmitUTF8Identifier: false),
+                ct
+            ).ConfigureAwait(false);
+            return Results.Success();
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (IOException ex)
+        {
+            return Results.Failure(ex.Message);
+        }
+    }
+}

--- a/src/Engine/Recipes/RecipeYamlParser.cs
+++ b/src/Engine/Recipes/RecipeYamlParser.cs
@@ -1,0 +1,227 @@
+using System.Globalization;
+using System.Text;
+using DataMorph.Engine.Models;
+using DataMorph.Engine.Models.Actions;
+
+namespace DataMorph.Engine.Recipes;
+
+/// <summary>
+/// Parses YAML text into <see cref="Recipe"/> objects.
+/// AOT-safe: no reflection is used.
+/// </summary>
+internal sealed class RecipeYamlParser
+{
+    private sealed record RootParseState(string Name, string? Description, DateTimeOffset? LastModified, ParseState ParseState);
+
+    /// <summary>
+    /// Parses a YAML string into a recipe.
+    /// Returns a failure result for any parse or validation error.
+    /// </summary>
+    public static Result<Recipe> Parse(string yaml)
+    {
+        var rootState = new RootParseState(string.Empty, null, null, ParseState.Root);
+        List<MorphAction> actions = [];
+        Dictionary<string, string> currentAction = [];
+
+        foreach (var rawLine in yaml.Split('\n'))
+        {
+            var line = rawLine.TrimEnd('\r');
+            if (IsSkippable(line))
+            {
+                continue;
+            }
+
+            if (rootState.ParseState == ParseState.Root)
+            {
+                var result = ProcessRootLine(line, rootState);
+                if (result.IsFailure)
+                {
+                    return Results.Failure<Recipe>(result.Error);
+                }
+
+                rootState = result.Value;
+                continue;
+            }
+
+            if (line.StartsWith("  - type: ", StringComparison.Ordinal))
+            {
+                var startResult = StartNewAction(line, currentAction);
+                if (startResult.IsFailure)
+                {
+                    return Results.Failure<Recipe>(startResult.Error);
+                }
+
+                var (newCurrentAction, completedAction) = startResult.Value;
+                currentAction = newCurrentAction;
+                rootState = rootState with { ParseState = ParseState.ActionItem };
+                if (completedAction is not null)
+                {
+                    actions.Add(completedAction);
+                }
+
+                continue;
+            }
+
+            if (rootState.ParseState != ParseState.ActionItem || !line.StartsWith("    ", StringComparison.Ordinal))
+            {
+                return Results.Failure<Recipe>($"Unexpected line in actions context: '{line}'");
+            }
+
+            var fieldResult = ParseActionField(line);
+            if (fieldResult.IsFailure)
+            {
+                return Results.Failure<Recipe>(fieldResult.Error);
+            }
+
+            var (fieldKey, fieldValue) = fieldResult.Value;
+            currentAction[fieldKey] = fieldValue;
+        }
+
+        if (currentAction.ContainsKey("type"))
+        {
+            var buildResult = MorphActionParser.ParseAction(currentAction);
+            if (buildResult.IsFailure)
+            {
+                return Results.Failure<Recipe>(buildResult.Error);
+            }
+
+            actions.Add(buildResult.Value);
+        }
+
+        return string.IsNullOrEmpty(rootState.Name)
+            ? Results.Failure<Recipe>("Missing required field: 'name'")
+            : Results.Success(new Recipe
+            {
+                Name = rootState.Name,
+                Description = rootState.Description,
+                LastModified = rootState.LastModified,
+                Actions = actions.AsReadOnly(),
+            });
+    }
+
+    private static bool IsSkippable(string line)
+        => string.IsNullOrWhiteSpace(line) || line.AsSpan().TrimStart().StartsWith("#", StringComparison.Ordinal);
+
+    private static Result<RootParseState> ProcessRootLine(string line, RootParseState state)
+    {
+        if (line == "actions: []")
+        {
+            return Results.Success(state);
+        }
+
+        if (line == "actions:")
+        {
+            return Results.Success(state with { ParseState = ParseState.Actions });
+        }
+
+        var colonIdx = line.IndexOf(": ", StringComparison.Ordinal);
+        if (colonIdx < 0)
+        {
+            return Results.Failure<RootParseState>($"Malformed root-level line: '{line}'");
+        }
+
+        var key = line[..colonIdx];
+        var value = line[(colonIdx + 2)..];
+
+        return key switch
+        {
+            "name" => !string.IsNullOrEmpty(state.Name)
+                ? Results.Failure<RootParseState>("Duplicate root-level key: 'name'")
+                : Results.Success(state with { Name = UnquoteString(value) }),
+            "description" => state.Description is not null
+                ? Results.Failure<RootParseState>("Duplicate root-level key: 'description'")
+                : Results.Success(state with { Description = UnquoteString(value) }),
+            "lastModified" => state.LastModified is not null
+                ? Results.Failure<RootParseState>("Duplicate root-level key: 'lastModified'")
+                : ParseLastModifiedField(value, state),
+            _ => Results.Failure<RootParseState>($"Unknown root-level key: '{key}'"),
+        };
+    }
+
+    private static Result<RootParseState> ParseLastModifiedField(string value, RootParseState state)
+    {
+        var parseResult = TryParseLastModified(value);
+        if (parseResult.IsFailure)
+        {
+            return Results.Failure<RootParseState>(parseResult.Error);
+        }
+
+        return Results.Success(state with { LastModified = parseResult.Value });
+    }
+
+    private static Result<DateTimeOffset> TryParseLastModified(string value)
+    {
+        if (!DateTimeOffset.TryParse(UnquoteString(value), null, DateTimeStyles.RoundtripKind, out var dt))
+        {
+            return Results.Failure<DateTimeOffset>($"Invalid lastModified value: '{value}'");
+        }
+
+        return Results.Success(dt);
+    }
+
+    private static Result<(Dictionary<string, string> newAction, MorphAction? completedAction)> StartNewAction(
+        string line,
+        Dictionary<string, string> currentAction)
+    {
+        MorphAction? completedAction = null;
+        if (currentAction.ContainsKey("type"))
+        {
+            var parseResult = MorphActionParser.ParseAction(currentAction);
+            if (parseResult.IsFailure)
+            {
+                return Results.Failure<(Dictionary<string, string> newAction, MorphAction? completedAction)>(parseResult.Error);
+            }
+
+            completedAction = parseResult.Value;
+        }
+
+        var newAction = new Dictionary<string, string> { ["type"] = line["  - type: ".Length..] };
+        return Results.Success<(Dictionary<string, string> newAction, MorphAction? completedAction)>((newAction, completedAction));
+    }
+
+    private static Result<(string key, string value)> ParseActionField(string line)
+    {
+        var fieldContent = line[4..];
+        var colonIdx = fieldContent.IndexOf(": ", StringComparison.Ordinal);
+        if (colonIdx < 0)
+        {
+            return Results.Failure<(string key, string value)>($"Malformed action field: '{line}'");
+        }
+
+        return Results.Success((fieldContent[..colonIdx], UnquoteString(fieldContent[(colonIdx + 2)..])));
+    }
+
+    private static string UnquoteString(string value)
+    {
+        if (value.Length >= 2 && value[0] == '"' && value[^1] == '"')
+        {
+            var inner = value.AsSpan(1, value.Length - 2);
+            if (inner.IndexOf('\\') < 0)
+            {
+                return inner.ToString();
+            }
+
+            var sb = new StringBuilder(inner.Length);
+            for (var i = 0; i < inner.Length; i++)
+            {
+                if (inner[i] == '\\' && i + 1 < inner.Length)
+                {
+                    sb.Append(inner[i + 1] switch
+                    {
+                        '"' => '"',
+                        '\\' => '\\',
+                        var c => c,
+                    });
+                    i++;
+                    continue;
+                }
+
+                sb.Append(inner[i]);
+            }
+
+            return sb.ToString();
+        }
+
+        return value;
+    }
+}

--- a/src/Engine/Recipes/RecipeYamlSerializer.cs
+++ b/src/Engine/Recipes/RecipeYamlSerializer.cs
@@ -1,0 +1,84 @@
+using System.Diagnostics;
+using System.Globalization;
+using System.Text;
+using DataMorph.Engine.Models;
+using DataMorph.Engine.Models.Actions;
+
+namespace DataMorph.Engine.Recipes;
+
+/// <summary>
+/// Serializes and deserializes <see cref="Recipe"/> objects to and from YAML.
+/// AOT-safe: no reflection is used.
+/// </summary>
+internal sealed class RecipeYamlSerializer
+{
+    /// <summary>
+    /// Serializes a recipe to a YAML string.
+    /// </summary>
+    public static string Serialize(Recipe recipe)
+    {
+        var sb = new StringBuilder();
+        sb.Append("name: ").AppendLine(QuoteString(recipe.Name));
+
+        if (recipe.Description is not null)
+        {
+            sb.Append("description: ").AppendLine(QuoteString(recipe.Description));
+        }
+
+        if (recipe.LastModified is not null)
+        {
+            sb.Append("lastModified: ").AppendLine(QuoteString(recipe.LastModified.Value.ToString("O")));
+        }
+
+        if (recipe.Actions.Count == 0)
+        {
+            sb.AppendLine("actions: []");
+            return sb.ToString();
+        }
+
+        sb.AppendLine("actions:");
+        foreach (var action in recipe.Actions)
+        {
+            AppendAction(sb, action);
+        }
+
+        return sb.ToString();
+    }
+
+    private static void AppendAction(StringBuilder sb, MorphAction action)
+    {
+        switch (action)
+        {
+            case RenameColumnAction rename:
+                sb.AppendLine("  - type: rename");
+                sb.Append("    oldName: ").AppendLine(QuoteString(rename.OldName));
+                sb.Append("    newName: ").AppendLine(QuoteString(rename.NewName));
+                break;
+            case DeleteColumnAction delete:
+                sb.AppendLine("  - type: delete");
+                sb.Append("    columnName: ").AppendLine(QuoteString(delete.ColumnName));
+                break;
+            case CastColumnAction cast:
+                sb.AppendLine("  - type: cast");
+                sb.Append("    columnName: ").AppendLine(QuoteString(cast.ColumnName));
+                sb.AppendLine(CultureInfo.InvariantCulture, $"    targetType: {cast.TargetType}");
+                break;
+            case FilterAction filter:
+                sb.AppendLine("  - type: filter");
+                sb.Append("    columnName: ").AppendLine(QuoteString(filter.ColumnName));
+                sb.AppendLine(CultureInfo.InvariantCulture, $"    operator: {filter.Operator}");
+                sb.Append("    value: ").AppendLine(QuoteString(filter.Value));
+                break;
+            default:
+                throw new UnreachableException($"Unhandled MorphAction subtype in serializer");
+        }
+    }
+
+    private static string QuoteString(string value)
+    {
+        var escaped = value
+            .Replace("\\", "\\\\", StringComparison.Ordinal)
+            .Replace("\"", "\\\"", StringComparison.Ordinal);
+        return $"\"{escaped}\"";
+    }
+}

--- a/tests/DataMorph.Tests/Engine/Recipes/RecipeManagerTests.cs
+++ b/tests/DataMorph.Tests/Engine/Recipes/RecipeManagerTests.cs
@@ -1,0 +1,269 @@
+using AwesomeAssertions;
+using DataMorph.Engine.Models;
+using DataMorph.Engine.Models.Actions;
+using DataMorph.Engine.Recipes;
+
+namespace DataMorph.Tests.Engine.Recipes;
+
+public sealed class RecipeManagerTests : IDisposable
+{
+    private readonly string _testDir = Path.Combine(Path.GetTempPath(), $"recipe_tests_{Guid.NewGuid()}");
+
+    public RecipeManagerTests()
+    {
+        Directory.CreateDirectory(_testDir);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_testDir))
+        {
+            Directory.Delete(_testDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task SaveAsync_ThenLoadAsync_RoundTrip_ReturnsEquivalentRecipe()
+    {
+        // Arrange
+        var manager = new RecipeManager();
+        var filePath = Path.Combine(_testDir, "recipe.yaml");
+        var recipe = new Recipe
+        {
+            Name = "test",
+            Description = "Test recipe",
+            LastModified = new DateTimeOffset(2025, 6, 15, 10, 0, 0, TimeSpan.Zero),
+            Actions = [new RenameColumnAction { OldName = "old", NewName = "new" }],
+        };
+
+        // Act
+        var saveResult = await manager.SaveAsync(recipe, filePath);
+        var loadResult = await manager.LoadAsync(filePath);
+
+        // Assert
+        saveResult.IsSuccess.Should().BeTrue();
+        loadResult.IsSuccess.Should().BeTrue();
+        loadResult.Value.Name.Should().Be("test");
+        loadResult.Value.Description.Should().Be("Test recipe");
+        loadResult.Value.LastModified.Should().Be(new DateTimeOffset(2025, 6, 15, 10, 0, 0, TimeSpan.Zero));
+        loadResult.Value.Actions.Should().HaveCount(1);
+        var action = loadResult.Value.Actions[0].Should().BeOfType<RenameColumnAction>().Subject;
+        action.OldName.Should().Be("old");
+        action.NewName.Should().Be("new");
+    }
+
+    [Fact]
+    public async Task SaveAsync_CreatesFileAtSpecifiedPath()
+    {
+        // Arrange
+        var manager = new RecipeManager();
+        var filePath = Path.Combine(_testDir, "recipe.yaml");
+        var recipe = new Recipe { Name = "test", Actions = [] };
+
+        // Act
+        var result = await manager.SaveAsync(recipe, filePath);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        File.Exists(filePath).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task SaveAsync_OverwritesExistingFile()
+    {
+        // Arrange
+        var manager = new RecipeManager();
+        var filePath = Path.Combine(_testDir, "recipe.yaml");
+        await File.WriteAllTextAsync(filePath, "existing content");
+        var recipe = new Recipe { Name = "overwritten", Actions = [] };
+
+        // Act
+        var saveResult = await manager.SaveAsync(recipe, filePath);
+        var loadResult = await manager.LoadAsync(filePath);
+
+        // Assert
+        saveResult.IsSuccess.Should().BeTrue();
+        loadResult.IsSuccess.Should().BeTrue();
+        loadResult.Value.Name.Should().Be("overwritten");
+    }
+
+    [Fact]
+    public async Task SaveAsync_WritesUtf8WithoutBom()
+    {
+        // Arrange
+        var manager = new RecipeManager();
+        var filePath = Path.Combine(_testDir, "recipe.yaml");
+        var recipe = new Recipe { Name = "test", Actions = [] };
+
+        // Act
+        await manager.SaveAsync(recipe, filePath);
+        var bytes = await File.ReadAllBytesAsync(filePath);
+
+        // Assert
+        // UTF-8 BOM starts with 0xEF 0xBB 0xBF; absence of 0xEF confirms no BOM is written
+        bytes[0].Should().NotBe((byte)0xEF);
+    }
+
+    [Fact]
+    public async Task LoadAsync_NonExistentFile_ReturnsFailure()
+    {
+        // Arrange
+        var manager = new RecipeManager();
+        var filePath = Path.Combine(_testDir, "nonexistent.yaml");
+
+        // Act
+        var result = await manager.LoadAsync(filePath);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Contain(filePath);
+    }
+
+    [Fact]
+    public async Task LoadAsync_EmptyFile_ReturnsFailure()
+    {
+        // Arrange
+        var manager = new RecipeManager();
+        var filePath = Path.Combine(_testDir, "empty.yaml");
+        await File.WriteAllTextAsync(filePath, string.Empty);
+
+        // Act
+        var result = await manager.LoadAsync(filePath);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task LoadAsync_InvalidYaml_ReturnsFailure()
+    {
+        // Arrange
+        var manager = new RecipeManager();
+        var filePath = Path.Combine(_testDir, "invalid.yaml");
+        // A line with no ': ' separator produces a "Malformed root-level line" parse error
+        await File.WriteAllTextAsync(filePath, "not_valid_yaml_no_colon_separator");
+
+        // Act
+        var result = await manager.LoadAsync(filePath);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task SaveAsync_InvalidDirectoryPath_ReturnsFailure()
+    {
+        // Arrange
+        var manager = new RecipeManager();
+        var filePath = Path.Combine(_testDir, "nonexistent_subdir", "recipe.yaml");
+        var recipe = new Recipe { Name = "test", Actions = [] };
+
+        // Act
+        var result = await manager.SaveAsync(recipe, filePath);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task SaveAsync_NullRecipe_ThrowsArgumentNullException()
+    {
+        // Arrange
+        var manager = new RecipeManager();
+        var filePath = Path.Combine(_testDir, "recipe.yaml");
+
+        // Act
+        var act = async () => await manager.SaveAsync(null!, filePath);
+
+        // Assert
+        await act.Should().ThrowAsync<ArgumentNullException>();
+    }
+
+    [Fact]
+    public async Task SaveAsync_NullFilePath_ThrowsArgumentNullException()
+    {
+        // Arrange
+        var manager = new RecipeManager();
+        var recipe = new Recipe { Name = "test", Actions = [] };
+
+        // Act
+        var act = async () => await manager.SaveAsync(recipe, null!);
+
+        // Assert
+        await act.Should().ThrowAsync<ArgumentNullException>();
+    }
+
+    [Fact]
+    public async Task SaveAsync_WhitespaceFilePath_ThrowsArgumentException()
+    {
+        // Arrange
+        var manager = new RecipeManager();
+        var recipe = new Recipe { Name = "test", Actions = [] };
+
+        // Act
+        var act = async () => await manager.SaveAsync(recipe, "   ");
+
+        // Assert
+        await act.Should().ThrowAsync<ArgumentException>();
+    }
+
+    [Fact]
+    public async Task LoadAsync_NullFilePath_ThrowsArgumentNullException()
+    {
+        // Arrange
+        var manager = new RecipeManager();
+
+        // Act
+        var act = async () => await manager.LoadAsync(null!);
+
+        // Assert
+        await act.Should().ThrowAsync<ArgumentNullException>();
+    }
+
+    [Fact]
+    public async Task LoadAsync_WhitespaceFilePath_ThrowsArgumentException()
+    {
+        // Arrange
+        var manager = new RecipeManager();
+
+        // Act
+        var act = async () => await manager.LoadAsync("   ");
+
+        // Assert
+        await act.Should().ThrowAsync<ArgumentException>();
+    }
+
+    [Fact]
+    public async Task SaveAsync_CancelledToken_ThrowsOperationCanceledException()
+    {
+        // Arrange
+        var manager = new RecipeManager();
+        var filePath = Path.Combine(_testDir, "recipe.yaml");
+        var recipe = new Recipe { Name = "test", Actions = [] };
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        // Act
+        var act = async () => await manager.SaveAsync(recipe, filePath, cts.Token);
+
+        // Assert
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+
+    [Fact]
+    public async Task LoadAsync_CancelledToken_ThrowsOperationCanceledException()
+    {
+        // Arrange
+        var manager = new RecipeManager();
+        var filePath = Path.Combine(_testDir, "recipe.yaml");
+        await File.WriteAllTextAsync(filePath, "name: \"test\"\nactions: []");
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        // Act
+        var act = async () => await manager.LoadAsync(filePath, cts.Token);
+
+        // Assert
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+}

--- a/tests/DataMorph.Tests/Engine/Recipes/RecipeYamlParserTests.cs
+++ b/tests/DataMorph.Tests/Engine/Recipes/RecipeYamlParserTests.cs
@@ -1,0 +1,794 @@
+using AwesomeAssertions;
+using DataMorph.Engine.Models;
+using DataMorph.Engine.Models.Actions;
+using DataMorph.Engine.Recipes;
+using DataMorph.Engine.Types;
+
+namespace DataMorph.Tests.Engine.Recipes;
+
+public sealed class RecipeYamlParserTests
+{
+    // -----------------------------------------------------------------------
+    // Parse
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void Parse_ValidYaml_ReturnsRecipeWithCorrectName()
+    {
+        // Arrange
+        var yaml = "name: \"customer-data\"\nactions: []";
+
+        // Act
+        var result = RecipeYamlParser.Parse(yaml);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Name.Should().Be("customer-data");
+    }
+
+    [Fact]
+    public void Parse_EmptyActionList_ReturnsEmptyActions()
+    {
+        // Arrange
+        var yaml = "name: \"test\"\nactions: []";
+
+        // Act
+        var result = RecipeYamlParser.Parse(yaml);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Actions.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Parse_RenameAction_ParsesOldNameAndNewName()
+    {
+        // Arrange
+        var yaml = """
+            name: "test"
+            actions:
+              - type: rename
+                oldName: "old_col"
+                newName: "new_col"
+            """;
+
+        // Act
+        var result = RecipeYamlParser.Parse(yaml);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        var action = result.Value.Actions[0].Should().BeOfType<RenameColumnAction>().Subject;
+        action.OldName.Should().Be("old_col");
+        action.NewName.Should().Be("new_col");
+    }
+
+    [Fact]
+    public void Parse_DeleteAction_ParsesColumnName()
+    {
+        // Arrange
+        var yaml = """
+            name: "test"
+            actions:
+              - type: delete
+                columnName: "temp_field"
+            """;
+
+        // Act
+        var result = RecipeYamlParser.Parse(yaml);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        var action = result.Value.Actions[0].Should().BeOfType<DeleteColumnAction>().Subject;
+        action.ColumnName.Should().Be("temp_field");
+    }
+
+    [Fact]
+    public void Parse_CastAction_ParsesColumnNameAndTargetType()
+    {
+        // Arrange
+        var yaml = """
+            name: "test"
+            actions:
+              - type: cast
+                columnName: "age"
+                targetType: WholeNumber
+            """;
+
+        // Act
+        var result = RecipeYamlParser.Parse(yaml);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        var action = result.Value.Actions[0].Should().BeOfType<CastColumnAction>().Subject;
+        action.ColumnName.Should().Be("age");
+        action.TargetType.Should().Be(ColumnType.WholeNumber);
+    }
+
+    [Fact]
+    public void Parse_FilterAction_ParsesColumnNameOperatorAndValue()
+    {
+        // Arrange
+        var yaml = """
+            name: "test"
+            actions:
+              - type: filter
+                columnName: "status"
+                operator: Equals
+                value: "active"
+            """;
+
+        // Act
+        var result = RecipeYamlParser.Parse(yaml);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        var action = result.Value.Actions[0].Should().BeOfType<FilterAction>().Subject;
+        action.ColumnName.Should().Be("status");
+        action.Operator.Should().Be(FilterOperator.Equals);
+        action.Value.Should().Be("active");
+    }
+
+    [Fact]
+    public void Parse_MultipleActions_PreservesOrder()
+    {
+        // Arrange
+        var yaml = """
+            name: "test"
+            actions:
+              - type: rename
+                oldName: "a"
+                newName: "b"
+              - type: delete
+                columnName: "temp"
+              - type: cast
+                columnName: "age"
+                targetType: WholeNumber
+            """;
+
+        // Act
+        var result = RecipeYamlParser.Parse(yaml);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Actions.Should().HaveCount(3);
+        result.Value.Actions[0].Should().BeOfType<RenameColumnAction>();
+        result.Value.Actions[1].Should().BeOfType<DeleteColumnAction>();
+        result.Value.Actions[2].Should().BeOfType<CastColumnAction>();
+    }
+
+    [Fact]
+    public void Parse_UnknownActionType_ReturnsFailure()
+    {
+        // Arrange
+        var yaml = """
+            name: "test"
+            actions:
+              - type: unsupported
+                columnName: "col"
+            """;
+
+        // Act
+        var result = RecipeYamlParser.Parse(yaml);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Contain("unsupported");
+    }
+
+    [Fact]
+    public void Parse_RenameAction_MissingOldName_ReturnsFailure()
+    {
+        // Arrange
+        var yaml = """
+            name: "test"
+            actions:
+              - type: rename
+                newName: "new"
+            """;
+
+        // Act
+        var result = RecipeYamlParser.Parse(yaml);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Contain("oldName");
+    }
+
+    [Fact]
+    public void Parse_RenameAction_MissingNewName_ReturnsFailure()
+    {
+        // Arrange
+        var yaml = """
+            name: "test"
+            actions:
+              - type: rename
+                oldName: "old"
+            """;
+
+        // Act
+        var result = RecipeYamlParser.Parse(yaml);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Contain("newName");
+    }
+
+    [Fact]
+    public void Parse_DeleteAction_MissingColumnName_ReturnsFailure()
+    {
+        // Arrange
+        var yaml = """
+            name: "test"
+            actions:
+              - type: delete
+            """;
+
+        // Act
+        var result = RecipeYamlParser.Parse(yaml);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Contain("columnName");
+    }
+
+    [Fact]
+    public void Parse_CastAction_MissingColumnName_ReturnsFailure()
+    {
+        // Arrange
+        var yaml = """
+            name: "test"
+            actions:
+              - type: cast
+                targetType: WholeNumber
+            """;
+
+        // Act
+        var result = RecipeYamlParser.Parse(yaml);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Contain("columnName");
+    }
+
+    [Fact]
+    public void Parse_CastAction_MissingTargetType_ReturnsFailure()
+    {
+        // Arrange
+        var yaml = """
+            name: "test"
+            actions:
+              - type: cast
+                columnName: "age"
+            """;
+
+        // Act
+        var result = RecipeYamlParser.Parse(yaml);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Contain("targetType");
+    }
+
+    [Fact]
+    public void Parse_FilterAction_MissingColumnName_ReturnsFailure()
+    {
+        // Arrange
+        var yaml = """
+            name: "test"
+            actions:
+              - type: filter
+                operator: Equals
+                value: "active"
+            """;
+
+        // Act
+        var result = RecipeYamlParser.Parse(yaml);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Contain("columnName");
+    }
+
+    [Fact]
+    public void Parse_FilterAction_MissingOperator_ReturnsFailure()
+    {
+        // Arrange
+        var yaml = """
+            name: "test"
+            actions:
+              - type: filter
+                columnName: "status"
+                value: "active"
+            """;
+
+        // Act
+        var result = RecipeYamlParser.Parse(yaml);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Contain("operator");
+    }
+
+    [Fact]
+    public void Parse_FilterAction_MissingValue_ReturnsFailure()
+    {
+        // Arrange
+        var yaml = """
+            name: "test"
+            actions:
+              - type: filter
+                columnName: "status"
+                operator: Equals
+            """;
+
+        // Act
+        var result = RecipeYamlParser.Parse(yaml);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Contain("value");
+    }
+
+    [Fact]
+    public void Parse_InvalidEnumValue_ReturnsFailure()
+    {
+        // Arrange
+        var yaml = """
+            name: "test"
+            actions:
+              - type: cast
+                columnName: "age"
+                targetType: InvalidType
+            """;
+
+        // Act
+        var result = RecipeYamlParser.Parse(yaml);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Contain("InvalidType");
+    }
+
+    [Fact]
+    public void Parse_FilterAction_InvalidOperator_ReturnsFailure()
+    {
+        // Arrange
+        var yaml = """
+            name: "test"
+            actions:
+              - type: filter
+                columnName: "status"
+                operator: InvalidOperator
+                value: "active"
+            """;
+
+        // Act
+        var result = RecipeYamlParser.Parse(yaml);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Contain("InvalidOperator");
+    }
+
+    [Fact]
+    public void Parse_MissingNameField_ReturnsFailure()
+    {
+        // Arrange
+        var yaml = "actions: []";
+
+        // Act
+        var result = RecipeYamlParser.Parse(yaml);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Contain("name");
+    }
+
+    [Fact]
+    public void Parse_CommentLines_AreIgnored()
+    {
+        // Arrange
+        var yaml = """
+            # This is a comment
+            name: "test"
+            # Another comment
+            actions: []
+            """;
+
+        // Act
+        var result = RecipeYamlParser.Parse(yaml);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Name.Should().Be("test");
+    }
+
+    [Fact]
+    public void Parse_BlankLines_AreIgnored()
+    {
+        // Arrange
+        var yaml = "\nname: \"test\"\n\nactions: []\n\n";
+
+        // Act
+        var result = RecipeYamlParser.Parse(yaml);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Name.Should().Be("test");
+    }
+
+    [Fact]
+    public void Parse_EscapedQuoteInStringValue_ParsesCorrectly()
+    {
+        // Arrange
+        var yaml = """
+            name: "test"
+            actions:
+              - type: rename
+                oldName: "col\"name"
+                newName: "new"
+            """;
+
+        // Act
+        var result = RecipeYamlParser.Parse(yaml);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        var action = result.Value.Actions[0].Should().BeOfType<RenameColumnAction>().Subject;
+        action.OldName.Should().Be("col\"name");
+    }
+
+    [Fact]
+    public void Parse_UnquotedStringValue_ParsesCorrectly()
+    {
+        // Arrange
+        var yaml = "name: customer-data\nactions: []";
+
+        // Act
+        var result = RecipeYamlParser.Parse(yaml);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Name.Should().Be("customer-data");
+    }
+
+    [Fact]
+    public void Parse_InvalidLastModified_ReturnsFailure()
+    {
+        // Arrange
+        var yaml = "name: \"test\"\nlastModified: \"not-a-date\"\nactions: []";
+
+        // Act
+        var result = RecipeYamlParser.Parse(yaml);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Contain("lastModified");
+    }
+
+    [Fact]
+    public void Parse_CrlfLineEndings_ParsesCorrectly()
+    {
+        // Arrange
+        var yaml = "name: \"test\"\r\nactions: []\r\n";
+
+        // Act
+        var result = RecipeYamlParser.Parse(yaml);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Name.Should().Be("test");
+    }
+
+    [Fact]
+    public void Parse_MalformedRootLevelLine_ReturnsFailure()
+    {
+        // Arrange
+        var yaml = "name: \"test\"\njustakeynovalue\nactions: []";
+
+        // Act
+        var result = RecipeYamlParser.Parse(yaml);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Contain("justakeynovalue");
+    }
+
+    [Fact]
+    public void Parse_DuplicateNameKey_ReturnsFailure()
+    {
+        // Arrange
+        var yaml = "name: \"first\"\nname: \"second\"\nactions: []";
+
+        // Act
+        var result = RecipeYamlParser.Parse(yaml);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Contain("name");
+    }
+
+    [Fact]
+    public void Parse_DuplicateDescriptionKey_ReturnsFailure()
+    {
+        // Arrange
+        var yaml = "name: \"test\"\ndescription: \"first\"\ndescription: \"second\"\nactions: []";
+
+        // Act
+        var result = RecipeYamlParser.Parse(yaml);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Contain("description");
+    }
+
+    [Fact]
+    public void Parse_DuplicateLastModifiedKey_ReturnsFailure()
+    {
+        // Arrange
+        var yaml = "name: \"test\"\nlastModified: \"2025-01-01T00:00:00+00:00\"\nlastModified: \"2025-06-01T00:00:00+00:00\"\nactions: []";
+
+        // Act
+        var result = RecipeYamlParser.Parse(yaml);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Contain("lastModified");
+    }
+
+    [Fact]
+    public void Parse_ActionsKeyWithNoItems_ReturnsEmptyActions()
+    {
+        // Arrange
+        var yaml = "name: \"test\"\nactions:";
+
+        // Act
+        var result = RecipeYamlParser.Parse(yaml);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Actions.Should().BeEmpty();
+    }
+
+    // -----------------------------------------------------------------------
+    // Round-trip
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void RoundTrip_RenameAction_ProducesEquivalentRecipe()
+    {
+        // Arrange
+        var original = new Recipe
+        {
+            Name = "test",
+            Actions = [new RenameColumnAction { OldName = "col_a", NewName = "col_b" }],
+        };
+
+        // Act
+        var result = RecipeYamlParser.Parse(RecipeYamlSerializer.Serialize(original));
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Name.Should().Be("test");
+        var action = result.Value.Actions[0].Should().BeOfType<RenameColumnAction>().Subject;
+        action.OldName.Should().Be("col_a");
+        action.NewName.Should().Be("col_b");
+    }
+
+    [Fact]
+    public void RoundTrip_DeleteAction_ProducesEquivalentRecipe()
+    {
+        // Arrange
+        var original = new Recipe
+        {
+            Name = "test",
+            Actions = [new DeleteColumnAction { ColumnName = "temp" }],
+        };
+
+        // Act
+        var result = RecipeYamlParser.Parse(RecipeYamlSerializer.Serialize(original));
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        var action = result.Value.Actions[0].Should().BeOfType<DeleteColumnAction>().Subject;
+        action.ColumnName.Should().Be("temp");
+    }
+
+    [Fact]
+    public void RoundTrip_CastAction_ProducesEquivalentRecipe()
+    {
+        // Arrange
+        var original = new Recipe
+        {
+            Name = "test",
+            Actions = [new CastColumnAction { ColumnName = "age", TargetType = ColumnType.WholeNumber }],
+        };
+
+        // Act
+        var result = RecipeYamlParser.Parse(RecipeYamlSerializer.Serialize(original));
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        var action = result.Value.Actions[0].Should().BeOfType<CastColumnAction>().Subject;
+        action.ColumnName.Should().Be("age");
+        action.TargetType.Should().Be(ColumnType.WholeNumber);
+    }
+
+    [Fact]
+    public void RoundTrip_FilterAction_ProducesEquivalentRecipe()
+    {
+        // Arrange
+        var original = new Recipe
+        {
+            Name = "test",
+            Actions = [new FilterAction { ColumnName = "status", Operator = FilterOperator.Equals, Value = "active" }],
+        };
+
+        // Act
+        var result = RecipeYamlParser.Parse(RecipeYamlSerializer.Serialize(original));
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        var action = result.Value.Actions[0].Should().BeOfType<FilterAction>().Subject;
+        action.ColumnName.Should().Be("status");
+        action.Operator.Should().Be(FilterOperator.Equals);
+        action.Value.Should().Be("active");
+    }
+
+    [Fact]
+    public void RoundTrip_MultipleActions_PreservesAllActions()
+    {
+        // Arrange
+        var original = new Recipe
+        {
+            Name = "pipeline",
+            Actions =
+            [
+                new RenameColumnAction { OldName = "user_id", NewName = "userId" },
+                new DeleteColumnAction { ColumnName = "temp" },
+                new CastColumnAction { ColumnName = "age", TargetType = ColumnType.WholeNumber },
+                new FilterAction { ColumnName = "status", Operator = FilterOperator.Equals, Value = "active" },
+            ],
+        };
+
+        // Act
+        var result = RecipeYamlParser.Parse(RecipeYamlSerializer.Serialize(original));
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Actions.Should().HaveCount(4);
+        result.Value.Actions[0].Should().BeOfType<RenameColumnAction>();
+        result.Value.Actions[1].Should().BeOfType<DeleteColumnAction>();
+        result.Value.Actions[2].Should().BeOfType<CastColumnAction>();
+        result.Value.Actions[3].Should().BeOfType<FilterAction>();
+    }
+
+    [Fact]
+    public void RoundTrip_WithNullableFieldsPopulated_PreservesValues()
+    {
+        // Arrange
+        var original = new Recipe
+        {
+            Name = "full",
+            Description = "A description",
+            LastModified = new DateTimeOffset(2025, 6, 15, 10, 0, 0, TimeSpan.Zero),
+            Actions = [],
+        };
+
+        // Act
+        var result = RecipeYamlParser.Parse(RecipeYamlSerializer.Serialize(original));
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Description.Should().Be("A description");
+        result.Value.LastModified.Should().Be(new DateTimeOffset(2025, 6, 15, 10, 0, 0, TimeSpan.Zero));
+    }
+
+    [Fact]
+    public void RoundTrip_WithNullableFieldsAbsent_ReturnsNulls()
+    {
+        // Arrange
+        var original = new Recipe { Name = "minimal", Actions = [] };
+
+        // Act
+        var result = RecipeYamlParser.Parse(RecipeYamlSerializer.Serialize(original));
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Description.Should().BeNull();
+        result.Value.LastModified.Should().BeNull();
+    }
+
+    [Fact]
+    public void RoundTrip_BackslashInStringValue_PreservesValue()
+    {
+        // Arrange
+        var original = new Recipe
+        {
+            Name = "test",
+            Actions = [new RenameColumnAction { OldName = @"C:\data\file", NewName = "output" }],
+        };
+
+        // Act
+        var result = RecipeYamlParser.Parse(RecipeYamlSerializer.Serialize(original));
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        var action = result.Value.Actions[0].Should().BeOfType<RenameColumnAction>().Subject;
+        action.OldName.Should().Be(@"C:\data\file");
+    }
+
+    [Fact]
+    public void RoundTrip_BackslashFollowedByQuote_PreservesValue()
+    {
+        // Arrange
+        var original = new Recipe
+        {
+            Name = "test",
+            Actions = [new RenameColumnAction { OldName = "col\\\"name", NewName = "output" }],
+        };
+
+        // Act
+        var result = RecipeYamlParser.Parse(RecipeYamlSerializer.Serialize(original));
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        var action = result.Value.Actions[0].Should().BeOfType<RenameColumnAction>().Subject;
+        action.OldName.Should().Be("col\\\"name");
+    }
+
+    [Theory]
+    [InlineData(FilterOperator.Equals)]
+    [InlineData(FilterOperator.NotEquals)]
+    [InlineData(FilterOperator.GreaterThan)]
+    [InlineData(FilterOperator.LessThan)]
+    [InlineData(FilterOperator.GreaterThanOrEqual)]
+    [InlineData(FilterOperator.LessThanOrEqual)]
+    [InlineData(FilterOperator.Contains)]
+    [InlineData(FilterOperator.NotContains)]
+    [InlineData(FilterOperator.StartsWith)]
+    [InlineData(FilterOperator.EndsWith)]
+    public void RoundTrip_FilterAction_AllOperators_PreservesOperator(FilterOperator op)
+    {
+        // Arrange
+        var original = new Recipe
+        {
+            Name = "test",
+            Actions = [new FilterAction { ColumnName = "col", Operator = op, Value = "v" }],
+        };
+
+        // Act
+        var result = RecipeYamlParser.Parse(RecipeYamlSerializer.Serialize(original));
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        var action = result.Value.Actions[0].Should().BeOfType<FilterAction>().Subject;
+        action.Operator.Should().Be(op);
+    }
+
+    [Theory]
+    [InlineData(ColumnType.Text)]
+    [InlineData(ColumnType.WholeNumber)]
+    [InlineData(ColumnType.FloatingPoint)]
+    [InlineData(ColumnType.Boolean)]
+    [InlineData(ColumnType.Timestamp)]
+    [InlineData(ColumnType.JsonObject)]
+    [InlineData(ColumnType.JsonArray)]
+    public void RoundTrip_CastAction_AllColumnTypes_PreservesTargetType(ColumnType columnType)
+    {
+        // Arrange
+        var original = new Recipe
+        {
+            Name = "test",
+            Actions = [new CastColumnAction { ColumnName = "col", TargetType = columnType }],
+        };
+
+        // Act
+        var result = RecipeYamlParser.Parse(RecipeYamlSerializer.Serialize(original));
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        var action = result.Value.Actions[0].Should().BeOfType<CastColumnAction>().Subject;
+        action.TargetType.Should().Be(columnType);
+    }
+}

--- a/tests/DataMorph.Tests/Engine/Recipes/RecipeYamlSerializerTests.cs
+++ b/tests/DataMorph.Tests/Engine/Recipes/RecipeYamlSerializerTests.cs
@@ -1,0 +1,205 @@
+using AwesomeAssertions;
+using DataMorph.Engine.Models;
+using DataMorph.Engine.Models.Actions;
+using DataMorph.Engine.Recipes;
+using DataMorph.Engine.Types;
+
+namespace DataMorph.Tests.Engine.Recipes;
+
+public sealed class RecipeYamlSerializerTests
+{
+    [Fact]
+    public void Serialize_EmptyActions_ProducesActionsEmptyListLine()
+    {
+        // Arrange
+        var recipe = new Recipe { Name = "test", Actions = [] };
+
+        // Act
+        var yaml = RecipeYamlSerializer.Serialize(recipe);
+
+        // Assert
+        yaml.Should().Contain("actions: []");
+    }
+
+    [Fact]
+    public void Serialize_WithRenameAction_ProducesCorrectYaml()
+    {
+        // Arrange
+        var recipe = new Recipe
+        {
+            Name = "test",
+            Actions = [new RenameColumnAction { OldName = "old", NewName = "new" }],
+        };
+
+        // Act
+        var yaml = RecipeYamlSerializer.Serialize(recipe);
+
+        // Assert
+        yaml.Should().Contain("  - type: rename");
+        yaml.Should().Contain("    oldName: \"old\"");
+        yaml.Should().Contain("    newName: \"new\"");
+    }
+
+    [Fact]
+    public void Serialize_WithDeleteAction_ProducesCorrectYaml()
+    {
+        // Arrange
+        var recipe = new Recipe
+        {
+            Name = "test",
+            Actions = [new DeleteColumnAction { ColumnName = "temp_field" }],
+        };
+
+        // Act
+        var yaml = RecipeYamlSerializer.Serialize(recipe);
+
+        // Assert
+        yaml.Should().Contain("  - type: delete");
+        yaml.Should().Contain("    columnName: \"temp_field\"");
+    }
+
+    [Fact]
+    public void Serialize_WithCastAction_ProducesCorrectYaml()
+    {
+        // Arrange
+        var recipe = new Recipe
+        {
+            Name = "test",
+            Actions = [new CastColumnAction { ColumnName = "age", TargetType = ColumnType.WholeNumber }],
+        };
+
+        // Act
+        var yaml = RecipeYamlSerializer.Serialize(recipe);
+
+        // Assert
+        yaml.Should().Contain("  - type: cast");
+        yaml.Should().Contain("    columnName: \"age\"");
+        yaml.Should().Contain("    targetType: WholeNumber");
+    }
+
+    [Fact]
+    public void Serialize_WithFilterAction_ProducesCorrectYaml()
+    {
+        // Arrange
+        var recipe = new Recipe
+        {
+            Name = "test",
+            Actions = [new FilterAction { ColumnName = "status", Operator = FilterOperator.Equals, Value = "active" }],
+        };
+
+        // Act
+        var yaml = RecipeYamlSerializer.Serialize(recipe);
+
+        // Assert
+        yaml.Should().Contain("  - type: filter");
+        yaml.Should().Contain("    columnName: \"status\"");
+        yaml.Should().Contain("    operator: Equals");
+        yaml.Should().Contain("    value: \"active\"");
+    }
+
+    [Fact]
+    public void Serialize_NullDescription_OmitsDescriptionField()
+    {
+        // Arrange
+        var recipe = new Recipe { Name = "test", Actions = [], Description = null };
+
+        // Act
+        var yaml = RecipeYamlSerializer.Serialize(recipe);
+
+        // Assert
+        yaml.Should().NotContain("description:");
+    }
+
+    [Fact]
+    public void Serialize_NullLastModified_OmitsLastModifiedField()
+    {
+        // Arrange
+        var recipe = new Recipe { Name = "test", Actions = [], LastModified = null };
+
+        // Act
+        var yaml = RecipeYamlSerializer.Serialize(recipe);
+
+        // Assert
+        yaml.Should().NotContain("lastModified:");
+    }
+
+    [Fact]
+    public void Serialize_StringValueWithDoubleQuote_EscapesQuoteCharacter()
+    {
+        // Arrange
+        var recipe = new Recipe
+        {
+            Name = "test",
+            Actions = [new RenameColumnAction { OldName = "col\"name", NewName = "new" }],
+        };
+
+        // Act
+        var yaml = RecipeYamlSerializer.Serialize(recipe);
+
+        // Assert
+        yaml.Should().Contain("    oldName: \"col\\\"name\"");
+    }
+
+    [Fact]
+    public void Serialize_StringValueWithBackslash_EscapesBackslash()
+    {
+        // Arrange
+        var recipe = new Recipe
+        {
+            Name = "test",
+            Actions = [new RenameColumnAction { OldName = @"C:\data", NewName = "output" }],
+        };
+
+        // Act
+        var yaml = RecipeYamlSerializer.Serialize(recipe);
+
+        // Assert
+        yaml.Should().Contain(@"    oldName: ""C:\\data""");
+    }
+
+    [Fact]
+    public void Serialize_StringValueWithBackslashAndQuote_EscapesBoth()
+    {
+        // Arrange
+        var recipe = new Recipe
+        {
+            Name = "test",
+            Actions = [new RenameColumnAction { OldName = "col\\\"name", NewName = "output" }],
+        };
+
+        // Act
+        var yaml = RecipeYamlSerializer.Serialize(recipe);
+
+        // Assert
+        yaml.Should().Contain("    oldName: \"col\\\\\\\"name\"");
+    }
+
+    [Fact]
+    public void Serialize_FieldOrder_NameFirstActionsLast()
+    {
+        // Arrange
+        var recipe = new Recipe
+        {
+            Name = "test",
+            Description = "desc",
+            LastModified = new DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero),
+            Actions = [],
+        };
+
+        // Act
+        var yaml = RecipeYamlSerializer.Serialize(recipe);
+
+        // Assert
+        var nameIdx = yaml.IndexOf("name:", StringComparison.Ordinal);
+        var descIdx = yaml.IndexOf("description:", StringComparison.Ordinal);
+        var lastModIdx = yaml.IndexOf("lastModified:", StringComparison.Ordinal);
+        var actionsIdx = yaml.IndexOf("actions:", StringComparison.Ordinal);
+        nameIdx.Should().BeGreaterThanOrEqualTo(0, "name field should be present");
+        descIdx.Should().BeGreaterThanOrEqualTo(0, "description field should be present");
+        lastModIdx.Should().BeGreaterThanOrEqualTo(0, "lastModified field should be present");
+        actionsIdx.Should().BeGreaterThanOrEqualTo(0, "actions field should be present");
+        nameIdx.Should().BeLessThan(descIdx);
+        descIdx.Should().BeLessThan(lastModIdx);
+        lastModIdx.Should().BeLessThan(actionsIdx);
+    }
+}


### PR DESCRIPTION
## Summary

- Add `IRecipeManager` interface and `RecipeManager` implementation for saving/loading the Action Stack as a human-readable `morph-recipe.yaml` file
- Implement `RecipeYamlSerializer` (custom, AOT-safe, no external dependencies) and `MorphActionParser` state-machine YAML parser
- Integrate Save Recipe (`Ctrl+S`) and Load Recipe (File menu) into `MainWindow`
- Add comprehensive unit tests for serializer, parser, and file I/O round-trips

## Test plan

- [ ] `dotnet build` passes with no warnings
- [ ] `dotnet test` — all RecipeYamlSerializerTests, RecipeYamlParserTests, RecipeManagerTests pass
- [ ] TUI: open a CSV, apply actions, Save Recipe → verify `morph-recipe.yaml` is written
- [ ] TUI: Load Recipe from saved file → verify Action Stack is restored correctly
- [ ] TUI: Load Recipe with invalid/missing file → verify error message is shown without crash

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)