### PR TITLE
feat: add clear action stack command with c key binding

### DIFF
--- a/docs/design_clear_action_stack.md
+++ b/docs/design_clear_action_stack.md
@@ -1,0 +1,64 @@
+# Design: Clear Action Stack Command
+
+## Overview
+
+Add a dedicated `c` key binding that clears all `MorphAction` entries from the `ActionStack`.
+This allows users to reset all transformations without quitting or reloading the file.
+
+## Requirements
+
+- Pressing `c` triggers the Clear command **only when `ActionStack.Count > 0`**.
+- The command shows a confirmation dialog before clearing.
+- After confirmation, the `ActionStack` is reset to empty and the table view is refreshed.
+- The feature is available in both `CsvTableView` and `JsonLinesTableView` (handled via the
+  existing global `AppKeyHandler`).
+
+## User Flow
+
+1. User presses `c` in a table view.
+2. `AppKeyHandler` checks `_state.ActionStack.Count`.
+   - If `== 0`: keypress is ignored (no dialog shown).
+   - If `> 0`: proceeds to step 3.
+3. A `MessageBox.Query` confirmation dialog is shown:
+   - Title: `"Clear Actions"`
+   - Message: `"Clear all actions from the stack?"`
+   - Buttons: `"Yes"` / `"No"`
+4. If the user confirms (Yes):
+   - `AppState.ClearMorphActions()` is called, resetting `ActionStack` to `[]`.
+   - `ViewManager.RefreshCurrentTableView()` is called to re-render the table.
+5. If the user cancels (No): nothing changes.
+
+## Architecture
+
+### Dispatch Flow
+
+```
+AppKeyHandler (OnGlobalKeyDown)
+  └─ key == 'c'  →  HandleClearActions()
+       ├─ ActionStack.Count == 0  →  return (no-op)
+       ├─ MessageBox.Query(...)
+       │   ├─ Yes  →  AppState.ClearMorphActions()
+       │   │          ViewManager.RefreshCurrentTableView()
+       │   └─ No   →  return
+```
+
+### Why a dedicated key binding instead of the `x` action menu
+
+Clear is a stack-level operation, not a column-scoped operation. The `x` action menu
+(Rename, Delete, Cast, Filter, Fill, Format Timestamp) is designed for column-specific
+transformations. Placing Clear there would conflate two different levels of concern.
+A dedicated `c` key keeps the action menu focused on column operations and makes the
+Clear command directly accessible without navigating a menu.
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `src/App/AppState.cs` | Add `ClearMorphActions()` method |
+| `src/App/AppKeyHandler.cs` | Handle `c` key in `OnGlobalKeyDown`; add `HandleClearActions()` |
+| `src/App/Views/Dialogs/HelpDialog.cs` | Document `c` key in help text |
+
+## Out of Scope
+
+- Per-action undo (single-step rollback) — not part of this feature.
+- Persisting the cleared state to disk — clearing is in-memory only.

--- a/src/App/AppKeyHandler.cs
+++ b/src/App/AppKeyHandler.cs
@@ -37,7 +37,7 @@ internal sealed class AppKeyHandler : IDisposable
     internal static bool IsGlobalShortcut(KeyCode keyCode)
     {
         var baseKey = keyCode & ~(KeyCode.ShiftMask | KeyCode.CtrlMask | KeyCode.AltMask);
-        return baseKey is KeyCode.O or KeyCode.S or KeyCode.Q or KeyCode.T or KeyCode.X or (KeyCode)'?';
+        return baseKey is KeyCode.O or KeyCode.S or KeyCode.Q or KeyCode.T or KeyCode.X or KeyCode.C or (KeyCode)'?';
     }
 
     internal AppKeyHandler(
@@ -180,6 +180,17 @@ internal sealed class AppKeyHandler : IDisposable
         return true;
     }
 
+    /// <summary>
+    /// Handles the clear action stack shortcut (c).
+    /// Shows a confirmation dialog and clears the action stack if confirmed.
+    /// Does nothing when the action stack is empty.
+    /// </summary>
+    /// <returns><c>true</c> if the key was handled; <c>false</c> otherwise.</returns>
+    internal bool HandleClearActions()
+    {
+        throw new NotImplementedException();
+    }
+
     private void OnGlobalKeyDown(object? sender, Key key)
     {
         if (key.Handled)
@@ -214,6 +225,7 @@ internal sealed class AppKeyHandler : IDisposable
             KeyCode.Q => HandleQuit(),
             KeyCode.T => HandleViewToggle(),
             KeyCode.X => HandleActionMenu(),
+            KeyCode.C => HandleClearActions(),
             (KeyCode)'?' => HandleHelp(),
             _ => false,
         };

