### PR TITLE
chore: upgrade .NET SDK from 10.0.101 to 10.0.201

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "10.0.101",
+    "version": "10.0.201",
     "rollForward": "latestFeature",
     "allowPrerelease": true
   }


### PR DESCRIPTION
Update `global.json` to pin the .NET SDK to `10.0.201`, which is the latest installed patch in the 10.0 feature band.