### PR TITLE
refactor: replace exit code magic numbers with ExitCode enum

### DIFF
--- a/src/App/Cli/ExitCode.cs
+++ b/src/App/Cli/ExitCode.cs
@@ -1,0 +1,17 @@
+namespace DataMorph.App.Cli;
+
+/// <summary>
+/// Defines the exit codes for the application.
+/// </summary>
+internal enum ExitCode
+{
+    /// <summary>
+    /// Success exit code.
+    /// </summary>
+    Success = 0,
+
+    /// <summary>
+    /// Failure exit code.
+    /// </summary>
+    Failure = 1
+}

--- a/src/App/Cli/RecordProcessor.cs
+++ b/src/App/Cli/RecordProcessor.cs
@@ -2,7 +2,7 @@ namespace DataMorph.App.Cli;
 
 internal static class RecordProcessor
 {
-    public static async ValueTask<int> ProcessAsync<TReader, TWriter>(
+    public static async ValueTask<ExitCode> ProcessAsync<TReader, TWriter>(
         TReader reader,
         TWriter writer,
         int outputColumnCount,
@@ -33,6 +33,6 @@ internal static class RecordProcessor
         }
 
         await writer.FlushAsync(ct).ConfigureAwait(false);
-        return 0;
+        return ExitCode.Success;
     }
 }

--- a/src/App/Cli/Runner.cs
+++ b/src/App/Cli/Runner.cs
@@ -19,8 +19,8 @@ internal static class Runner
     /// <param name="args">The validated CLI arguments.</param>
     /// <param name="logger">The app logger for logging messages.</param>
     /// <param name="ct">Cancellation token.</param>
-    /// <returns>Exit code: <c>0</c> on success, <c>1</c> on any failure.</returns>
-    public static async ValueTask<int> RunAsync(Arguments args, IAppLogger logger, CancellationToken ct = default)
+    /// <returns>Exit code: <see cref="ExitCode.Success"/> on success, <see cref="ExitCode.Failure"/> on any failure.</returns>
+    public static async ValueTask<ExitCode> RunAsync(Arguments args, IAppLogger logger, CancellationToken ct = default)
     {
         ArgumentNullException.ThrowIfNull(args);
 
@@ -31,7 +31,7 @@ internal static class Runner
             if (recipeResult.IsFailure)
             {
                 await logger.WriteErrorAsync($"Error loading recipe: {recipeResult.Error}");
-                return 1;
+                return ExitCode.Failure;
             }
 
             var recipe = recipeResult.Value;
@@ -53,19 +53,19 @@ internal static class Runner
         catch (OperationCanceledException)
         {
             await logger.WriteErrorAsync("Operation cancelled");
-            return 1;
+            return ExitCode.Failure;
         }
         catch (NotSupportedException ex)
         {
             await logger.WriteErrorAsync(ex.Message);
-            return 1;
+            return ExitCode.Failure;
         }
 #pragma warning disable CA1031 // Do not catch general exception types
         catch (Exception ex)
 #pragma warning restore CA1031 // Do not catch general exception types
         {
             await logger.WriteErrorAsync($"Error: {ex.Message}");
-            return 1;
+            return ExitCode.Failure;
         }
     }
 

--- a/src/App/Program.cs
+++ b/src/App/Program.cs
@@ -7,7 +7,7 @@ if (args.Contains("--cli"))
     if (parseResult.IsFailure)
     {
         await Console.Error.WriteLineAsync(parseResult.Error);
-        return 1;
+        return (int)ExitCode.Failure;
     }
 
     var logger = new ConsoleAppLogger();
@@ -19,7 +19,7 @@ if (args.Contains("--cli"))
         cts.Cancel();
     };
 
-    return await Runner.RunAsync(parseResult.Value, logger, cts.Token);
+    return (int)await Runner.RunAsync(parseResult.Value, logger, cts.Token);
 }
 
 var result = TuiApplication.Create();
@@ -28,4 +28,4 @@ using var mainWindow = result.mainWindow;
 
 app.Init();
 app.Run(mainWindow);
-return 0;
+return (int)ExitCode.Success;

--- a/src/Generators/FormatDispatcherGenerator.cs
+++ b/src/Generators/FormatDispatcherGenerator.cs
@@ -169,7 +169,7 @@ public class FormatDispatcherGenerator : IIncrementalGenerator
         sb.AppendLine();
         sb.AppendLine("internal static class FormatDispatcher");
         sb.AppendLine("{");