--- a/src/App/AppKeyHandler.cs
+++ b/src/App/AppKeyHandler.cs
@@ -188,7 +188,25 @@ internal sealed class AppKeyHandler : IDisposable
     /// <returns><c>true</c> if the key was handled; <c>false</c> otherwise.</returns>
     internal bool HandleClearActions()
     {
-        throw new NotImplementedException();
+        if (_state.ActionStack.Count == 0)
+        {
+            return false;
+        }
+
+        var result = MessageBox.Query(
+            _app,
+            "Clear Actions",
+            "Clear all actions from the stack?",
+            "Yes",
+            "No"
+        );
+        if (result == 0)
+        {
+            _state.ClearMorphActions();
+            _viewManager.RefreshCurrentTableView();
+        }
+
+        return true;
     }
 
     private void OnGlobalKeyDown(object? sender, Key key)

--- a/src/App/AppState.cs
+++ b/src/App/AppState.cs
@@ -75,6 +75,14 @@ internal sealed class AppState : IDisposable
         ActionStack = [.. ActionStack, action];
     }
 
+    /// <summary>
+    /// Clears all morph actions from the Action Stack, resetting it to an empty state.
+    /// </summary>
+    internal void ClearMorphActions()
+    {
+        throw new NotImplementedException();
+    }
+
     /// <inheritdoc/>
     public void Dispose()
     {

--- a/src/App/AppState.cs
+++ b/src/App/AppState.cs
@@ -80,7 +80,7 @@ internal sealed class AppState : IDisposable
     /// </summary>
     internal void ClearMorphActions()
     {
-        throw new NotImplementedException();
+        ActionStack = [];
     }
 
     /// <inheritdoc/>

--- a/src/App/ViewManager.cs
+++ b/src/App/ViewManager.cs
@@ -64,6 +64,11 @@ internal sealed class ViewManager : IDisposable
             {
                 hints.Add("x:Menu");
             }
+
+            if (_state.ActionStack.Count > 0)
+            {
+                hints.Add("c:Clear");
+            }
         }
 
         hints.Add("?:Help");

--- a/src/App/Views/Dialogs/HelpDialog.cs
+++ b/src/App/Views/Dialogs/HelpDialog.cs
@@ -54,6 +54,7 @@ internal sealed class HelpDialog : Dialog
             q       : Quit
             t       : Toggle Tree/Table View (JSON Lines)
             x       : Context-Sensitive Action Menu
+            c       : Clear all actions from the stack
             ?       : Help (this overlay)
 
             Navigation

--- a/tests/DataMorph.Tests/App/AppKeyHandlerTests.cs
+++ b/tests/DataMorph.Tests/App/AppKeyHandlerTests.cs
@@ -183,23 +183,25 @@ public sealed class AppKeyHandlerTests
     public void HandleClearActions_WhenActionStackIsEmpty_ReturnsFalse()
     {
         // Arrange
+        using var app = CreateTestApp();
+        using var state = new AppState();
+        using var window = new Window();
+        var modeController = new ModeController(state);
+        using var viewManager = new ViewManager(window, state, modeController);
+        var fileDialogHandler = new FileDialogHandler(app, state, viewManager, _ => { });
+        var recipeCommandHandler = new RecipeCommandHandler(app, state, viewManager);
+        using var handler = new AppKeyHandler(app, state, viewManager, fileDialogHandler, recipeCommandHandler, null);
 
         // Act
+        var result = handler.HandleClearActions();
 
         // Assert
+        result.Should().BeFalse();
+        state.ActionStack.Should().BeEmpty();
     }
 
