### PR TITLE
fix: use raw column names for morph action creation

### DIFF
--- a/src/App/ViewManager.cs
+++ b/src/App/ViewManager.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Text;
 using DataMorph.Engine.IO.Csv;
@@ -72,6 +73,13 @@ internal sealed class ViewManager : IDisposable
             )
             : rawSource;
 
+        Func<int, string> getRawColumnName = source switch
+        {
+            Views.LazyTransformer lt => i => lt.RawColumnNames[i],
+            Views.VirtualTableSource vts => i => vts.RawColumnNames[i],
+            _ => throw new UnreachableException(),
+        };
+
         var view = new Views.CsvTableView
         {
             X = 0,
@@ -81,6 +89,7 @@ internal sealed class ViewManager : IDisposable
             Table = source,
             Style = new TableStyle { AlwaysShowHeaders = true },
             OnMorphAction = HandleMorphAction,
+            GetRawColumnName = getRawColumnName,
         };
         SwapView(view);
 
@@ -150,7 +159,18 @@ internal sealed class ViewManager : IDisposable
             )
             : source;
 
-        var view = new Views.JsonLinesTableView(() => _ = _onToggle(), HandleMorphAction)
+        Func<int, string> getRawColumnName = tableSource switch
+        {
+            Views.LazyTransformer lt => i => lt.RawColumnNames[i],
+            Views.JsonLinesTableSource jts => i => jts.RawColumnNames[i],
+            _ => throw new UnreachableException(),
+        };
+
+        var view = new Views.JsonLinesTableView(
+            () => _ = _onToggle(),
+            HandleMorphAction,
+            getRawColumnName: getRawColumnName
+        )
         {
             X = 0,
             Y = 0,

--- a/src/App/Views/CsvTableView.cs
+++ b/src/App/Views/CsvTableView.cs
@@ -28,6 +28,12 @@ internal sealed class CsvTableView : TableView
     /// </summary>
     internal Func<bool>? IsRowIndexComplete { get; init; }
 
+    /// <summary>
+    /// Resolves a column index to the raw (un-labeled) column name for action creation.
+    /// When <see langword="null"/>, morphing is disabled (same guard as <see cref="OnMorphAction"/>).
+    /// </summary>
+    internal Func<int, string>? GetRawColumnName { get; init; }
+
     /// <inheritdoc/>
     protected override bool OnKeyDown(Key key)
     {
@@ -104,13 +110,14 @@ internal sealed class CsvTableView : TableView
 
     private bool HandleRenameColumn()
     {
-        if (App is null || OnMorphAction is null || Table is null || SelectedColumn < 0)
+        if (App is null || OnMorphAction is null || GetRawColumnName is null
+            || Table is null || SelectedColumn < 0)
         {
             return true;
         }
 
-        var columnName = Table.ColumnNames[SelectedColumn];
-        using var dialog = new RenameColumnDialog(columnName);
+        var rawName = GetRawColumnName(SelectedColumn);
+        using var dialog = new RenameColumnDialog(rawName);
         App.Run(dialog);
 
         if (!dialog.Confirmed || dialog.NewName is null)
@@ -118,19 +125,21 @@ internal sealed class CsvTableView : TableView
             return true;
         }
 
-        OnMorphAction(new RenameColumnAction { OldName = columnName, NewName = dialog.NewName });
+        OnMorphAction(new RenameColumnAction { OldName = rawName, NewName = dialog.NewName });
         return true;
     }
 
     private bool HandleDeleteColumn()
     {
-        if (App is null || OnMorphAction is null || Table is null || SelectedColumn < 0)
+        if (App is null || OnMorphAction is null || GetRawColumnName is null
+            || Table is null || SelectedColumn < 0)
         {
             return true;
         }
 
-        var columnName = Table.ColumnNames[SelectedColumn];
-        using var dialog = new DeleteColumnDialog(columnName);
+        var displayName = Table.ColumnNames[SelectedColumn];
+        var rawName = GetRawColumnName(SelectedColumn);
+        using var dialog = new DeleteColumnDialog(displayName);
         App.Run(dialog);
 
         if (!dialog.Confirmed)
@@ -138,19 +147,21 @@ internal sealed class CsvTableView : TableView
             return true;
         }
 
-        OnMorphAction(new DeleteColumnAction { ColumnName = columnName });
+        OnMorphAction(new DeleteColumnAction { ColumnName = rawName });
         return true;
     }
 
     private bool HandleCastColumn()
     {
-        if (App is null || OnMorphAction is null || Table is null || SelectedColumn < 0)
+        if (App is null || OnMorphAction is null || GetRawColumnName is null
+            || Table is null || SelectedColumn < 0)
         {
             return true;
         }
 
-        var columnName = Table.ColumnNames[SelectedColumn];
-        using var dialog = new CastColumnDialog(columnName, ColumnType.Text);
+        var displayName = Table.ColumnNames[SelectedColumn];
+        var rawName = GetRawColumnName(SelectedColumn);
+        using var dialog = new CastColumnDialog(displayName, ColumnType.Text);
         App.Run(dialog);
 
         if (!dialog.Confirmed || dialog.SelectedType is null)
@@ -159,14 +170,15 @@ internal sealed class CsvTableView : TableView
         }
 
         OnMorphAction(
-            new CastColumnAction { ColumnName = columnName, TargetType = dialog.SelectedType.Value }
+            new CastColumnAction { ColumnName = rawName, TargetType = dialog.SelectedType.Value }
         );
         return true;
     }
 
     private bool HandleFilterColumn()
     {
-        if (App is null || OnMorphAction is null || Table is null || SelectedColumn < 0)
+        if (App is null || OnMorphAction is null || GetRawColumnName is null
+            || Table is null || SelectedColumn < 0)
         {
             return true;
         }
@@ -177,8 +189,9 @@ internal sealed class CsvTableView : TableView
             return true;
         }
 
