### PR TITLE
fix: add Table null check in OnKeyDown methods

### DIFF
--- a/src/App/Views/CsvTableView.cs
+++ b/src/App/Views/CsvTableView.cs
@@ -31,6 +31,11 @@ internal sealed class CsvTableView : TableView
     /// <inheritdoc/>
     protected override bool OnKeyDown(Key key)
     {
+        if (Table is null)
+        {
+            throw new InvalidOperationException("Table cannot be null");
+        }
+
         if (key.KeyCode == (KeyCode.R | KeyCode.ShiftMask))
         {
             return HandleRenameColumn();

--- a/src/App/Views/JsonLinesTableView.cs
+++ b/src/App/Views/JsonLinesTableView.cs
@@ -45,6 +45,11 @@ internal sealed class JsonLinesTableView : TableView
     /// <inheritdoc/>
     protected override bool OnKeyDown(Key key)
     {
+        if (Table is null)
+        {
+            throw new InvalidOperationException("Table cannot be null");
+        }
+
         if (key.KeyCode == KeyCode.T)
         {
             _onTableModeToggle();


### PR DESCRIPTION
After Terminal.Gui upgrade, TableView.Table property became nullable.
Added exception to handle unreachable null case in JsonLinesTableView
and CsvTableView to satisfy compiler null safety checks.