-    [Fact]
-    public void HandleClearActions_WhenActionStackHasActions_ReturnsTrue()
-    {
-        // Arrange
-
-        // Act
-
-        // Assert
-        // Note: MessageBox.Query display is not unit-testable (requires TUI event loop).
-        //       Verify return value true (key consumed) only.
-    }
+    // Note: MessageBox.Query display is not unit-testable (requires TUI event loop).
+    // This scenario requires integration testing with TUI event loop support.
 
     private static IApplication CreateTestApp()
     {

--- a/tests/DataMorph.Tests/App/AppKeyHandlerTests.cs
+++ b/tests/DataMorph.Tests/App/AppKeyHandlerTests.cs
@@ -15,6 +15,7 @@ public sealed class AppKeyHandlerTests
     [InlineData(KeyCode.Q)]
     [InlineData(KeyCode.T)]
     [InlineData(KeyCode.X)]
+    [InlineData(KeyCode.C)]
     [InlineData((KeyCode)'?')]
     public void IsGlobalShortcut_WithGlobalShortcutKeys_ReturnsTrue(KeyCode keyCode)
     {
@@ -47,6 +48,7 @@ public sealed class AppKeyHandlerTests
     [InlineData(KeyCode.Q | KeyCode.CtrlMask)]
     [InlineData(KeyCode.T | KeyCode.CtrlMask)]
     [InlineData(KeyCode.X | KeyCode.CtrlMask)]
+    [InlineData(KeyCode.C | KeyCode.CtrlMask)]
     [InlineData((KeyCode)'?' | KeyCode.CtrlMask)]
     public void IsGlobalShortcut_WithModifierKeys_ReturnsTrue(KeyCode keyCode)
     {
@@ -175,6 +177,28 @@ public sealed class AppKeyHandlerTests
 
         // Assert
         result.Should().BeFalse();
+    }
+
+    [Fact]
+    public void HandleClearActions_WhenActionStackIsEmpty_ReturnsFalse()
+    {
+        // Arrange
+
+        // Act
+
+        // Assert
+    }
+
+    [Fact]
+    public void HandleClearActions_WhenActionStackHasActions_ReturnsTrue()
+    {
+        // Arrange
+
+        // Act
+
+        // Assert
+        // Note: MessageBox.Query display is not unit-testable (requires TUI event loop).
+        //       Verify return value true (key consumed) only.
     }
 
     private static IApplication CreateTestApp()

--- a/tests/DataMorph.Tests/App/AppStateTests.cs
+++ b/tests/DataMorph.Tests/App/AppStateTests.cs
@@ -63,29 +63,43 @@ public sealed class AppStateTests
     public void ClearMorphActions_WithActions_ClearsActionStack()
     {
         // Arrange
+        using var state = new AppState();
+        state.AddMorphAction(new RenameColumnAction { OldName = "a", NewName = "b" });
+        state.AddMorphAction(new DeleteColumnAction { ColumnName = "c" });
 
         // Act
+        state.ClearMorphActions();
 
         // Assert
+        state.ActionStack.Should().BeEmpty();
     }
 
     [Fact]
     public void ClearMorphActions_WithEmptyStack_StackRemainsEmpty()
     {
         // Arrange
+        using var state = new AppState();
 
         // Act
+        state.ClearMorphActions();
 
         // Assert
+        state.ActionStack.Should().BeEmpty();
     }
 
     [Fact]
     public void ClearMorphActions_DoesNotMutatePreviousStackReference()
     {
         // Arrange
+        using var state = new AppState();
+        state.AddMorphAction(new RenameColumnAction { OldName = "a", NewName = "b" });
+        var originalList = state.ActionStack;
 
         // Act
+        state.ClearMorphActions();
 
         // Assert
+        originalList.Should().HaveCount(1);
+        state.ActionStack.Should().BeEmpty();
     }
 }

--- a/tests/DataMorph.Tests/App/AppStateTests.cs
+++ b/tests/DataMorph.Tests/App/AppStateTests.cs
@@ -58,4 +58,34 @@ public sealed class AppStateTests
         originalList.Should().ContainSingle();
         state.ActionStack.Should().HaveCount(2);
     }
+
+    [Fact]
+    public void ClearMorphActions_WithActions_ClearsActionStack()
+    {
+        // Arrange
+
+        // Act
+
+        // Assert
+    }
+
+    [Fact]
+    public void ClearMorphActions_WithEmptyStack_StackRemainsEmpty()
+    {
+        // Arrange
+
+        // Act
+
+        // Assert
+    }
+
+    [Fact]
+    public void ClearMorphActions_DoesNotMutatePreviousStackReference()
+    {
+        // Arrange
+
+        // Act
+
+        // Assert
+    }
 }


### PR DESCRIPTION
## Summary

- Add `c` key binding to clear all `MorphAction` entries from the `ActionStack`
- Shows a confirmation dialog before clearing; no-op when the stack is already empty
- Display `c:Clear` hint in the status bar only when `ActionStack.Count > 0`

## Changes

| File | Change |
|------|--------|
| `src/App/AppState.cs` | Add `ClearMorphActions()` method |
| `src/App/AppKeyHandler.cs` | Add `HandleClearActions()` and dispatch `c` key in `OnGlobalKeyDown` |
| `src/App/ViewManager.cs` | Show `c:Clear` status bar hint when action stack is non-empty |
| `src/App/Views/Dialogs/HelpDialog.cs` | Document `c` key in help text |

Closes #159