-        var columnName = Table.ColumnNames[SelectedColumn];
-        using var dialog = new FilterColumnDialog(columnName);
+        var displayName = Table.ColumnNames[SelectedColumn];
+        var rawName = GetRawColumnName(SelectedColumn);
+        using var dialog = new FilterColumnDialog(displayName);
         App.Run(dialog);
 
         if (!dialog.Confirmed || dialog.SelectedOperator is null || dialog.Value is null)
@@ -189,7 +202,7 @@ internal sealed class CsvTableView : TableView
         OnMorphAction(
             new FilterAction
             {
-                ColumnName = columnName,
+                ColumnName = rawName,
                 Operator = dialog.SelectedOperator.Value,
                 Value = dialog.Value,
             }
@@ -199,13 +212,15 @@ internal sealed class CsvTableView : TableView
 
     private bool HandleFillColumn()
     {
-        if (App is null || OnMorphAction is null || Table is null || SelectedColumn < 0)
+        if (App is null || OnMorphAction is null || GetRawColumnName is null
+            || Table is null || SelectedColumn < 0)
         {
             return true;
         }
 
-        var columnName = Table.ColumnNames[SelectedColumn];
-        using var dialog = new FillColumnDialog(columnName);
+        var displayName = Table.ColumnNames[SelectedColumn];
+        var rawName = GetRawColumnName(SelectedColumn);
+        using var dialog = new FillColumnDialog(displayName);
         App.Run(dialog);
 
         if (!dialog.Confirmed)
@@ -213,7 +228,7 @@ internal sealed class CsvTableView : TableView
             return true;
         }
 
-        OnMorphAction(new FillColumnAction { ColumnName = columnName, Value = dialog.Value });
+        OnMorphAction(new FillColumnAction { ColumnName = rawName, Value = dialog.Value });
         return true;
     }
 }

