### PR TITLE
chore: ignore .working/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,3 +97,4 @@ Desktop.ini
 *.local.*
 
 .aider*
+.working/


### PR DESCRIPTION
This PR adds the  directory to  to prevent temporary working files from being tracked.