### PR TITLE
fix: downgrade Microsoft.NET.Test.Sdk to 17.13.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,10 @@ updates:
     labels:
       - "dependencies"
       - "nuget"
+    # Versions > 17.13.0 cause TypeLoadException when Terminal.Gui scans assemblies (VSTest #15075)
+    ignore:
+      - dependency-name: "Microsoft.NET.Test.Sdk"
+        versions: ["> 17.13.0"]
 
   # GitHub Actions updates
   - package-ecosystem: "github-actions"

--- a/tests/DataMorph.Tests/DataMorph.Tests.csproj
+++ b/tests/DataMorph.Tests/DataMorph.Tests.csproj
@@ -23,7 +23,7 @@
     <PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
     <PackageReference Include="coverlet.collector" Version="8.0.1" />
     <PackageReference Include="AwesomeAssertions" Version="9.4.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>


### PR DESCRIPTION
## Summary
This PR downgrades `Microsoft.NET.Test.Sdk` from 18.4.0 to 17.13.0 to resolve a `System.TypeLoadException` during test execution.

## Problem
Versions of `Microsoft.NET.Test.Sdk` 17.14.0 and newer (including 18.4.0) contain a regression in `Microsoft.TestPlatform.CoreUtilities` that causes a `TypeLoadException` when reflection is performed on all loaded assemblies. This is triggered by `Terminal.Gui` during its configuration initialization.

## Changes
- Downgraded `Microsoft.NET.Test.Sdk` to **17.13.0** in `DataMorph.Tests.csproj`.
- Updated `.github/dependabot.yml` to ignore versions of `Microsoft.NET.Test.Sdk` greater than 17.13.0.

Refer to [microsoft/vstest #15075](https://github.com/microsoft/vstest/issues/15075) for details on the upstream issue.