--- a/src/App/Views/JsonLinesTableSource.cs
+++ b/src/App/Views/JsonLinesTableSource.cs
@@ -14,6 +14,7 @@ internal sealed class JsonLinesTableSource : ITableSource
     private readonly RowByteCache _cache;
     private volatile TableSchema _schema;
     private volatile string[] _columnNames;
+    private volatile string[] _rawColumnNames;
     private volatile byte[][] _columnNameUtf8;
 
     /// <summary>
@@ -28,6 +29,7 @@ internal sealed class JsonLinesTableSource : ITableSource
         _cache = cache;
         _schema = schema;
         _columnNames = BuildColumnNames(schema);
+        _rawColumnNames = BuildRawColumnNames(schema);
         _columnNameUtf8 = BuildColumnNamesUtf8(schema);
     }
 
@@ -39,6 +41,8 @@ internal sealed class JsonLinesTableSource : ITableSource
 
     /// <inheritdoc/>
     public string[] ColumnNames => _columnNames;
+
+    internal string[] RawColumnNames => _rawColumnNames;
 
     /// <inheritdoc/>
     public object this[int row, int col]
@@ -76,14 +80,19 @@ internal sealed class JsonLinesTableSource : ITableSource
     {
         ArgumentNullException.ThrowIfNull(schema);
         var newColumnNames = BuildColumnNames(schema);
+        var newRawColumnNames = BuildRawColumnNames(schema);
         var newColumnNameUtf8 = BuildColumnNamesUtf8(schema);
         _columnNames = newColumnNames;
+        _rawColumnNames = newRawColumnNames;
         _columnNameUtf8 = newColumnNameUtf8;
         _schema = schema;
     }
 
     private static string[] BuildColumnNames(TableSchema schema) =>
         [.. schema.Columns.Select(c => $"{c.Name} ({ColumnTypeLabel.ToLabel(c.Type)})")];
+
+    private static string[] BuildRawColumnNames(TableSchema schema) =>
+        [.. schema.Columns.Select(c => c.Name)];
 
     private static byte[][] BuildColumnNamesUtf8(TableSchema schema) =>
         [.. schema.Columns.Select(c => Encoding.UTF8.GetBytes(c.Name))];

--- a/src/App/Views/JsonLinesTableView.cs
+++ b/src/App/Views/JsonLinesTableView.cs
@@ -16,6 +16,7 @@ internal sealed class JsonLinesTableView : TableView
     private readonly Action _onTableModeToggle;
     private readonly Action<MorphAction>? _onMorphAction;
     private readonly Func<bool>? _isRowIndexComplete;
+    private readonly Func<int, string>? _getRawColumnName;
     private readonly VimKeyTranslator _vimKeys = new();
 
     /// <summary>
@@ -31,15 +32,22 @@ internal sealed class JsonLinesTableView : TableView
     /// <c>BuildIndex</c> has completed. When <see langword="null"/>, the guard is skipped.
     /// The <c>Shift+F</c> filter action is blocked until this returns <see langword="true"/>.
     /// </param>
+    /// <param name="getRawColumnName">
+    /// Optional delegate that resolves a column index to its raw (unlabeled) schema name.
+    /// Used when constructing <see cref="MorphAction"/>s to avoid embedding type labels in
+    /// action column names. When <see langword="null"/>, morphing actions are disabled.
+    /// </param>
     internal JsonLinesTableView(
         Action onTableModeToggle,
         Action<MorphAction>? onMorphAction = null,
-        Func<bool>? isRowIndexComplete = null
+        Func<bool>? isRowIndexComplete = null,
+        Func<int, string>? getRawColumnName = null
     )
     {
         _onTableModeToggle = onTableModeToggle;
         _onMorphAction = onMorphAction;
         _isRowIndexComplete = isRowIndexComplete;
+        _getRawColumnName = getRawColumnName;
     }
 
     /// <inheritdoc/>