-        sb.AppendLine("    public static async ValueTask<int> DispatchAsync(");
+        sb.AppendLine("    public static async ValueTask<ExitCode> DispatchAsync(");
         sb.AppendLine("        DataFormat inputFormat,");
         sb.AppendLine("        DataFormat outputFormat,");
         sb.AppendLine("        Arguments args,");
@@ -206,7 +206,7 @@ public class FormatDispatcherGenerator : IIncrementalGenerator
             {
                 sb.AppendLine();
                 sb.AppendLine(
-                    $"    private static async ValueTask<int> Run{reader.FormatName}To{writer.FormatName}Async("
+                    $"    private static async ValueTask<ExitCode> Run{reader.FormatName}To{writer.FormatName}Async("
                 );
                 sb.AppendLine("        Arguments args,");
                 sb.AppendLine("        TableSchema inputSchema,");

--- a/tests/DataMorph.Tests/App/Cli/RunnerTests.cs
+++ b/tests/DataMorph.Tests/App/Cli/RunnerTests.cs
@@ -72,7 +72,7 @@ public sealed class RunnerTests : IDisposable
         var exitCode = await Runner.RunAsync(args, logger);
 
         // Assert
-        exitCode.Should().Be(0);
+        exitCode.Should().Be(ExitCode.Success);
         logger.Errors.Count.Should().Be(0);
         File.Exists(outputFile).Should().BeTrue();
         var output = await File.ReadAllTextAsync(outputFile);
@@ -96,7 +96,7 @@ public sealed class RunnerTests : IDisposable
         var exitCode = await Runner.RunAsync(args, logger);
 
         // Assert
-        exitCode.Should().Be(0);
+        exitCode.Should().Be(ExitCode.Success);
         logger.Errors.Count.Should().Be(0);
         File.Exists(outputFile).Should().BeTrue();
         var output = await File.ReadAllTextAsync(outputFile);
@@ -117,7 +117,7 @@ public sealed class RunnerTests : IDisposable
         var exitCode = await Runner.RunAsync(args, logger);
 
         // Assert
-        exitCode.Should().Be(0);
+        exitCode.Should().Be(ExitCode.Success);
         logger.Errors.Count.Should().Be(0);
         File.Exists(outputFile).Should().BeTrue();
         var output = await File.ReadAllTextAsync(outputFile);
@@ -139,7 +139,7 @@ public sealed class RunnerTests : IDisposable
         var exitCode = await Runner.RunAsync(args, logger);
 
         // Assert
-        exitCode.Should().Be(0);
+        exitCode.Should().Be(ExitCode.Success);
         logger.Errors.Count.Should().Be(0);
         File.Exists(outputFile).Should().BeTrue();
         var output = await File.ReadAllTextAsync(outputFile);
@@ -163,7 +163,7 @@ public sealed class RunnerTests : IDisposable
         var exitCode = await Runner.RunAsync(args, logger);
 
         // Assert
-        exitCode.Should().Be(0);
+        exitCode.Should().Be(ExitCode.Success);
         logger.Errors.Count.Should().Be(0);
         File.Exists(outputFile).Should().BeTrue();
         var output = await File.ReadAllTextAsync(outputFile);
@@ -186,7 +186,7 @@ public sealed class RunnerTests : IDisposable
         var exitCode = await Runner.RunAsync(args, logger);
 
         // Assert
-        exitCode.Should().Be(0);
+        exitCode.Should().Be(ExitCode.Success);
         logger.Errors.Count.Should().Be(0);
         File.Exists(outputFile).Should().BeTrue();
         var output = await File.ReadAllTextAsync(outputFile);
@@ -208,7 +208,7 @@ public sealed class RunnerTests : IDisposable
         var exitCode = await Runner.RunAsync(args, logger);
 
         // Assert
-        exitCode.Should().Be(0);
+        exitCode.Should().Be(ExitCode.Success);
         logger.Errors.Count.Should().Be(0);
         File.Exists(outputFile).Should().BeTrue();
         var output = await File.ReadAllTextAsync(outputFile);
@@ -230,7 +230,7 @@ public sealed class RunnerTests : IDisposable
         var exitCode = await Runner.RunAsync(args, logger);
 
         // Assert
-        exitCode.Should().Be(0);
+        exitCode.Should().Be(ExitCode.Success);
         logger.Errors.Count.Should().Be(0);
         File.Exists(outputFile).Should().BeTrue();
         var output = await File.ReadAllTextAsync(outputFile);
@@ -253,7 +253,7 @@ public sealed class RunnerTests : IDisposable
         var exitCode = await Runner.RunAsync(args, logger);
 
         // Assert
-        exitCode.Should().Be(0);
+        exitCode.Should().Be(ExitCode.Success);
         logger.Errors.Count.Should().Be(0);
         File.Exists(outputFile).Should().BeTrue();
         var output = await File.ReadAllTextAsync(outputFile);
@@ -276,7 +276,7 @@ public sealed class RunnerTests : IDisposable
         var exitCode = await Runner.RunAsync(args, logger);
 
         // Assert
-        exitCode.Should().Be(0);
+        exitCode.Should().Be(ExitCode.Success);
         logger.Errors.Count.Should().Be(0);
         File.Exists(outputFile).Should().BeTrue();
         var output = await File.ReadAllTextAsync(outputFile);
@@ -298,7 +298,7 @@ public sealed class RunnerTests : IDisposable
         var exitCode = await Runner.RunAsync(args, logger);
 
         // Assert
-        exitCode.Should().Be(1);
+        exitCode.Should().Be(ExitCode.Failure);
         logger.Errors.Should().ContainSingle().Which.Should().StartWith("Error: Could not find file");
         File.Exists(outputFile).Should().BeFalse();
     }
