### PR TITLE
chore: extract terminal-gui-v2 research commands into a script

### DIFF
--- a/.claude/skills/terminal-gui-v2/SKILL.md
+++ b/.claude/skills/terminal-gui-v2/SKILL.md
@@ -27,15 +27,13 @@ Key namespaces:
 - `Views` — `Window`, `Dialog`, `TableView`, `TreeView`, `MenuBar`, `StatusBar`, etc.
 - `Input` — `Key`, `KeyCode`, `Command`, `KeyBinding`
 
-**Upstream source (v2_develop branch):**
+**Upstream source (develop branch):**
 ```bash
 # List files in a directory
-gh api "repos/gui-cs/Terminal.Gui/contents/Terminal.Gui/<Dir>?ref=v2_develop" \
-  | python3 -c "import json,sys; [print(d['name']) for d in json.load(sys.stdin)]"
+.claude/skills/terminal-gui-v2/tgui-browse.sh list <Dir>
 
 # Read a specific file
-gh api "repos/gui-cs/Terminal.Gui/contents/Terminal.Gui/<Dir>/<File>.cs?ref=v2_develop" \
-  | python3 -c "import json,sys,base64; print(base64.b64decode(json.load(sys.stdin)['content']).decode())"
+.claude/skills/terminal-gui-v2/tgui-browse.sh read <Dir> <File>.cs
 ```
 
 ---

--- a/.claude/skills/terminal-gui-v2/tgui-browse.sh
+++ b/.claude/skills/terminal-gui-v2/tgui-browse.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Browse Terminal.Gui v2 source files via GitHub API.
+#
+# Usage:
+#   tgui-browse.sh list <Dir>            — list files in Terminal.Gui/<Dir>
+#   tgui-browse.sh read <Dir> <File>.cs  — print source of a file
+#
+# All paths are relative to the Terminal.Gui/ directory in the v2_develop branch.
+
+set -euo pipefail
+
+REPO="gui-cs/Terminal.Gui"
+REF="develop"
+BASE="Terminal.Gui"
+
+cmd="${1:-}"
+shift || true
+
+case "$cmd" in
+  list)
+    dir="${1:?Usage: tgui-browse.sh list <Dir>}"
+    gh api "repos/${REPO}/contents/${BASE}/${dir}?ref=${REF}" \
+      | python3 -c "import json,sys; [print(d['name']) for d in json.load(sys.stdin)]"
+    ;;
+  read)
+    dir="${1:?Usage: tgui-browse.sh read <Dir> <File>.cs}"
+    file="${2:?Usage: tgui-browse.sh read <Dir> <File>.cs}"
+    gh api "repos/${REPO}/contents/${BASE}/${dir}/${file}?ref=${REF}" \
+      | python3 -c "import json,sys,base64; print(base64.b64decode(json.load(sys.stdin)['content']).decode())"
+    ;;
+  *)
+    echo "Usage:"
+    echo "  tgui-browse.sh list <Dir>"
+    echo "  tgui-browse.sh read <Dir> <File>.cs"
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
## Summary

- Replace inline `gh api | python3` pipes in `SKILL.md` with `tgui-browse.sh` script
- Add `tgui-browse.sh list <Dir>` and `tgui-browse.sh read <Dir> <File>.cs` subcommands
- Fix upstream branch name: `v2_develop` → `develop` (old branch returned HTTP 404)

This eliminates per-invocation approval prompts for `gh api` and `python3` by consolidating them into a single pre-approved script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)