@@ -124,13 +132,14 @@ internal sealed class JsonLinesTableView : TableView
 
     private bool HandleRenameColumn()
     {
-        if (App is null || _onMorphAction is null || Table is null || SelectedColumn < 0)
+        if (App is null || _onMorphAction is null || _getRawColumnName is null
+            || Table is null || SelectedColumn < 0)
         {
             return true;
         }
 
-        var columnName = Table.ColumnNames[SelectedColumn];
-        using var dialog = new RenameColumnDialog(columnName);
+        var rawName = _getRawColumnName(SelectedColumn);
+        using var dialog = new RenameColumnDialog(rawName);
         App.Run(dialog);
 
         if (!dialog.Confirmed || dialog.NewName is null)
@@ -138,19 +147,21 @@ internal sealed class JsonLinesTableView : TableView
             return true;
         }
 
-        _onMorphAction(new RenameColumnAction { OldName = columnName, NewName = dialog.NewName });
+        _onMorphAction(new RenameColumnAction { OldName = rawName, NewName = dialog.NewName });
         return true;
     }
 
     private bool HandleDeleteColumn()
     {
-        if (App is null || _onMorphAction is null || Table is null || SelectedColumn < 0)
+        if (App is null || _onMorphAction is null || _getRawColumnName is null
+            || Table is null || SelectedColumn < 0)
         {
             return true;
         }
 
-        var columnName = Table.ColumnNames[SelectedColumn];
-        using var dialog = new DeleteColumnDialog(columnName);
+        var displayName = Table.ColumnNames[SelectedColumn];
+        var rawName = _getRawColumnName(SelectedColumn);
+        using var dialog = new DeleteColumnDialog(displayName);
         App.Run(dialog);
 
         if (!dialog.Confirmed)
@@ -158,19 +169,21 @@ internal sealed class JsonLinesTableView : TableView
             return true;
         }
 
-        _onMorphAction(new DeleteColumnAction { ColumnName = columnName });
+        _onMorphAction(new DeleteColumnAction { ColumnName = rawName });
         return true;
     }
 
     private bool HandleCastColumn()
     {
-        if (App is null || _onMorphAction is null || Table is null || SelectedColumn < 0)
+        if (App is null || _onMorphAction is null || _getRawColumnName is null
+            || Table is null || SelectedColumn < 0)
         {
             return true;
         }
 
-        var columnName = Table.ColumnNames[SelectedColumn];
-        using var dialog = new CastColumnDialog(columnName, ColumnType.Text);
+        var displayName = Table.ColumnNames[SelectedColumn];
+        var rawName = _getRawColumnName(SelectedColumn);
+        using var dialog = new CastColumnDialog(displayName, ColumnType.Text);
         App.Run(dialog);
 
         if (!dialog.Confirmed || dialog.SelectedType is null)
@@ -179,14 +192,15 @@ internal sealed class JsonLinesTableView : TableView
         }
 
         _onMorphAction(
-            new CastColumnAction { ColumnName = columnName, TargetType = dialog.SelectedType.Value }
+            new CastColumnAction { ColumnName = rawName, TargetType = dialog.SelectedType.Value }
         );
         return true;
     }
 
     private bool HandleFilterColumn()
     {
-        if (App is null || _onMorphAction is null || Table is null || SelectedColumn < 0)
+        if (App is null || _onMorphAction is null || _getRawColumnName is null
+            || Table is null || SelectedColumn < 0)
         {
             return true;
         }
@@ -197,8 +211,9 @@ internal sealed class JsonLinesTableView : TableView
             return true;
         }
 
-        var columnName = Table.ColumnNames[SelectedColumn];
-        using var dialog = new FilterColumnDialog(columnName);
+        var displayName = Table.ColumnNames[SelectedColumn];
+        var rawName = _getRawColumnName(SelectedColumn);
+        using var dialog = new FilterColumnDialog(displayName);
         App.Run(dialog);
 
         if (!dialog.Confirmed || dialog.SelectedOperator is null || dialog.Value is null)