@@ -317,7 +317,7 @@ public sealed class RunnerTests : IDisposable
         var exitCode = await Runner.RunAsync(args, logger);
 
         // Assert
-        exitCode.Should().Be(1);
+        exitCode.Should().Be(ExitCode.Failure);
         logger.Errors.Should().ContainSingle().Which.Should().StartWith("Error loading recipe: File not found:");
         File.Exists(outputFile).Should().BeFalse();
     }
@@ -336,7 +336,7 @@ public sealed class RunnerTests : IDisposable
         var exitCode = await Runner.RunAsync(args, logger);
 
         // Assert
-        exitCode.Should().Be(1);
+        exitCode.Should().Be(ExitCode.Failure);
         logger.Errors.Should().ContainSingle().Which.Should().Be("Unsupported format: .JSON (Standard JSON format is not supported for batch processing. Use .jsonl for JSON Lines.)");
         File.Exists(outputFile).Should().BeFalse();
     }
@@ -355,7 +355,7 @@ public sealed class RunnerTests : IDisposable
         var exitCode = await Runner.RunAsync(args, logger);
 
         // Assert
-        exitCode.Should().Be(1);
+        exitCode.Should().Be(ExitCode.Failure);
         logger.Errors.Should().ContainSingle().Which.Should().Be("Unsupported format: .JSON (Standard JSON format is not supported for batch processing. Use .jsonl for JSON Lines.)");
         File.Exists(outputFile).Should().BeFalse();
     }
@@ -374,7 +374,7 @@ public sealed class RunnerTests : IDisposable
         var exitCode = await Runner.RunAsync(args, logger);
 
         // Assert
-        exitCode.Should().Be(1);
+        exitCode.Should().Be(ExitCode.Failure);
         logger.Errors.Should().ContainSingle().Which.Should().Be("Unsupported file extension: .UNKNOWN");
         File.Exists(outputFile).Should().BeFalse();
     }
@@ -395,7 +395,7 @@ public sealed class RunnerTests : IDisposable
         var exitCode = await Runner.RunAsync(args, logger, cts.Token);
 
         // Assert
-        exitCode.Should().Be(1);
+        exitCode.Should().Be(ExitCode.Failure);
         logger.Errors.Should().ContainSingle().Which.Should().Be("Operation cancelled");
         File.Exists(outputFile).Should().BeFalse();
     }
@@ -414,7 +414,7 @@ public sealed class RunnerTests : IDisposable
         var exitCode = await Runner.RunAsync(args, logger);
 
         // Assert
-        exitCode.Should().Be(1);
+        exitCode.Should().Be(ExitCode.Failure);
         logger.Errors.Should().ContainSingle().Which.Should().StartWith("Error loading recipe: Unknown root-level key:");
         File.Exists(outputFile).Should().BeFalse();
     }
@@ -433,7 +433,7 @@ public sealed class RunnerTests : IDisposable
         var exitCode = await Runner.RunAsync(args, logger);
 
         // Assert
-        exitCode.Should().Be(0);
+        exitCode.Should().Be(ExitCode.Success);
         logger.Errors.Count.Should().Be(0);
         File.Exists(outputFile).Should().BeTrue();
         var output = await File.ReadAllTextAsync(outputFile);


### PR DESCRIPTION
Replaced magic numbers 0 and 1 with an `ExitCode` enum for improved readability and type safety in the CLI runner.