### PR TITLE
refactor: implement idempotent Dispose for CLI record readers and writers

### DIFF
--- a/src/App/Cli/CsvRecordReader.cs
+++ b/src/App/Cli/CsvRecordReader.cs
@@ -6,9 +6,10 @@ namespace DataMorph.App.Cli;
 
 internal struct CsvRecordReader : IRecordReader, IDisposable
 {
-    private readonly SepReader _reader;
     private readonly int[] _outputToSourceIndexMap;
     private readonly IReadOnlyList<FilterSpec> _filters;
+    private SepReader? _reader;
+    private bool _disposed;
 
     public CsvRecordReader(SepReader reader, BatchOutputSchema outputSchema)
     {
@@ -29,20 +30,42 @@ internal struct CsvRecordReader : IRecordReader, IDisposable
         }
 
         _filters = outputSchema.Filters;
+        _disposed = false;
     }
 
     public ValueTask<bool> MoveNextAsync(CancellationToken ct)
     {
+        ThrowIfDisposed();
+        if (_reader is null)
+        {
+            return new ValueTask<bool>(false);
+        }
         return _reader.MoveNextAsync(ct);
+    }
+
+    public readonly void ThrowIfDisposed()
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
     }
 
     public readonly bool EvaluateFilters()
     {
+        ThrowIfDisposed();
+        if (_reader is null)
+        {
+            return false;
+        }
         return FilterEvaluator.EvaluateCsvFilters(_reader.Current, _filters);
     }
 
     public readonly ReadOnlySpan<char> GetCellSpan(int outputColumnIndex)
     {
+        ThrowIfDisposed();
+        if (_reader is null)
+        {
+            return [];
+        }
+
         var sourceIndex = _outputToSourceIndexMap[outputColumnIndex];
         if (sourceIndex >= 0 && sourceIndex < _reader.Current.ColCount)
         {
@@ -53,6 +76,13 @@ internal struct CsvRecordReader : IRecordReader, IDisposable
 
     public void Dispose()
     {
-        _reader.Dispose();
+        if (_disposed)
+        {
+            return;
+        }
+
+        _reader?.Dispose();
+        _reader = null;
+        _disposed = true;
     }
 }

--- a/src/App/Cli/CsvRecordWriter.cs
+++ b/src/App/Cli/CsvRecordWriter.cs
@@ -5,19 +5,27 @@ namespace DataMorph.App.Cli;
 
 internal struct CsvRecordWriter : IRecordWriter, IDisposable, IAsyncDisposable
 {
-    private readonly StreamWriter _writer;
     private readonly BatchOutputSchema _outputSchema;
     private readonly StringBuilder _sb;
+    private StreamWriter? _writer;
+    private bool _disposed;
 
     public CsvRecordWriter(StreamWriter writer, BatchOutputSchema outputSchema)
     {
         _writer = writer;
         _outputSchema = outputSchema;
         _sb = new StringBuilder();
+        _disposed = false;
     }
 
     public async ValueTask WriteHeaderAsync(CancellationToken ct)
     {
+        ThrowIfDisposed();
+        if (_writer is null)
+        {
+            return;
+        }
+
         for (var i = 0; i < _outputSchema.Columns.Count; i++)
         {
             if (i > 0)
@@ -35,12 +43,14 @@ internal struct CsvRecordWriter : IRecordWriter, IDisposable, IAsyncDisposable
 
     public ValueTask WriteStartRecordAsync(CancellationToken ct)
     {
+        ThrowIfDisposed();
         _sb.Clear();
         return default;
     }
 
     public void WriteCellSpan(int outputColumnIndex, ReadOnlySpan<char> value)
     {
+        ThrowIfDisposed();
         if (outputColumnIndex > 0)
         {
             _sb.Append(',');
@@ -58,25 +68,55 @@ internal struct CsvRecordWriter : IRecordWriter, IDisposable, IAsyncDisposable
 
     public async ValueTask WriteEndRecordAsync(CancellationToken ct)
     {
+        ThrowIfDisposed();
+        if (_writer is null)
+        {
+            return;
+        }
+
         await _writer.WriteLineAsync(_sb.ToString().AsMemory(), ct).ConfigureAwait(false);
     }
 
     public async ValueTask FlushAsync(CancellationToken ct)
     {
+        ThrowIfDisposed();
+        if (_writer is null)
+        {
+            return;
+        }
         await _writer.FlushAsync(ct).ConfigureAwait(false);
     }
 
+    public readonly void ThrowIfDisposed()
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+    }
 
     public void Dispose()
     {
+        if (_disposed)
+        {
+            return;
+        }
+
         _writer?.Dispose();
+        _writer = null;
+        _disposed = true;
     }
 
     public async ValueTask DisposeAsync()
     {
+        if (_disposed)
+        {
+            return;
+        }
+
         if (_writer is not null)
         {
             await _writer.DisposeAsync().ConfigureAwait(false);
+            _writer = null;
         }
+
+        _disposed = true;
     }
 }

--- a/src/App/Cli/JsonLinesRecordReader.cs
+++ b/src/App/Cli/JsonLinesRecordReader.cs
@@ -9,15 +9,15 @@ namespace DataMorph.App.Cli;
 internal struct JsonLinesRecordReader : IRecordReader, IDisposable
 {
     private readonly RowIndexer _rowIndexer;
-    private readonly RowReader _rowReader;
     private readonly Memory<byte>[] _columnNameUtf8Bytes;
     private readonly Dictionary<int, ReadOnlyMemory<byte>> _filterIndexToNameBytes;
     private readonly IReadOnlyList<Engine.Filtering.FilterSpec> _filters;
-
+    private RowReader? _rowReader;
     private long _batchStart;
     private IReadOnlyList<ReadOnlyMemory<byte>> _currentBatch;
     private int _batchIndex;
     private ReadOnlyMemory<byte> _currentLineBytes;
+    private bool _disposed;
 
     public JsonLinesRecordReader(RowIndexer rowIndexer, RowReader rowReader, TableSchema inputSchema, BatchOutputSchema outputSchema)
     {
@@ -36,10 +36,17 @@ internal struct JsonLinesRecordReader : IRecordReader, IDisposable
         _currentBatch = [];
         _batchIndex = -1;
         _currentLineBytes = default;
+        _disposed = false;
     }
 
     public ValueTask<bool> MoveNextAsync(CancellationToken ct)
     {
+        ThrowIfDisposed();
+        if (_rowReader is null)
+        {
+            return new ValueTask<bool>(false);
+        }
+
         while (true)
         {
             _batchIndex++;
@@ -69,13 +76,20 @@ internal struct JsonLinesRecordReader : IRecordReader, IDisposable
         }
     }
 
+    public readonly void ThrowIfDisposed()
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+    }
+
     public readonly bool EvaluateFilters()
     {
+        ThrowIfDisposed();
         return FilterEvaluator.EvaluateJsonFilters(_currentLineBytes, (IReadOnlyList<FilterSpec>)_filters, _filterIndexToNameBytes);
     }
 
     public readonly ReadOnlySpan<char> GetCellSpan(int outputColumnIndex)
     {
+        ThrowIfDisposed();
         var columnNameSpan = _columnNameUtf8Bytes[outputColumnIndex].Span;
         var value = CellExtractor.ExtractCell(_currentLineBytes.Span, columnNameSpan);
         return value.AsSpan();
@@ -83,6 +97,13 @@ internal struct JsonLinesRecordReader : IRecordReader, IDisposable
 
     public void Dispose()
     {
-        _rowReader.Dispose();
+        if (_disposed)
+        {
+            return;
+        }
+
+        _rowReader?.Dispose();
+        _rowReader = null;
+        _disposed = true;
     }
 }

--- a/src/App/Cli/JsonLinesRecordWriter.cs
+++ b/src/App/Cli/JsonLinesRecordWriter.cs
@@ -7,11 +7,12 @@ namespace DataMorph.App.Cli;
 
 internal struct JsonLinesRecordWriter : IRecordWriter, IDisposable, IAsyncDisposable
 {
-    private readonly StreamWriter _writer;
     private readonly BatchOutputSchema _outputSchema;
-    private readonly byte[] _buffer;
-    private readonly MemoryStream _ms;
-    private readonly Utf8JsonWriter _jsonWriter;
+    private StreamWriter? _writer;
+    private byte[]? _buffer;
+    private MemoryStream? _ms;
+    private Utf8JsonWriter? _jsonWriter;
+    private bool _disposed;
 
     public JsonLinesRecordWriter(StreamWriter writer, byte[] buffer, MemoryStream ms, Utf8JsonWriter jsonWriter, BatchOutputSchema outputSchema)
     {
@@ -20,15 +21,23 @@ internal struct JsonLinesRecordWriter : IRecordWriter, IDisposable, IAsyncDispos
         _ms = ms;
         _jsonWriter = jsonWriter;
         _outputSchema = outputSchema;
+        _disposed = false;
     }
 
     public ValueTask WriteHeaderAsync(CancellationToken ct)
     {
+        ThrowIfDisposed();
         return default;
     }
 
     public ValueTask WriteStartRecordAsync(CancellationToken ct)
     {
+        ThrowIfDisposed();
+        if (_ms is null || _jsonWriter is null)
+        {
+            return default;
+        }
+
         _ms.SetLength(0);
         _jsonWriter.Reset(_ms);
         _jsonWriter.WriteStartObject();
@@ -37,6 +46,12 @@ internal struct JsonLinesRecordWriter : IRecordWriter, IDisposable, IAsyncDispos
 
     public void WriteCellSpan(int outputColumnIndex, ReadOnlySpan<char> value)
     {
+        ThrowIfDisposed();
+        if (_jsonWriter is null)
+        {
+            return;
+        }
+
         var colName = _outputSchema.Columns[outputColumnIndex].OutputName;
         _jsonWriter.WritePropertyName(colName);
         WriteJsonValue(_jsonWriter, value);
@@ -44,6 +59,12 @@ internal struct JsonLinesRecordWriter : IRecordWriter, IDisposable, IAsyncDispos
 
     public async ValueTask WriteEndRecordAsync(CancellationToken ct)
     {
+        ThrowIfDisposed();
+        if (_jsonWriter is null || _ms is null || _writer is null || _buffer is null)
+        {
+            return;
+        }
+
         _jsonWriter.WriteEndObject();
         await _jsonWriter.FlushAsync(ct).ConfigureAwait(false);
 
@@ -53,6 +74,11 @@ internal struct JsonLinesRecordWriter : IRecordWriter, IDisposable, IAsyncDispos
 
     public async ValueTask FlushAsync(CancellationToken ct)
     {
+        ThrowIfDisposed();
+        if (_writer is null)
+        {
+            return;
+        }
         await _writer.FlushAsync(ct).ConfigureAwait(false);
     }
 
@@ -97,34 +123,59 @@ internal struct JsonLinesRecordWriter : IRecordWriter, IDisposable, IAsyncDispos
         writer.WriteStringValue(value);
     }
 
+    public readonly void ThrowIfDisposed()
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+    }
+
     public void Dispose()
     {
+        if (_disposed)
+        {
+            return;
+        }
+
         _jsonWriter?.Dispose();
+        _jsonWriter = null;
         _ms?.Dispose();
+        _ms = null;
         _writer?.Dispose();
+        _writer = null;
         if (_buffer is not null)
         {
             System.Buffers.ArrayPool<byte>.Shared.Return(_buffer);
+            _buffer = null;
         }
+        _disposed = true;
     }
 
     public async ValueTask DisposeAsync()
     {
+        if (_disposed)
+        {
+            return;
+        }
+
         if (_jsonWriter is not null)
         {
             await _jsonWriter.DisposeAsync().ConfigureAwait(false);
+            _jsonWriter = null;
         }
         if (_ms is not null)
         {
             await _ms.DisposeAsync().ConfigureAwait(false);
+            _ms = null;
         }
         if (_writer is not null)
         {
             await _writer.DisposeAsync().ConfigureAwait(false);
+            _writer = null;
         }
         if (_buffer is not null)
         {
             System.Buffers.ArrayPool<byte>.Shared.Return(_buffer);
+            _buffer = null;
         }
+        _disposed = true;
     }
 }


### PR DESCRIPTION
Implements idempotent Dispose and DisposeAsync patterns for CsvRecordReader, CsvRecordWriter, JsonLinesRecordReader, and JsonLinesRecordWriter in `App/Cli`.