@@ -209,7 +224,7 @@ internal sealed class JsonLinesTableView : TableView
         _onMorphAction(
             new FilterAction
             {
-                ColumnName = columnName,
+                ColumnName = rawName,
                 Operator = dialog.SelectedOperator.Value,
                 Value = dialog.Value,
             }
@@ -219,13 +234,15 @@ internal sealed class JsonLinesTableView : TableView
 
     private bool HandleFillColumn()
     {
-        if (App is null || _onMorphAction is null || Table is null || SelectedColumn < 0)
+        if (App is null || _onMorphAction is null || _getRawColumnName is null
+            || Table is null || SelectedColumn < 0)
         {
             return true;
         }
 
-        var columnName = Table.ColumnNames[SelectedColumn];
-        using var dialog = new FillColumnDialog(columnName);
+        var displayName = Table.ColumnNames[SelectedColumn];
+        var rawName = _getRawColumnName(SelectedColumn);
+        using var dialog = new FillColumnDialog(displayName);
         App.Run(dialog);
 
         if (!dialog.Confirmed)
@@ -233,7 +250,7 @@ internal sealed class JsonLinesTableView : TableView
             return true;
         }
 
-        _onMorphAction(new FillColumnAction { ColumnName = columnName, Value = dialog.Value });
+        _onMorphAction(new FillColumnAction { ColumnName = rawName, Value = dialog.Value });
         return true;
     }
 }

--- a/src/App/Views/LazyTransformer.cs
+++ b/src/App/Views/LazyTransformer.cs
@@ -1,5 +1,6 @@
 using System.Globalization;
 using DataMorph.Engine.Filtering;
+using DataMorph.Engine.IO.Csv;
 using DataMorph.Engine.Models;
 using DataMorph.Engine.Models.Actions;
 using DataMorph.Engine.Types;
@@ -21,6 +22,7 @@ internal sealed class LazyTransformer : ITableSource
     private readonly ITableSource _source;
     private readonly IReadOnlyList<int> _sourceColumnIndices;
     private readonly string[] _columnNames;
+    private readonly string[] _rawColumnNames;
     private readonly IReadOnlyList<ColumnType> _columnTypes;
     private readonly IReadOnlyList<string?> _fillValues;
     private readonly IFilterRowIndexer? _filterRowIndexer;
@@ -50,7 +52,7 @@ internal sealed class LazyTransformer : ITableSource
         ArgumentNullException.ThrowIfNull(actions);
 
         _source = source;
-        (_columnNames, _columnTypes, _sourceColumnIndices, _fillValues, var filterSpecs) =
+        (_columnNames, _rawColumnNames, _columnTypes, _sourceColumnIndices, _fillValues, var filterSpecs) =
             BuildTransformedSchema(originalSchema, actions);
 
         if (filterSpecs.Count > 0 && filterRowIndexerFactory is not null)
@@ -80,6 +82,13 @@ internal sealed class LazyTransformer : ITableSource
 
     /// <inheritdoc/>
     public string[] ColumnNames => _columnNames;
+
+    /// <summary>
+    /// Gets the raw (unlabeled) column names in output order.
+    /// Use these when constructing <see cref="MorphAction"/>s so that action
+    /// <c>ColumnName</c> values match the schema names used inside <see cref="BuildTransformedSchema"/>.
+    /// </summary>
+    internal string[] RawColumnNames => _rawColumnNames;
 
     /// <inheritdoc/>
     public object this[int row, int col]
@@ -127,6 +136,7 @@ internal sealed class LazyTransformer : ITableSource
     /// </summary>
     private static (
         string[] columnNames,
+        string[] rawColumnNames,
         IReadOnlyList<ColumnType> columnTypes,
         IReadOnlyList<int> sourceColumnIndices,
         IReadOnlyList<string?> fillValues,
@@ -204,7 +214,8 @@ internal sealed class LazyTransformer : ITableSource
                     continue;
                 }
 
-                working[fillIdx] = working[fillIdx] with { FillValue = fill.Value };
+                var inferredType = TypeInferrer.InferType(fill.Value.AsSpan());
+                working[fillIdx] = working[fillIdx] with { FillValue = fill.Value, Type = inferredType };
                 continue;
             }
         }
@@ -217,6 +228,9 @@ internal sealed class LazyTransformer : ITableSource
         }
 
         return (
+            remaining
+                .ConvertAll(workingColumn => $"{workingColumn.Name} ({ColumnTypeLabel.ToLabel(workingColumn.Type)})")
+                .ToArray(),
             remaining.ConvertAll(workingColumn => workingColumn.Name).ToArray(),
             remaining.ConvertAll(workingColumn => workingColumn.Type),
             remaining.ConvertAll(workingColumn => workingColumn.SourceIndex),

--- a/src/App/Views/VirtualTableSource.cs
+++ b/src/App/Views/VirtualTableSource.cs
@@ -13,17 +13,20 @@ internal sealed class VirtualTableSource : ITableSource
     private readonly DataRowCache _cache;
     private readonly TableSchema _schema;
     private readonly string[] _columnNames;
+    private readonly string[] _rawColumnNames;
 
     public VirtualTableSource(DataRowIndexer indexer, TableSchema schema)
     {
         _schema = schema;
         _columnNames = [.. _schema.Columns.Select(c => $"{c.Name} ({ColumnTypeLabel.ToLabel(c.Type)})")];
+        _rawColumnNames = [.. _schema.Columns.Select(c => c.Name)];
         _cache = new DataRowCache(indexer, _schema.ColumnCount);
     }
 
     public int Rows => _cache.TotalRows;
     public int Columns => _schema.ColumnCount;
     public string[] ColumnNames => _columnNames;
+    internal string[] RawColumnNames => _rawColumnNames;
 
     public object this[int row, int col]
     {

--- a/tests/DataMorph.Tests/App/Views/LazyTransformerTests.cs
+++ b/tests/DataMorph.Tests/App/Views/LazyTransformerTests.cs
@@ -137,8 +137,8 @@ public sealed class LazyTransformerTests
         var transformer = new LazyTransformer(source, schema, actions);
 
         // Assert
-        transformer.ColumnNames[0].Should().Be("X");
-        transformer.ColumnNames[1].Should().Be("B");
+        transformer.ColumnNames[0].Should().Be("X (text)");
+        transformer.ColumnNames[1].Should().Be("B (text)");
     }
 
     [Fact]
@@ -191,7 +191,7 @@ public sealed class LazyTransformerTests
 
         // Assert
         transformer.Columns.Should().Be(2);
-        transformer.ColumnNames.Should().BeEquivalentTo(["A", "C"], o => o.WithStrictOrdering());
+        transformer.ColumnNames.Should().BeEquivalentTo(["A (text)", "C (text)"], o => o.WithStrictOrdering());
     }
 
     [Fact]
@@ -293,7 +293,7 @@ public sealed class LazyTransformerTests
 
         // Assert
         transformer.Columns.Should().Be(1);
-        transformer.ColumnNames[0].Should().Be("B");
+        transformer.ColumnNames[0].Should().Be("B (text)");
     }
 
     // -------------------------------------------------------------------------
@@ -570,7 +570,7 @@ public sealed class LazyTransformerTests
         var names = transformer.ColumnNames;
 
         // Assert
-        names.Should().BeEquivalentTo(["X", "B"], o => o.WithStrictOrdering());
+        names.Should().BeEquivalentTo(["X (text)", "B (text)"], o => o.WithStrictOrdering());
     }
 
     // -------------------------------------------------------------------------
@@ -947,6 +947,7 @@ public sealed class LazyTransformerTests
         var transformer = new LazyTransformer(source, schema, actions);
 
         // Assert
+        transformer.ColumnNames[0].Should().Be("X (text)");
         transformer[0, 0].Should().Be("FILLED");
         transformer[0, 1].Should().Be("b1");
     }
@@ -1025,7 +1026,7 @@ public sealed class LazyTransformerTests
         var transformer = new LazyTransformer(source, schema, actions);
 
         // Assert
-        transformer.ColumnNames[0].Should().Be("X");
+        transformer.ColumnNames[0].Should().Be("X (text)");
         transformer[0, 0].Should().Be("FILLED");
     }
 
@@ -1080,9 +1081,194 @@ public sealed class LazyTransformerTests
         // Assert
         // All three columns should be present after fill action
         transformer.ColumnNames.Should().HaveCount(3);
-        transformer.ColumnNames[0].Should().Be("A");
-        transformer.ColumnNames[1].Should().Be("B");
-        transformer.ColumnNames[2].Should().Be("C");
+        transformer.ColumnNames[0].Should().Be("A (text)");
+        transformer.ColumnNames[1].Should().Be("B (text)");
+        transformer.ColumnNames[2].Should().Be("C (text)");
         transformer.Columns.Should().Be(3);
+    }
+
+    // -------------------------------------------------------------------------
+    // RawColumnNames — unlabeled raw names
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void RawColumnNames_EmptyActionStack_ReturnsSchemaNames()
+    {
+        // Arrange
+        var source = new FakeTableSource(
+            [
+                ["42", "hello"],
+            ],
+            ["Age", "Name"]
+        );
+        var schema = MakeSchema(("Age", ColumnType.WholeNumber), ("Name", ColumnType.Text));
+
+        // Act
+        var transformer = new LazyTransformer(source, schema, []);
+
+        // Assert
+        transformer.RawColumnNames[0].Should().Be("Age");
+        transformer.RawColumnNames[1].Should().Be("Name");
+    }
+
+    [Fact]
+    public void RawColumnNames_WithRenameAction_ReflectsNewName()
+    {
+        // Arrange
+        var source = new FakeTableSource(
+            [
+                ["hello", "world"],
+            ],
+            ["A", "B"]
+        );
+        var schema = MakeSchema(("A", ColumnType.Text), ("B", ColumnType.Text));
+        IReadOnlyList<MorphAction> actions =
+        [
+            new RenameColumnAction { OldName = "A", NewName = "X" },
+        ];
+
+        // Act
+        var transformer = new LazyTransformer(source, schema, actions);
+
+        // Assert
+        transformer.RawColumnNames[0].Should().Be("X");
+        transformer.RawColumnNames[1].Should().Be("B");
+    }
+
+    [Fact]
+    public void RawColumnNames_WithDeleteAction_ExcludesDeletedColumn()
+    {
+        // Arrange
+        var source = new FakeTableSource(
+            [
+                ["a", "b", "c"],
+            ],
+            ["A", "B", "C"]
+        );
+        var schema = MakeSchema(
+            ("A", ColumnType.Text),
+            ("B", ColumnType.Text),
+            ("C", ColumnType.Text)
+        );
+        IReadOnlyList<MorphAction> actions = [new DeleteColumnAction { ColumnName = "B" }];
+
+        // Act
+        var transformer = new LazyTransformer(source, schema, actions);
+
+        // Assert
+        transformer.RawColumnNames.Should().BeEquivalentTo(["A", "C"], o => o.WithStrictOrdering());
+    }
+
+    [Fact]
+    public void ColumnNames_WithCastAction_ReflectsNewTypeLabel()
+    {
+        // Arrange
+        var source = new FakeTableSource([["42"]], ["A"]);
+        var schema = MakeSchema(("A", ColumnType.Text));
+        IReadOnlyList<MorphAction> actions =
+        [
+            new CastColumnAction { ColumnName = "A", TargetType = ColumnType.WholeNumber },
+        ];
+
+        // Act
+        var transformer = new LazyTransformer(source, schema, actions);
+
+        // Assert
+        transformer.ColumnNames[0].Should().Be("A (number)");
+        transformer.RawColumnNames[0].Should().Be("A");
+    }
+
+    [Fact]
+    public void ColumnNames_EmptyActionStack_ReturnsLabeledNames()
+    {
+        // Arrange
+        var source = new FakeTableSource(
+            [
+                ["42", "hello"],
+            ],
+            ["Age", "Name"]
+        );
+        var schema = MakeSchema(("Age", ColumnType.WholeNumber), ("Name", ColumnType.Text));
+
+        // Act
+        var transformer = new LazyTransformer(source, schema, []);
+
+        // Assert
+        transformer.ColumnNames[0].Should().Be("Age (number)");
+        transformer.ColumnNames[1].Should().Be("Name (text)");
+    }
+
+    // -------------------------------------------------------------------------
+    // Fill — type inference
+    // -------------------------------------------------------------------------
+
+    [Theory]
+    [InlineData("42", "number")]
+    [InlineData("3.14", "float")]
+    [InlineData("true", "bool")]
+    [InlineData("hello", "text")]
+    [InlineData("", "text")]
+    public void FillColumnAction_InfersTypeFromValue_HeaderLabelUpdated(
+        string fillValue,
+        string expectedLabel
+    )
+    {
+        // Arrange
+        var source = new FakeTableSource(
+            [
+                ["original"],
+            ],
+            ["A"]
+        );
+        var schema = MakeSchema(("A", ColumnType.WholeNumber));
+        IReadOnlyList<MorphAction> actions =
+        [
+            new FillColumnAction { ColumnName = "A", Value = fillValue },
+        ];
+
+        // Act
+        var transformer = new LazyTransformer(source, schema, actions);
+
+        // Assert
+        transformer.ColumnNames[0].Should().Be($"A ({expectedLabel})");
+        transformer.RawColumnNames[0].Should().Be("A");
+    }
+
+    [Fact]
+    public void FillColumnAction_NumberColumnFilledWithText_TypeChangesToText()
+    {
+        // Arrange
+        var source = new FakeTableSource([["100"]], ["Price"]);
+        var schema = MakeSchema(("Price", ColumnType.WholeNumber));
+        IReadOnlyList<MorphAction> actions =
+        [
+            new FillColumnAction { ColumnName = "Price", Value = "N/A" },
+        ];
+
+        // Act
+        var transformer = new LazyTransformer(source, schema, actions);
+
+        // Assert
+        transformer.ColumnNames[0].Should().Be("Price (text)");
+        transformer[0, 0].Should().Be("N/A");
+    }
+
+    [Fact]
+    public void FillColumnAction_TextColumnFilledWithNumber_TypeChangesToNumber()
+    {
+        // Arrange
+        var source = new FakeTableSource([["hello"]], ["Value"]);
+        var schema = MakeSchema(("Value", ColumnType.Text));
+        IReadOnlyList<MorphAction> actions =
+        [
+            new FillColumnAction { ColumnName = "Value", Value = "42" },
+        ];
+
+        // Act
+        var transformer = new LazyTransformer(source, schema, actions);
+
+        // Assert
+        transformer.ColumnNames[0].Should().Be("Value (number)");
+        transformer[0, 0].Should().Be("42");
     }
 }


### PR DESCRIPTION
## Summary

- Add `RawColumnNames` to `LazyTransformer`, `VirtualTableSource`, and `JsonLinesTableSource`
- Wire `GetRawColumnName` delegate in views so morph actions receive raw schema names instead of labeled display names (e.g. `"salary"` instead of `"salary (number)"`)
- Infer column type from fill value and align `ColumnNames` label format across all sources

Closes #153