### PR TITLE
feat: implement sliding window LRU cache with prefetch and LRU eviction

### DIFF
--- a/docs/design_sliding_window_lru_cache.md
+++ b/docs/design_sliding_window_lru_cache.md
@@ -78,7 +78,7 @@ This avoids redundant node allocations for already-cached rows while keeping the
 
 #### Separate preparatory rename commit
 
-Before implementing the cache strategy, a standalone commit renames `GetRow` → `Get` (CSV) and `GetLineBytes` → `Get` (JSON Lines). This keeps the cache strategy diff clean and reviewable in isolation.
+Before implementing the cache strategy, a standalone commit renames `GetLineBytes` → `GetRow` (JSON Lines) to align with CSV's existing naming. This keeps the cache strategy diff clean and reviewable in isolation.
 
 ---
 
@@ -181,7 +181,7 @@ public abstract class SlidingWindowLruCache<TRow> ~~: IRowCache<TRow>~~
         int prefetchWindow = DefaultPrefetchWindow);
 
     public int TotalRows { get; }
-    public TRow Get(int index);
+    public TRow GetRow(int index);
 
     // Subclasses implement file I/O for a range of rows
     protected abstract IEnumerable<TRow> LoadRows(
@@ -223,7 +223,7 @@ public sealed class RowByteCache(
 ### 2.3 LRU Algorithm
 
 ```
-Get(index):
+GetRow(index):
   if index out of range → return default
   if index in dictionary:
     move node to MRU head
@@ -268,9 +268,7 @@ Prefetch(requestedRow):
 
 | File | Change |
 |------|--------|
-| `src/Engine/IO/Csv/DataRowCache.cs` | `GetRow` → `Get` |
-| `src/Engine/IO/JsonLines/RowByteCache.cs` | `GetLineBytes` → `Get` |
-| `src/App/Views/VirtualTableSource.cs` | update call site |
+| `src/Engine/IO/JsonLines/RowByteCache.cs` | `GetLineBytes` → `GetRow` |
 | `src/App/Views/JsonLinesTableSource.cs` | update call site |
 | `src/App/Views/JsonLinesTreeView.cs` | update call site |
 | `tests/` | update all test call sites |

--- a/docs/design_sliding_window_lru_cache.md
+++ b/docs/design_sliding_window_lru_cache.md
@@ -1,0 +1,336 @@
+# Sliding Window LRU Cache - Design Document
+
+## Scope
+
+Improve the caching strategy for `DataRowCache` (CSV) and `RowByteCache` (JSON Lines) by replacing the current "clear-all-and-reload" approach with a sliding window prefetch combined with LRU eviction. The two classes are also unified under a shared generic interface and abstract base class.
+
+---
+
+## ADR: Architecture Decision Record
+
+### Context
+
+Both `DataRowCache` and `RowByteCache` share an identical but inefficient caching strategy: on any cache miss, the entire cache is cleared and a new window of 200 rows is loaded from disk. This means that scrolling even one row past the cached window triggers a full 200-row reload, discarding rows that are still relevant.
+
+### Decision Log
+
+The following decisions were made through design discussion.
+
+#### Strategy: Sliding Window + LRU
+
+**Considered:**
+- Option A: Sliding window with differential load (load only missing rows on miss)
+- Option B: LRU cache (individual row eviction, random-access-friendly)
+- **Adopted:** Combination of A and B — prefetch a centered window on miss, evict via LRU
+
+**Rationale:** The combination retains the sequential-scan efficiency of sliding window prefetch while preventing the "full cache wipe" problem through LRU eviction.
+
+#### Prefetch Window: 20 rows, center-aligned
+
+On a cache miss for row N, rows `[N-10, N+9]` (clamped to valid range) are loaded in a single I/O.
+
+**Considered:** Forward-biased window (N to N+19) to optimize downward scrolling.  
+**Rejected:** DataMorph supports bidirectional scrolling, so center-aligned is more appropriate.
+
+**Note on multiple I/O per render:** If the terminal displays more rows than the prefetch window size, the initial render may trigger more than one I/O. This was explicitly accepted as a non-issue — the improvement to scrolling hit rate outweighs the minor cost of occasional extra I/O on first render. Prefetch window size is configurable via the constructor to allow tuning if needed.
+
+#### Already-cached rows within prefetch window
+
+When loading a prefetch window, some rows may already be in the LRU cache. For each row in the window:
+- **Key found in dictionary:** skip node creation; update LRU position only (move to MRU head)
+- **Key not found:** create or reuse a node and add to cache
+
+This avoids redundant node allocations for already-cached rows while keeping the I/O sequential and simple.
+
+#### Heap allocation minimization: lazy allocation + node reuse
+
+**Considered:** Pre-allocate all `capacity` nodes upfront at construction time.  
+**Rejected:** Files with fewer than `capacity` rows would incur unnecessary allocations.
+
+**Adopted:** Lazy allocation with evicted-node reuse:
+- While cache is not full: allocate `LinkedListNode` objects on demand (`new` per miss)
+- Once cache is full: reuse the evicted tail node by overwriting its value — zero `new` allocations per operation
+
+**Node reuse safety rule:** Before reusing an evicted node, `Clear()` must always be called to reset all properties. The correctness of `Clear()` is verified by a dedicated unit test that asserts every property is in its default state after the call.
+
+`Dictionary` is initialized with `capacity` to prevent rehashing as entries are added.
+
+#### Code unification: interface + abstract base class
+
+**Interface `IRowCache<TRow>`** (`DataMorph.Engine.IO` namespace):
+- Single method: `TRow Get(int index)`
+- All external classes and unit tests reference this interface only
+- Ensures testability via mocking and allows future alternative implementations without inheriting the base class
+
+**Abstract base class `SlidingWindowLruCache<TRow>`** (`DataMorph.Engine.IO` namespace):
+- Implements `IRowCache<TRow>`
+- Encapsulates LRU structure (`Dictionary` + `LinkedList`), prefetch logic, and node reuse
+- Is an implementation detail — external classes must not reference it directly
+
+**Concrete classes:**
+- `DataRowCache : SlidingWindowLruCache<CsvDataRow>, IRowCache<CsvDataRow>`
+- `RowByteCache : SlidingWindowLruCache<ReadOnlyMemory<byte>>, IRowCache<ReadOnlyMemory<byte>>`
+
+**Considered:** Separate interfaces per format (`IDataRowCache` for CSV, `IRowByteCache` for JSON Lines).  
+**Rejected:** A single generic interface `IRowCache<TRow>` was adopted instead, as it avoids duplication and keeps the contract consistent across formats.
+
+**Rationale for separate interface from base class:** Even if the base class is refactored or replaced in the future, callers remain unaffected as long as `IRowCache<TRow>` is satisfied.
+
+#### Separate preparatory rename commit
+
+Before implementing the cache strategy, a standalone commit renames `GetRow` → `Get` (CSV) and `GetLineBytes` → `Get` (JSON Lines) to align with the new interface. This keeps the cache strategy diff clean and reviewable in isolation.
+
+---
+
+## 1. Requirements
+
+### Functional Requirements
+
+- On cache miss, prefetch 20 rows centered on the requested row
+- Retain existing cached rows on miss (no full-cache wipe)
+- Evict least-recently-used rows when cache exceeds capacity
+- Reuse evicted `LinkedListNode` objects to avoid post-warmup heap allocations
+- Expose a common generic interface `IRowCache<TRow>` for external consumers
+- Preserve existing public behavior: `DataRowCache` for CSV, `RowByteCache` for JSON Lines
+
+### Non-Functional Requirements
+
+- **Zero allocations** after cache reaches capacity (hot path)
+- **Native AOT compatible** (no reflection)
+- **Thread-safety:** future-proof; document assumptions
+- Prefetch window size and capacity configurable via constructor
+
+---
+
+## 2. Design
+
+### 2.1 Interface: `IRowCache<TRow>`
+
+```csharp
+namespace DataMorph.Engine.IO;
+
+public interface IRowCache<TRow>
+{
+    int TotalRows { get; }
+    TRow Get(int index);
+}
+```
+
+### 2.2 Abstract Base Class: `SlidingWindowLruCache<TRow>`
+
+#### Responsibilities
+- Maintain LRU structure (`Dictionary<int, LinkedListNode<CacheEntry<TRow>>>` + `LinkedList<CacheEntry<TRow>>`)
+- On miss: calculate prefetch window, load rows via abstract method, populate cache
+- On hit: move node to MRU head
+- On eviction: reuse tail node via `Clear()` + reassignment
+
+#### Key structures
+
+```csharp
+// Value type stored in each LinkedListNode.
+// Stored as a struct so it is laid out inline inside the LinkedListNode heap object,
+// avoiding a separate heap allocation per entry.
+internal struct CacheEntry<TRow>
+{
+    internal int RowIndex;
+    internal TRow Value;
+
+    internal void Clear(TRow emptyValue)
+    {
+        RowIndex = -1;
+        Value = emptyValue;
+    }
+}
+```
+
+`CacheEntry` does not know what an "empty" `TRow` looks like, so the caller supplies it via `emptyValue`. The base class exposes an abstract property that each subclass overrides:
+
+```csharp
+protected abstract TRow EmptyValue { get; }
+
+// Usage on eviction:
+entry.Clear(EmptyValue);
+```
+
+Concrete overrides:
+```csharp
+// DataRowCache (CSV)
+protected override CsvDataRow EmptyValue => [];
+
+// RowByteCache (JSON Lines)
+protected override ReadOnlyMemory<byte> EmptyValue => ReadOnlyMemory<byte>.Empty;
+```
+
+This avoids the null-forgiving operator (`!`) while keeping `CacheEntry` free of format-specific knowledge.
+
+#### API
+
+```csharp
+namespace DataMorph.Engine.IO;
+
+public abstract class SlidingWindowLruCache<TRow> : IRowCache<TRow>
+{
+    private const int DefaultCapacity = 200;
+    private const int DefaultPrefetchWindow = 20;
+
+    protected SlidingWindowLruCache(
+        IRowIndexer indexer,
+        int capacity = DefaultCapacity,
+        int prefetchWindow = DefaultPrefetchWindow);
+
+    public int TotalRows { get; }
+    public TRow Get(int index);
+
+    // Subclasses implement file I/O for a range of rows
+    protected abstract IEnumerable<TRow> LoadRows(
+        long byteOffset,
+        int rowOffsetToSkip,
+        int rowsToFetch);
+}
+```
+
+### 2.3 Concrete Classes
+
+```csharp
+// CSV
+public sealed class DataRowCache(
+    IRowIndexer indexer,
+    int columnCount,
+    int capacity = 200,
+    int prefetchWindow = 20)
+    : SlidingWindowLruCache<CsvDataRow>(indexer, capacity, prefetchWindow), IRowCache<CsvDataRow>
+{
+    protected override IEnumerable<CsvDataRow> LoadRows(
+        long byteOffset, int rowOffsetToSkip, int rowsToFetch);
+}
+
+// JSON Lines
+public sealed class RowByteCache(
+    IRowIndexer indexer,
+    int capacity = 200,
+    int prefetchWindow = 20)
+    : SlidingWindowLruCache<ReadOnlyMemory<byte>>(indexer, capacity, prefetchWindow),
+      IRowCache<ReadOnlyMemory<byte>>, IDisposable
+{
+    protected override IEnumerable<ReadOnlyMemory<byte>> LoadRows(
+        long byteOffset, int rowOffsetToSkip, int rowsToFetch);
+    public void Dispose();
+}
+```
+
+### 2.4 LRU Algorithm
+
+```
+Get(index):
+  if index out of range → return default
+  if index in dictionary:
+    move node to MRU head
+    return node value
+  else:
+    Prefetch(index)
+    return dictionary[index].Value
+
+Prefetch(requestedRow):
+  halfWindow = prefetchWindow / 2
+  windowStart = clamp(requestedRow - halfWindow, 0, TotalRows - prefetchWindow)
+  windowEnd   = clamp(windowStart + prefetchWindow - 1, 0, TotalRows - 1)
+
+  (byteOffset, rowOffsetToSkip) = indexer.GetCheckPoint(windowStart)
+  rows = LoadRows(byteOffset, rowOffsetToSkip, windowEnd - windowStart + 1)
+
+  foreach (rowIndex, rowValue) in rows:
+    if rowIndex in dictionary:
+      move node to MRU head   // already cached, just refresh LRU
+    else:
+      if cache is full:
+        node = evict tail node
+        node.entry.Clear()
+      else:
+        node = new LinkedListNode<CacheEntry<TRow>>()
+      node.entry = { RowIndex = rowIndex, Value = rowValue }
+      dictionary[rowIndex] = node
+      prepend node to MRU head
+```
+
+### 2.5 Thread Safety
+
+- Not thread-safe by design (consistent with current implementation)
+- All access is assumed to occur on the TUI rendering thread
+- Document this assumption; flag for future review if parallel access is required
+
+---
+
+## 3. Implementation Plan
+
+### Step 0: Rename existing methods (standalone commit)
+
+| File | Change |
+|------|--------|
+| `src/Engine/IO/Csv/DataRowCache.cs` | `GetRow` → `Get` |
+| `src/Engine/IO/JsonLines/RowByteCache.cs` | `GetLineBytes` → `Get` |
+| `src/App/Views/VirtualTableSource.cs` | update call site |
+| `src/App/Views/JsonLinesTableSource.cs` | update call site |
+| `src/App/Views/JsonLinesTreeView.cs` | update call site |
+| `tests/` | update all test call sites |
+
+### Step 1: Skeleton
+
+| File | Action |
+|------|--------|
+| `src/Engine/IO/IRowCache.cs` | Create interface |
+| `src/Engine/IO/CacheEntry.cs` | Create entry struct |
+| `src/Engine/IO/SlidingWindowLruCache.cs` | Create abstract base class |
+| `src/Engine/IO/Csv/DataRowCache.cs` | Refactor to extend base |
+| `src/Engine/IO/JsonLines/RowByteCache.cs` | Refactor to extend base |
+| `tests/.../SlidingWindowLruCacheTests.cs` | Create test class skeleton |
+| `tests/.../DataRowCacheTests.cs` | Update existing tests |
+| `tests/.../RowByteCacheTests.cs` | Update existing tests |
+
+### Step 2: Logic implementation
+
+- Implement LRU logic in `SlidingWindowLruCache<TRow>`
+- Implement `LoadRows` in `DataRowCache` and `RowByteCache`
+- Complete all unit tests
+
+---
+
+## 4. Testing Strategy
+
+### 4.1 Unit Tests
+
+**`CacheEntry<TRow>.Clear(emptyValue)`**
+- `RowIndex == -1` after `Clear()` is called
+- `Value == emptyValue` after `Clear()` is called
+
+**`SlidingWindowLruCache<TRow>` (via `IRowCache<TRow>`)**
+
+| # | Scenario |
+|---|----------|
+| 1 | Cache miss: prefetch window is loaded |
+| 2 | Cache hit: no I/O, LRU position updated |
+| 3 | Prefetch window clamped at start of file (row 0) |
+| 4 | Prefetch window clamped at end of file |
+| 5 | Eviction: LRU tail is evicted when capacity is reached |
+| 6 | Node reuse: evicted node object is reused (no new allocation after warmup) |
+| 7 | Already-cached rows in prefetch window: no duplicate entries, LRU updated |
+| 8 | File with fewer rows than capacity: no excess allocations |
+| 9 | Out-of-range index returns default value |
+| 10 | TotalRows = 0 returns default value |
+
+### 4.2 Benchmarks
+
+- Compare cache hit rate: old strategy vs new strategy under sequential and random access patterns
+- Verify zero allocations after cache warmup using `MemoryDiagnoser`
+
+---
+
+## 5. Acceptance Criteria
+
+- [ ] `IRowCache<TRow>` interface defined; all external callers use it
+- [ ] `SlidingWindowLruCache<TRow>` implements prefetch + LRU correctly
+- [ ] No full-cache wipe on miss
+- [ ] Node reuse verified: zero `LinkedListNode` allocations after cache is full
+- [ ] `CacheEntry.Clear()` unit test passes
+- [ ] All existing tests updated and passing
+- [ ] `dotnet build` with zero warnings
+- [ ] `dotnet format` clean

--- a/docs/design_sliding_window_lru_cache.md
+++ b/docs/design_sliding_window_lru_cache.md
@@ -55,30 +55,30 @@ This avoids redundant node allocations for already-cached rows while keeping the
 
 `Dictionary` is initialized with `capacity` to prevent rehashing as entries are added.
 
-#### Code unification: interface + abstract base class
+#### Code unification: ~~interface +~~ abstract base class
 
-**Interface `IRowCache<TRow>`** (`DataMorph.Engine.IO` namespace):
-- Single method: `TRow Get(int index)`
-- All external classes and unit tests reference this interface only
-- Ensures testability via mocking and allows future alternative implementations without inheriting the base class
+~~**Interface `IRowCache<TRow>`** (`DataMorph.Engine.IO` namespace):~~
+- ~~Single method: `TRow Get(int index)`~~
+- ~~All external classes and unit tests reference this interface only~~
+- ~~Ensures testability via mocking and allows future alternative implementations without inheriting the base class~~
 
 **Abstract base class `SlidingWindowLruCache<TRow>`** (`DataMorph.Engine.IO` namespace):
-- Implements `IRowCache<TRow>`
+- ~~Implements `IRowCache<TRow>`~~
 - Encapsulates LRU structure (`Dictionary` + `LinkedList`), prefetch logic, and node reuse
 - Is an implementation detail — external classes must not reference it directly
 
 **Concrete classes:**
-- `DataRowCache : SlidingWindowLruCache<CsvDataRow>, IRowCache<CsvDataRow>`
-- `RowByteCache : SlidingWindowLruCache<ReadOnlyMemory<byte>>, IRowCache<ReadOnlyMemory<byte>>`
+- `DataRowCache : SlidingWindowLruCache<CsvDataRow> ~~, IRowCache<CsvDataRow>~~`
+- `RowByteCache : SlidingWindowLruCache<ReadOnlyMemory<byte>> ~~, IRowCache<ReadOnlyMemory<byte>>~~`
 
-**Considered:** Separate interfaces per format (`IDataRowCache` for CSV, `IRowByteCache` for JSON Lines).  
-**Rejected:** A single generic interface `IRowCache<TRow>` was adopted instead, as it avoids duplication and keeps the contract consistent across formats.
-
-**Rationale for separate interface from base class:** Even if the base class is refactored or replaced in the future, callers remain unaffected as long as `IRowCache<TRow>` is satisfied.
+**Decision: Reject Generic Interface due to CA1859**
+**Considered:** Generic interface `IRowCache<TRow>`.
+**Rejected:** While architecturally clean, using an interface for fields triggers C# warning **CA1859** (Change type of field to concrete type for improved performance). In high-performance TUI rendering paths, devirtualization of these calls is critical.
+**Adopted:** Use the abstract base class `SlidingWindowLruCache<TRow>` or concrete types directly in fields to ensure optimal JIT optimization and zero warnings.
 
 #### Separate preparatory rename commit
 
-Before implementing the cache strategy, a standalone commit renames `GetRow` → `Get` (CSV) and `GetLineBytes` → `Get` (JSON Lines) to align with the new interface. This keeps the cache strategy diff clean and reviewable in isolation.
+Before implementing the cache strategy, a standalone commit renames `GetRow` → `Get` (CSV) and `GetLineBytes` → `Get` (JSON Lines). This keeps the cache strategy diff clean and reviewable in isolation.
 
 ---
 
@@ -90,12 +90,14 @@ Before implementing the cache strategy, a standalone commit renames `GetRow` →
 - Retain existing cached rows on miss (no full-cache wipe)
 - Evict least-recently-used rows when cache exceeds capacity
 - Reuse evicted `LinkedListNode` objects to avoid post-warmup heap allocations
-- Expose a common generic interface `IRowCache<TRow>` for external consumers
+- ~~Expose a common generic interface `IRowCache<TRow>` for external consumers~~
+- Use a common generic base class `SlidingWindowLruCache<TRow>` for implementation sharing
 - Preserve existing public behavior: `DataRowCache` for CSV, `RowByteCache` for JSON Lines
 
 ### Non-Functional Requirements
 
 - **Zero allocations** after cache reaches capacity (hot path)
+- **High performance devirtualization:** Use concrete types for fields to avoid interface call overhead (CA1859)
 - **Native AOT compatible** (no reflection)
 - **Thread-safety:** future-proof; document assumptions
 - Prefetch window size and capacity configurable via constructor
@@ -104,19 +106,19 @@ Before implementing the cache strategy, a standalone commit renames `GetRow` →
 
 ## 2. Design
 
-### 2.1 Interface: `IRowCache<TRow>`
+### ~~2.1 Interface: `IRowCache<TRow>`~~
 
 ```csharp
-namespace DataMorph.Engine.IO;
+~~namespace DataMorph.Engine.IO;
 
 public interface IRowCache<TRow>
 {
     int TotalRows { get; }
     TRow Get(int index);
-}
+}~~
 ```
 
-### 2.2 Abstract Base Class: `SlidingWindowLruCache<TRow>`
+### 2.1 Abstract Base Class: `SlidingWindowLruCache<TRow>`
 
 #### Responsibilities
 - Maintain LRU structure (`Dictionary<int, LinkedListNode<CacheEntry<TRow>>>` + `LinkedList<CacheEntry<TRow>>`)
@@ -168,7 +170,7 @@ This avoids the null-forgiving operator (`!`) while keeping `CacheEntry` free of
 ```csharp
 namespace DataMorph.Engine.IO;
 
-public abstract class SlidingWindowLruCache<TRow> : IRowCache<TRow>
+public abstract class SlidingWindowLruCache<TRow> ~~: IRowCache<TRow>~~
 {
     private const int DefaultCapacity = 200;
     private const int DefaultPrefetchWindow = 20;
@@ -189,7 +191,7 @@ public abstract class SlidingWindowLruCache<TRow> : IRowCache<TRow>
 }
 ```
 
-### 2.3 Concrete Classes
+### 2.2 Concrete Classes
 
 ```csharp
 // CSV
@@ -198,7 +200,7 @@ public sealed class DataRowCache(
     int columnCount,
     int capacity = 200,
     int prefetchWindow = 20)
-    : SlidingWindowLruCache<CsvDataRow>(indexer, capacity, prefetchWindow), IRowCache<CsvDataRow>
+    : SlidingWindowLruCache<CsvDataRow>(indexer, capacity, prefetchWindow) ~~, IRowCache<CsvDataRow>~~
 {
     protected override IEnumerable<CsvDataRow> LoadRows(
         long byteOffset, int rowOffsetToSkip, int rowsToFetch);
@@ -210,7 +212,7 @@ public sealed class RowByteCache(
     int capacity = 200,
     int prefetchWindow = 20)
     : SlidingWindowLruCache<ReadOnlyMemory<byte>>(indexer, capacity, prefetchWindow),
-      IRowCache<ReadOnlyMemory<byte>>, IDisposable
+      ~~IRowCache<ReadOnlyMemory<byte>>,~~ IDisposable
 {
     protected override IEnumerable<ReadOnlyMemory<byte>> LoadRows(
         long byteOffset, int rowOffsetToSkip, int rowsToFetch);
@@ -218,7 +220,7 @@ public sealed class RowByteCache(
 }
 ```
 
-### 2.4 LRU Algorithm
+### 2.3 LRU Algorithm
 
 ```
 Get(index):
@@ -252,7 +254,7 @@ Prefetch(requestedRow):
       prepend node to MRU head
 ```
 
-### 2.5 Thread Safety
+### 2.4 Thread Safety
 
 - Not thread-safe by design (consistent with current implementation)
 - All access is assumed to occur on the TUI rendering thread
@@ -277,7 +279,7 @@ Prefetch(requestedRow):
 
 | File | Action |
 |------|--------|
-| `src/Engine/IO/IRowCache.cs` | Create interface |
+| ~~`src/Engine/IO/IRowCache.cs`~~ | ~~Create interface~~ |
 | `src/Engine/IO/CacheEntry.cs` | Create entry struct |
 | `src/Engine/IO/SlidingWindowLruCache.cs` | Create abstract base class |
 | `src/Engine/IO/Csv/DataRowCache.cs` | Refactor to extend base |
@@ -302,7 +304,7 @@ Prefetch(requestedRow):
 - `RowIndex == -1` after `Clear()` is called
 - `Value == emptyValue` after `Clear()` is called
 
-**`SlidingWindowLruCache<TRow>` (via `IRowCache<TRow>`)**
+**`SlidingWindowLruCache<TRow>` ~~ (via `IRowCache<TRow>`)~~**
 
 | # | Scenario |
 |---|----------|
@@ -326,7 +328,7 @@ Prefetch(requestedRow):
 
 ## 5. Acceptance Criteria
 
-- [ ] `IRowCache<TRow>` interface defined; all external callers use it
+- ~~[ ] `IRowCache<TRow>` interface defined; all external callers use it~~
 - [ ] `SlidingWindowLruCache<TRow>` implements prefetch + LRU correctly
 - [ ] No full-cache wipe on miss
 - [ ] Node reuse verified: zero `LinkedListNode` allocations after cache is full

--- a/src/App/Views/JsonLinesTableSource.cs
+++ b/src/App/Views/JsonLinesTableSource.cs
@@ -59,7 +59,7 @@ internal sealed class JsonLinesTableSource : ITableSource
                 throw new ArgumentOutOfRangeException(nameof(col));
             }
 
-            var lineBytes = _cache.GetLineBytes(row);
+            var lineBytes = _cache.GetRow(row);
             if (lineBytes.IsEmpty)
             {
                 return "<null>";

--- a/src/App/Views/JsonLinesTableSource.cs
+++ b/src/App/Views/JsonLinesTableSource.cs
@@ -34,7 +34,7 @@ internal sealed class JsonLinesTableSource : ITableSource
     }
 
     /// <inheritdoc/>
-    public int Rows => _cache.TotalLines;
+    public int Rows => _cache.TotalRows;
 
     /// <inheritdoc/>
     public int Columns => _schema.ColumnCount;

--- a/src/App/Views/JsonLinesTreeView.cs
+++ b/src/App/Views/JsonLinesTreeView.cs
@@ -48,7 +48,7 @@ internal sealed class JsonLinesTreeView : TreeView
 
     private void LoadInitialRootNodes()
     {
-        var linesToLoad = Math.Min(_cache.TotalLines, InitialLoadCount);
+        var linesToLoad = Math.Min(_cache.TotalRows, InitialLoadCount);
 
         for (var i = 0; i < linesToLoad; i++)
         {

--- a/src/App/Views/JsonLinesTreeView.cs
+++ b/src/App/Views/JsonLinesTreeView.cs
@@ -52,7 +52,7 @@ internal sealed class JsonLinesTreeView : TreeView
 
         for (var i = 0; i < linesToLoad; i++)
         {
-            var lineBytes = _cache.GetLineBytes(i);
+            var lineBytes = _cache.GetRow(i);
             if (lineBytes.IsEmpty)
             {
                 continue;

--- a/src/Engine/IO/CacheEntry.cs
+++ b/src/Engine/IO/CacheEntry.cs
@@ -15,5 +15,9 @@ internal struct CacheEntry<TRow>
     /// Resets the entry to its default/empty state.
     /// </summary>
     /// <param name="emptyValue">The empty/default value for the row type.</param>
-    internal void Clear(TRow emptyValue) => throw new NotImplementedException();
+    internal void Clear(TRow emptyValue)
+    {
+        RowIndex = -1;
+        Value = emptyValue;
+    }
 }

--- a/src/Engine/IO/CacheEntry.cs
+++ b/src/Engine/IO/CacheEntry.cs
@@ -1,0 +1,19 @@
+namespace DataMorph.Engine.IO;
+
+/// <summary>
+/// Represents a cached row entry.
+/// Stored as a struct to avoid a separate heap allocation per entry
+/// when used as the value type in LinkedListNode.
+/// </summary>
+/// <typeparam name="TRow">The type of row data.</typeparam>
+internal struct CacheEntry<TRow>
+{
+    internal int RowIndex;
+    internal TRow Value;
+
+    /// <summary>
+    /// Resets the entry to its default/empty state.
+    /// </summary>
+    /// <param name="emptyValue">The empty/default value for the row type.</param>
+    internal void Clear(TRow emptyValue) => throw new NotImplementedException();
+}

--- a/src/Engine/IO/Csv/DataRowCache.cs
+++ b/src/Engine/IO/Csv/DataRowCache.cs
@@ -1,5 +1,3 @@
-using System.Diagnostics.CodeAnalysis;
-
 namespace DataMorph.Engine.IO.Csv;
 
 /// <summary>
@@ -13,7 +11,6 @@ public sealed class DataRowCache(
     int prefetchWindow = 20)
     : SlidingWindowLruCache<CsvDataRow>(indexer, capacity, prefetchWindow)
 {
-    [SuppressMessage("Performance", "CA1823:Avoid unused private fields", Justification = "Used in LoadRows implementation (Step 2)")]
     private readonly DataRowReader _reader = new(indexer.FilePath, columnCount);
 
     /// <inheritdoc/>
@@ -23,5 +20,6 @@ public sealed class DataRowCache(
     protected override IEnumerable<CsvDataRow> LoadRows(
         long byteOffset,
         int rowOffsetToSkip,
-        int rowsToFetch) => throw new NotImplementedException();
+        int rowsToFetch) =>
+        _reader.ReadRows(byteOffset, rowOffsetToSkip, rowsToFetch);
 }

--- a/src/Engine/IO/Csv/DataRowCache.cs
+++ b/src/Engine/IO/Csv/DataRowCache.cs
@@ -1,155 +1,27 @@
+using System.Diagnostics.CodeAnalysis;
+
 namespace DataMorph.Engine.IO.Csv;
 
 /// <summary>
-/// Manages a sliding window cache of CSV data rows for efficient virtual scrolling.
+/// Manages a sliding window LRU cache of CSV data rows for efficient virtual scrolling.
 /// Uses ReadOnlyMemory for memory-efficient column storage.
 /// </summary>
-public sealed class DataRowCache
+public sealed class DataRowCache(
+    IRowIndexer indexer,
+    int columnCount,
+    int capacity = 200,
+    int prefetchWindow = 20)
+    : SlidingWindowLruCache<CsvDataRow>(indexer, capacity, prefetchWindow)
 {
-    private const int DefaultCacheSize = 200;
-    private readonly IRowIndexer _indexer;
-    private readonly DataRowReader _reader;
-    private readonly int _columnCount;
-    private readonly int _cacheSize;
-    private readonly Dictionary<int, CsvDataRow> _cache = [];
-    private int _cacheStartRow = -1;
+    [SuppressMessage("Performance", "CA1823:Avoid unused private fields", Justification = "Used in LoadRows implementation (Step 2)")]
+    private readonly DataRowReader _reader = new(indexer.FilePath, columnCount);
 
-    /// <summary>
-    /// Initializes a new instance of the <see cref="DataRowCache"/> class.
-    /// </summary>
-    /// <param name="indexer">The CSV row indexer for obtaining byte offsets.</param>
-    /// <param name="columnCount">The number of columns in the CSV.</param>
-    /// <param name="cacheSize">The size of the sliding window cache (default: 200).</param>
-    public DataRowCache(
-        IRowIndexer indexer,
-        int columnCount,
-        int cacheSize = DefaultCacheSize
-    )
-    {
-        _indexer = indexer;
-        _columnCount = columnCount;
-        _cacheSize = cacheSize;
-        ArgumentNullException.ThrowIfNull(indexer);
-        _reader = new DataRowReader(indexer.FilePath, columnCount);
-    }
+    /// <inheritdoc/>
+    protected override CsvDataRow EmptyValue => [];
 
-    /// <summary>
-    /// Gets the total number of rows in the CSV.
-    /// </summary>
-    public int TotalRows => (int)_indexer.TotalRows;
-
-    /// <summary>
-    /// Retrieves a row by its index, using the cache when possible.
-    /// </summary>
-    /// <param name="rowIndex">The zero-based row index.</param>
-    /// <returns>The CSV row, or an empty row if not available.</returns>
-    public CsvDataRow GetRow(int rowIndex)
-    {
-        // No data, nothing to do
-        if (TotalRows == 0)
-        {
-            return [];
-        }
-
-        if (rowIndex < 0 || rowIndex >= TotalRows)
-        {
-            return [];
-        }
-
-        if (!_cache.ContainsKey(rowIndex))
-        {
-            UpdateCache(rowIndex);
-        }
-
-        return _cache.TryGetValue(rowIndex, out var cachedRow) ? cachedRow : [];
-    }
-
-    private void UpdateCache(int requestedRow)
-    {
-        // Calculate cache window start row
-        var cacheStartRow = CalculateCacheStartRow(requestedRow);
-
-        // Calculate number of rows to fetch
-        var rowsToFetch = CalculateRowsToFetch(cacheStartRow);
-        if (rowsToFetch <= 0)
-        {
-            _cache.Clear();
-            _cacheStartRow = -1;
-            return;
-        }
-
-        // Get byte offset in file
-        var (byteOffset, rowOffsetToSkip) = _indexer.GetCheckPoint(cacheStartRow);
-
-        // Abort if offset is invalid
-        if (byteOffset < 0)
-        {
-            return;
-        }
-
-        // Clear current cache and load new data
-        _cache.Clear();
-        _cacheStartRow = cacheStartRow;
-
-        // Load rows from CSV file into cache
-        LoadRowsIntoCache(cacheStartRow, byteOffset, rowOffsetToSkip, rowsToFetch);
-    }
-
-    /// <summary>
-    /// Calculates the start row of the cache window centered around the requested row.
-    /// </summary>
-    /// <param name="requestedRow">The row index requested by the user.</param>
-    /// <returns>The start row of the cache window.</returns>
-    private int CalculateCacheStartRow(int requestedRow)
-    {
-        // If cache size is larger than total rows, start at row 0
-        if (_cacheSize >= TotalRows)
-        {
-            return 0;
-        }
-
-        var halfCacheSize = _cacheSize / 2;
-        var cacheStartRow = Math.Max(0, requestedRow - halfCacheSize);
-
-        var maxValidStartRow = TotalRows - _cacheSize;
-        return Math.Min(cacheStartRow, maxValidStartRow);
-    }
-
-    /// <summary>
-    /// Calculates the number of rows to fetch from the cache window.
-    /// </summary>
-    /// <param name="cacheStartRow">The start row of the cache window.</param>
-    /// <returns>The number of rows to fetch.</returns>
-    private int CalculateRowsToFetch(int cacheStartRow)
-    {
-        // Return the smaller of remaining rows and cache size
-        var remainingRows = TotalRows - cacheStartRow;
-        return Math.Min(_cacheSize, remainingRows);
-    }
-
-    /// <summary>
-    /// Loads rows from the CSV file and stores them in the cache.
-    /// </summary>
-    /// <param name="cacheStartRow">The start row of the cache window.</param>
-    /// <param name="byteOffset">The byte offset within the file.</param>
-    /// <param name="rowOffsetToSkip">The row offset to skip.</param>
-    /// <param name="rowsToFetch">The number of rows to fetch.</param>
-    private void LoadRowsIntoCache(
-        int cacheStartRow,
+    /// <inheritdoc/>
+    protected override IEnumerable<CsvDataRow> LoadRows(
         long byteOffset,
         int rowOffsetToSkip,
-        int rowsToFetch
-    )
-    {
-        // Read rows from CSV file
-        var rows = _reader.ReadRows(byteOffset, rowOffsetToSkip, rowsToFetch);
-
-        // Store read rows in cache
-        var currentRowIndex = cacheStartRow;
-        foreach (var row in rows)
-        {
-            _cache[currentRowIndex] = row;
-            currentRowIndex++;
-        }
-    }
+        int rowsToFetch) => throw new NotImplementedException();
 }

--- a/src/Engine/IO/JsonLines/RowByteCache.cs
+++ b/src/Engine/IO/JsonLines/RowByteCache.cs
@@ -37,7 +37,7 @@ public sealed class RowByteCache : IDisposable
     /// </summary>
     /// <param name="lineIndex">The zero-based line index.</param>
     /// <returns>The raw JSON bytes, or empty if not available.</returns>
-    public ReadOnlyMemory<byte> GetLineBytes(int lineIndex)
+    public ReadOnlyMemory<byte> GetRow(int lineIndex)
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
 

--- a/src/Engine/IO/JsonLines/RowByteCache.cs
+++ b/src/Engine/IO/JsonLines/RowByteCache.cs
@@ -10,18 +10,35 @@ public sealed class RowByteCache(
     int prefetchWindow = 20)
     : SlidingWindowLruCache<ReadOnlyMemory<byte>>(indexer, capacity, prefetchWindow), IDisposable
 {
+    private readonly RowReader _reader = new(indexer.FilePath);
+    private bool _disposed;
 
     /// <inheritdoc/>
     protected override ReadOnlyMemory<byte> EmptyValue => ReadOnlyMemory<byte>.Empty;
 
     /// <inheritdoc/>
+    public override ReadOnlyMemory<byte> GetRow(int index)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        return base.GetRow(index);
+    }
+
+    /// <inheritdoc/>
     protected override IEnumerable<ReadOnlyMemory<byte>> LoadRows(
         long byteOffset,
         int rowOffsetToSkip,
-        int rowsToFetch) => throw new NotImplementedException();
+        int rowsToFetch) =>
+        _reader.ReadLineBytes(byteOffset, rowOffsetToSkip, rowsToFetch);
 
     /// <inheritdoc/>
-#pragma warning disable CA1065
-    public void Dispose() => throw new NotImplementedException();
-#pragma warning restore CA1065
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _reader.Dispose();
+        _disposed = true;
+    }
 }

--- a/src/Engine/IO/JsonLines/RowByteCache.cs
+++ b/src/Engine/IO/JsonLines/RowByteCache.cs
@@ -1,142 +1,27 @@
 namespace DataMorph.Engine.IO.JsonLines;
 
 /// <summary>
-/// Manages a sliding window cache of JSON line bytes for efficient virtual scrolling.
+/// Manages a sliding window LRU cache of JSON line bytes for efficient virtual scrolling.
 /// Uses ReadOnlyMemory&lt;byte&gt; for memory-efficient line storage.
 /// </summary>
-public sealed class RowByteCache : IDisposable
+public sealed class RowByteCache(
+    IRowIndexer indexer,
+    int capacity = 200,
+    int prefetchWindow = 20)
+    : SlidingWindowLruCache<ReadOnlyMemory<byte>>(indexer, capacity, prefetchWindow), IDisposable
 {
-    private const int DefaultCacheSize = 200;
-    private readonly IRowIndexer _indexer;
-    private readonly RowReader _reader;
-    private readonly int _cacheSize;
-    private readonly Dictionary<int, ReadOnlyMemory<byte>> _cache = [];
-    private int _cacheStartRow = -1;
-    private bool _disposed;
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="RowByteCache"/> class.
-    /// </summary>
-    /// <param name="indexer">The row indexer for obtaining byte offsets.</param>
-    /// <param name="cacheSize">The size of the sliding window cache (default: 200).</param>
-    public RowByteCache(IRowIndexer indexer, int cacheSize = DefaultCacheSize)
-    {
-        ArgumentNullException.ThrowIfNull(indexer);
-        _indexer = indexer;
-        _cacheSize = cacheSize;
-        _reader = new RowReader(indexer.FilePath);
-    }
-
-    /// <summary>
-    /// Gets the total number of lines in the JSON Lines file.
-    /// </summary>
-    public int TotalLines => (int)_indexer.TotalRows;
-
-    /// <summary>
-    /// Retrieves raw JSON bytes for a line by its index, using the cache when possible.
-    /// </summary>
-    /// <param name="lineIndex">The zero-based line index.</param>
-    /// <returns>The raw JSON bytes, or empty if not available.</returns>
-    public ReadOnlyMemory<byte> GetRow(int lineIndex)
-    {
-        ObjectDisposedException.ThrowIf(_disposed, this);
-
-        if (TotalLines == 0)
-        {
-            return ReadOnlyMemory<byte>.Empty;
-        }
-
-        if (lineIndex < 0 || lineIndex >= TotalLines)
-        {
-            return ReadOnlyMemory<byte>.Empty;
-        }
-
-        if (!_cache.ContainsKey(lineIndex))
-        {
-            UpdateCache(lineIndex);
-        }
-
-        return _cache.TryGetValue(lineIndex, out var cachedBytes) ? cachedBytes : ReadOnlyMemory<byte>.Empty;
-    }
-
-    private void UpdateCache(int requestedRow)
-    {
-        var cacheStartRow = CalculateCacheStartRow(requestedRow);
-        var rowsToFetch = CalculateRowsToFetch(cacheStartRow);
-
-        if (rowsToFetch <= 0)
-        {
-            _cache.Clear();
-            _cacheStartRow = -1;
-            return;
-        }
-
-        var (byteOffset, rowOffsetToSkip) = _indexer.GetCheckPoint(cacheStartRow);
-
-        if (byteOffset < 0)
-        {
-            return;
-        }
-
-        _cache.Clear();
-        _cacheStartRow = cacheStartRow;
-
-        LoadRowsIntoCache(cacheStartRow, byteOffset, rowOffsetToSkip, rowsToFetch);
-    }
-
-    /// <summary>
-    /// Calculates the start row of the cache window centered around the requested row.
-    /// </summary>
-    private int CalculateCacheStartRow(int requestedRow)
-    {
-        if (_cacheSize >= TotalLines)
-        {
-            return 0;
-        }
-
-        var halfCacheSize = _cacheSize / 2;
-        var cacheStartRow = Math.Max(0, requestedRow - halfCacheSize);
-        var maxValidStartRow = TotalLines - _cacheSize;
-
-        return Math.Min(cacheStartRow, maxValidStartRow);
-    }
-
-    /// <summary>
-    /// Calculates the number of rows to fetch from the cache window.
-    /// </summary>
-    private int CalculateRowsToFetch(int cacheStartRow)
-    {
-        var remainingRows = TotalLines - cacheStartRow;
-        return Math.Min(_cacheSize, remainingRows);
-    }
-
-    /// <summary>
-    /// Loads lines from the JSON Lines file and stores them in the cache.
-    /// </summary>
-    private void LoadRowsIntoCache(
-        int cacheStartRow,
-        long byteOffset,
-        int rowOffsetToSkip,
-        int rowsToFetch
-    )
-    {
-        var lines = _reader.ReadLineBytes(byteOffset, rowOffsetToSkip, rowsToFetch);
-
-        var currentRowIndex = cacheStartRow;
-        foreach (var line in lines)
-        {
-            _cache[currentRowIndex] = line;
-            currentRowIndex++;
-        }
-    }
 
     /// <inheritdoc/>
-    public void Dispose()
-    {
-        if (!_disposed)
-        {
-            _reader.Dispose();
-            _disposed = true;
-        }
-    }
+    protected override ReadOnlyMemory<byte> EmptyValue => ReadOnlyMemory<byte>.Empty;
+
+    /// <inheritdoc/>
+    protected override IEnumerable<ReadOnlyMemory<byte>> LoadRows(
+        long byteOffset,
+        int rowOffsetToSkip,
+        int rowsToFetch) => throw new NotImplementedException();
+
+    /// <inheritdoc/>
+#pragma warning disable CA1065
+    public void Dispose() => throw new NotImplementedException();
+#pragma warning restore CA1065
 }

--- a/src/Engine/IO/LinkedListExtensions.cs
+++ b/src/Engine/IO/LinkedListExtensions.cs
@@ -1,0 +1,68 @@
+using System.Diagnostics;
+
+namespace DataMorph.Engine.IO;
+
+/// <summary>
+/// Provides specialized extension methods for <see cref="LinkedList{T}"/> of <see cref="CacheEntry{TRow}"/>
+/// to encapsulate LRU mechanics and node reuse.
+/// </summary>
+internal static class LinkedListExtensions
+{
+    /// <summary>
+    /// Moves an existing node to the front (Most Recently Used) position of the list.
+    /// </summary>
+    public static void MoveToFront<TRow>(
+        this LinkedList<CacheEntry<TRow>> list,
+        LinkedListNode<CacheEntry<TRow>> node
+    )
+    {
+        list.Remove(node);
+        list.AddFirst(node);
+    }
+
+    /// <summary>
+    /// Reuses the tail (Least Recently Used) node for a new row, updating the cache dictionary
+    /// and moving the node to the front.
+    /// </summary>
+    public static void ReuseTail<TRow>(
+        this LinkedList<CacheEntry<TRow>> list,
+        Dictionary<int, LinkedListNode<CacheEntry<TRow>>> cache,
+        int rowIndex,
+        TRow rowValue,
+        TRow emptyValue
+    )
+    {
+        var node = list.Last ?? throw new UnreachableException("LRU list must be non-empty.");
+        list.Remove(node);
+
+        // Remove old entry from cache dictionary
+        cache.Remove(node.ValueRef.RowIndex);
+
+        // Update node state
+        node.ValueRef.Clear(emptyValue);
+        node.ValueRef.RowIndex = rowIndex;
+        node.ValueRef.Value = rowValue;
+
+        // Add to front and update cache dictionary
+        list.AddFirst(node);
+        cache[rowIndex] = node;
+    }
+
+    /// <summary>
+    /// Creates a new node for the given row, adds it to the front of the list,
+    /// and registers it in the cache dictionary.
+    /// </summary>
+    public static void AddNew<TRow>(
+        this LinkedList<CacheEntry<TRow>> list,
+        Dictionary<int, LinkedListNode<CacheEntry<TRow>>> cache,
+        int rowIndex,
+        TRow rowValue
+    )
+    {
+        var node = new LinkedListNode<CacheEntry<TRow>>(
+            new CacheEntry<TRow> { RowIndex = rowIndex, Value = rowValue }
+        );
+        list.AddFirst(node);
+        cache[rowIndex] = node;
+    }
+}

--- a/src/Engine/IO/SlidingWindowLruCache.cs
+++ b/src/Engine/IO/SlidingWindowLruCache.cs
@@ -16,21 +16,115 @@ public abstract class SlidingWindowLruCache<TRow>
     private const int DefaultCapacity = 200;
     private const int DefaultPrefetchWindow = 20;
 
+    private readonly Dictionary<int, LinkedListNode<CacheEntry<TRow>>> _cache;
+    private readonly LinkedList<CacheEntry<TRow>> _lruList;
+    private readonly int _capacity;
+    private readonly int _prefetchWindow;
+    private readonly IRowIndexer _indexer;
+
     /// <summary>
     /// Initializes the LRU cache with the given indexer, capacity, and prefetch window size.
     /// </summary>
     protected SlidingWindowLruCache(
         IRowIndexer indexer,
         int capacity = DefaultCapacity,
-        int prefetchWindow = DefaultPrefetchWindow) => throw new NotImplementedException();
+        int prefetchWindow = DefaultPrefetchWindow
+    )
+    {
+        ArgumentNullException.ThrowIfNull(indexer);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(capacity);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(prefetchWindow);
+        _indexer = indexer;
+        _capacity = capacity;
+        _prefetchWindow = prefetchWindow;
+        _cache = new Dictionary<int, LinkedListNode<CacheEntry<TRow>>>(capacity);
+        _lruList = new LinkedList<CacheEntry<TRow>>();
+    }
 
-    /// <inheritdoc/>
-#pragma warning disable CA1065
-    public int TotalRows => throw new NotImplementedException();
-#pragma warning restore CA1065
+    /// <summary>
+    /// Gets the total number of rows in the data source.
+    /// </summary>
+    public int TotalRows => (int)_indexer.TotalRows;
 
-    /// <inheritdoc/>
-    public TRow GetRow(int index) => throw new NotImplementedException();
+    /// <summary>
+    /// Gets the row at the specified index.
+    /// </summary>
+    /// <param name="index">The zero-based row index.</param>
+    /// <returns>The row data at the specified index, or empty value if out of range.</returns>
+    public virtual TRow GetRow(int index)
+    {
+        if (index < 0 || index >= TotalRows)
+        {
+            return EmptyValue;
+        }
+
+        if (_cache.TryGetValue(index, out var node))
+        {
+            _lruList.MoveToFront(node);
+            return node.ValueRef.Value;
+        }
+
+        Prefetch(index);
+        return _cache.TryGetValue(index, out var fetchedNode)
+            ? fetchedNode.ValueRef.Value
+            : EmptyValue;
+    }
+
+    /// <summary>
+    /// Loads a prefetch window centered around the requested row.
+    /// The requested row is loaded first to prevent self-eviction.
+    /// </summary>
+    /// <param name="requestedRow">The row that was requested.</param>
+    private void Prefetch(int requestedRow)
+    {
+        var halfWindow = _prefetchWindow / 2;
+        var maxStart = TotalRows - _prefetchWindow;
+        var windowStart = Math.Max(0, Math.Min(requestedRow - halfWindow, maxStart));
+        var windowEnd = Math.Min(windowStart + _prefetchWindow - 1, TotalRows - 1);
+
+        (var byteOffset, var rowOffsetToSkip) = _indexer.GetCheckPoint(windowStart);
+        if (byteOffset < 0)
+        {
+            return;
+        }
+        var rows = LoadRows(byteOffset, rowOffsetToSkip, windowEnd - windowStart + 1);
+        var rowsArray = rows.ToArray();
+
+        var requestedIndex = requestedRow - windowStart;
+
+        // Add non-requested rows first, then the requested row last.
+        // This guarantees the requested row is the MRU entry after prefetch,
+        // preventing self-eviction when prefetchWindow exceeds capacity.
+        for (var i = 0; i < rowsArray.Length; i++)
+        {
+            if (i != requestedIndex)
+            {
+                AddOrUpdateCache(windowStart + i, rowsArray[i]);
+            }
+        }
+
+        if (requestedIndex >= 0 && requestedIndex < rowsArray.Length)
+        {
+            AddOrUpdateCache(requestedRow, rowsArray[requestedIndex]);
+        }
+    }
+
+    private void AddOrUpdateCache(int rowIndex, TRow rowValue)
+    {
+        if (_cache.TryGetValue(rowIndex, out var node))
+        {
+            _lruList.MoveToFront(node);
+            return;
+        }
+
+        if (_lruList.Count >= _capacity)
+        {
+            _lruList.ReuseTail(_cache, rowIndex, rowValue, EmptyValue);
+            return;
+        }
+
+        _lruList.AddNew(_cache, rowIndex, rowValue);
+    }
 
     /// <summary>
     /// Gets the empty/default value for the row type, used to reset cache entries.
@@ -47,5 +141,6 @@ public abstract class SlidingWindowLruCache<TRow>
     protected abstract IEnumerable<TRow> LoadRows(
         long byteOffset,
         int rowOffsetToSkip,
-        int rowsToFetch);
+        int rowsToFetch
+    );
 }

--- a/src/Engine/IO/SlidingWindowLruCache.cs
+++ b/src/Engine/IO/SlidingWindowLruCache.cs
@@ -1,0 +1,51 @@
+namespace DataMorph.Engine.IO;
+
+/// <summary>
+/// Abstract base class implementing a sliding window LRU cache for row-based data.
+/// Combines prefetch-based loading (centered on requested row) with LRU eviction
+/// to optimize sequential and bidirectional scrolling scenarios.
+/// </summary>
+/// <typeparam name="TRow">The type of row data.</typeparam>
+/// <remarks>
+/// Thread Safety: This implementation is not thread-safe by design.
+/// All access is assumed to occur on the TUI rendering thread (single-threaded context).
+/// Future parallel access scenarios would require synchronization.
+/// </remarks>
+public abstract class SlidingWindowLruCache<TRow>
+{
+    private const int DefaultCapacity = 200;
+    private const int DefaultPrefetchWindow = 20;
+
+    /// <summary>
+    /// Initializes the LRU cache with the given indexer, capacity, and prefetch window size.
+    /// </summary>
+    protected SlidingWindowLruCache(
+        IRowIndexer indexer,
+        int capacity = DefaultCapacity,
+        int prefetchWindow = DefaultPrefetchWindow) => throw new NotImplementedException();
+
+    /// <inheritdoc/>
+#pragma warning disable CA1065
+    public int TotalRows => throw new NotImplementedException();
+#pragma warning restore CA1065
+
+    /// <inheritdoc/>
+    public TRow GetRow(int index) => throw new NotImplementedException();
+
+    /// <summary>
+    /// Gets the empty/default value for the row type, used to reset cache entries.
+    /// </summary>
+    protected abstract TRow EmptyValue { get; }
+
+    /// <summary>
+    /// Loads a range of rows from the underlying data source.
+    /// </summary>
+    /// <param name="byteOffset">The byte offset within the file to start reading from.</param>
+    /// <param name="rowOffsetToSkip">The number of rows to skip from the byte offset.</param>
+    /// <param name="rowsToFetch">The number of rows to fetch.</param>
+    /// <returns>An enumerable of row data.</returns>
+    protected abstract IEnumerable<TRow> LoadRows(
+        long byteOffset,
+        int rowOffsetToSkip,
+        int rowsToFetch);
+}

--- a/tests/DataMorph.Tests/Engine/IO/CacheEntryTests.cs
+++ b/tests/DataMorph.Tests/Engine/IO/CacheEntryTests.cs
@@ -1,0 +1,36 @@
+using AwesomeAssertions;
+using DataMorph.Engine.IO;
+
+namespace DataMorph.Tests.Engine.IO;
+
+public sealed class CacheEntryTests
+{
+    [Fact]
+    public void Clear_WhenCalled_SetsRowIndexToMinusOne()
+    {
+        // Arrange
+        var entry = new CacheEntry<int> { RowIndex = 5, Value = 100 };
+        var emptyValue = -1;
+
+        // Act
+        entry.Clear(emptyValue);
+
+        // Assert
+        entry.RowIndex.Should().Be(-1);
+    }
+
+    [Fact]
+    public void Clear_WhenCalled_SetsValueToEmptyValue()
+    {
+        // Arrange
+        var entry = new CacheEntry<string> { RowIndex = 5, Value = "test" };
+        var emptyValue = string.Empty;
+
+        // Act
+        entry.Clear(emptyValue);
+
+        // Assert
+        entry.Value.Should().Be(string.Empty);
+        entry.RowIndex.Should().Be(-1);
+    }
+}

--- a/tests/DataMorph.Tests/Engine/IO/Csv/DataRowCacheTests.cs
+++ b/tests/DataMorph.Tests/Engine/IO/Csv/DataRowCacheTests.cs
@@ -31,6 +31,13 @@ public sealed class DataRowCacheTests : IDisposable
         return result;
     }
 
+    private static string BuildCsvWith20DataRows()
+    {
+        var header = "col1,col2";
+        var dataRows = Enumerable.Range(0, 20).Select(i => $"val{i * 2 + 1},val{i * 2 + 2}");
+        return string.Join("\n", [header, .. dataRows]);
+    }
+
     [Fact]
     public void GetRow_WithValidIndex_ReturnsCorrectRow()
     {
@@ -39,7 +46,7 @@ public sealed class DataRowCacheTests : IDisposable
         File.WriteAllText(_testFilePath, csvContent);
         var indexer = new DataRowIndexer(_testFilePath);
         indexer.BuildIndex();
-        var cache = new DataRowCache(indexer, columnCount: 3, cacheSize: 10);
+        var cache = new DataRowCache(indexer, columnCount: 3, capacity: 10, prefetchWindow: 20);
 
         // Act
         var row = cache.GetRow(0);
@@ -56,7 +63,7 @@ public sealed class DataRowCacheTests : IDisposable
         File.WriteAllText(_testFilePath, csvContent);
         var indexer = new DataRowIndexer(_testFilePath);
         indexer.BuildIndex();
-        var cache = new DataRowCache(indexer, columnCount: 2, cacheSize: 10);
+        var cache = new DataRowCache(indexer, columnCount: 2, capacity: 10, prefetchWindow: 20);
 
         // Act - Request same row multiple times
         var row1 = cache.GetRow(0);
@@ -77,7 +84,7 @@ public sealed class DataRowCacheTests : IDisposable
         File.WriteAllText(_testFilePath, csvContent);
         var indexer = new DataRowIndexer(_testFilePath);
         indexer.BuildIndex();
-        var cache = new DataRowCache(indexer, columnCount: 2);
+        var cache = new DataRowCache(indexer, columnCount: 2, capacity: 200, prefetchWindow: 20);
 
         // Act
         var row = cache.GetRow(-1);
@@ -94,7 +101,7 @@ public sealed class DataRowCacheTests : IDisposable
         File.WriteAllText(_testFilePath, csvContent);
         var indexer = new DataRowIndexer(_testFilePath);
         indexer.BuildIndex();
-        var cache = new DataRowCache(indexer, columnCount: 2);
+        var cache = new DataRowCache(indexer, columnCount: 2, capacity: 200, prefetchWindow: 20);
 
         // Act
         var row = cache.GetRow(100);
@@ -107,16 +114,11 @@ public sealed class DataRowCacheTests : IDisposable
     public void GetRow_WithSmallCacheSize_HandlesWindowedReads()
     {
         // Arrange
-        var lines = new List<string> { "col1,col2" };
-        for (var i = 0; i < 20; i++)
-        {
-            lines.Add($"val{i * 2 + 1},val{i * 2 + 2}");
-        }
-
-        File.WriteAllText(_testFilePath, string.Join("\n", lines));
+        var csvContent = BuildCsvWith20DataRows();
+        File.WriteAllText(_testFilePath, csvContent);
         var indexer = new DataRowIndexer(_testFilePath);
         indexer.BuildIndex();
-        var cache = new DataRowCache(indexer, columnCount: 2, cacheSize: 5);
+        var cache = new DataRowCache(indexer, columnCount: 2, capacity: 5, prefetchWindow: 20);
 
         // Act - Request rows outside the initial cache window
         var row0 = cache.GetRow(0);
@@ -137,7 +139,7 @@ public sealed class DataRowCacheTests : IDisposable
         File.WriteAllText(_testFilePath, csvContent);
         var indexer = new DataRowIndexer(_testFilePath);
         indexer.BuildIndex();
-        var cache = new DataRowCache(indexer, columnCount: 2);
+        var cache = new DataRowCache(indexer, columnCount: 2, capacity: 200, prefetchWindow: 20);
 
         // Act & Assert - DataRowIndexer counts data rows excluding header
         cache.TotalRows.Should().Be(4);
@@ -151,7 +153,7 @@ public sealed class DataRowCacheTests : IDisposable
         File.WriteAllText(_testFilePath, csvContent);
         var indexer = new DataRowIndexer(_testFilePath);
         indexer.BuildIndex();
-        var cache = new DataRowCache(indexer, columnCount: 3);
+        var cache = new DataRowCache(indexer, columnCount: 3, capacity: 200, prefetchWindow: 20);
 
         // Act & Assert
         // Sep.Reader enforces strict column count matching by default
@@ -166,7 +168,7 @@ public sealed class DataRowCacheTests : IDisposable
         File.WriteAllText(_testFilePath, "col1,col2");
         var indexer = new DataRowIndexer(_testFilePath);
         indexer.BuildIndex();
-        var cache = new DataRowCache(indexer, columnCount: 2);
+        var cache = new DataRowCache(indexer, columnCount: 2, capacity: 200, prefetchWindow: 20);
 
         // Act & Assert - No data rows exist (only header), so TotalRows should be 0
         // row 0 is out of bounds (no data rows)

--- a/tests/DataMorph.Tests/Engine/IO/JsonLines/RowByteCacheBenchmarks.cs
+++ b/tests/DataMorph.Tests/Engine/IO/JsonLines/RowByteCacheBenchmarks.cs
@@ -55,7 +55,7 @@ public sealed class RowByteCacheBenchmarks : IDisposable
                 lineIndex = _random.Next(CacheSize + 50, (int)totalLines - 1);
             }
 
-            var bytes = cache.GetLineBytes(lineIndex);
+            var bytes = cache.GetRow(lineIndex);
             _ = bytes.Length; // Use result (prevent optimization)
         }
 
@@ -74,7 +74,7 @@ public sealed class RowByteCacheBenchmarks : IDisposable
             // Sequential access (within the same window)
             var lineIndex = i % CacheSize;
 
-            var bytes = cache.GetLineBytes(lineIndex);
+            var bytes = cache.GetRow(lineIndex);
             _ = bytes.Length; // Use result (prevent optimization)
         }
 
@@ -89,7 +89,7 @@ public sealed class RowByteCacheBenchmarks : IDisposable
         // Repeated access to the same line (100% cache hit rate)
         for (var i = 0; i < 1000; i++)
         {
-            var bytes = cache.GetLineBytes(50);
+            var bytes = cache.GetRow(50);
             _ = bytes.Length; // Use result (prevent optimization)
         }
 
@@ -108,7 +108,7 @@ public sealed class RowByteCacheBenchmarks : IDisposable
         {
             // Random access
             var lineIndex = _random.Next(0, (int)totalLines - 1);
-            var bytes = cache.GetLineBytes(lineIndex);
+            var bytes = cache.GetRow(lineIndex);
             _ = bytes.Length;
         }
 
@@ -124,7 +124,7 @@ public sealed class RowByteCacheBenchmarks : IDisposable
         for (var i = 0; i < 200; i++)
         {
             var lineIndex = _random.Next(0, 10_000);
-            var bytes = cache.GetLineBytes(lineIndex);
+            var bytes = cache.GetRow(lineIndex);
             _ = bytes.Length;
         }
 
@@ -155,7 +155,7 @@ public sealed class RowByteCacheBenchmarks : IDisposable
             for (var i = 0; i < 100; i++)
             {
                 var lineIndex = _random.Next(0, 100_000);
-                var bytes = cache.GetLineBytes(lineIndex);
+                var bytes = cache.GetRow(lineIndex);
                 _ = bytes.Length;
             }
         }
@@ -172,7 +172,7 @@ public sealed class RowByteCacheBenchmarks : IDisposable
         var cache = new RowByteCache(_indexer, CacheSize);
 
         // Initial access
-        var bytes = cache.GetLineBytes(0);
+        var bytes = cache.GetRow(0);
         _ = bytes.Length;
 
         cache.Dispose();
@@ -186,7 +186,7 @@ public sealed class RowByteCacheBenchmarks : IDisposable
         cache1.Dispose();
 
         var cache2 = new RowByteCache(_indexer, CacheSize);
-        var bytes = cache2.GetLineBytes(0);
+        var bytes = cache2.GetRow(0);
         _ = bytes.Length;
 
         cache2.Dispose();

--- a/tests/DataMorph.Tests/Engine/IO/JsonLines/RowByteCacheBenchmarks.cs
+++ b/tests/DataMorph.Tests/Engine/IO/JsonLines/RowByteCacheBenchmarks.cs
@@ -14,7 +14,7 @@ public sealed class RowByteCacheBenchmarks : IDisposable
     private bool _disposed;
 
     [Params(100, 200, 500)]
-    public int CacheSize { get; set; }
+    public int Capacity { get; set; }
 
     public RowByteCacheBenchmarks()
     {
@@ -37,7 +37,7 @@ public sealed class RowByteCacheBenchmarks : IDisposable
     [Benchmark]
     public void Access_RandomPattern_CacheHit50()
     {
-        var cache = new RowByteCache(_indexer, CacheSize);
+        var cache = new RowByteCache(_indexer, capacity: Capacity, prefetchWindow: 20);
         var totalLines = _indexer.TotalRows;
 
         // Random access pattern (approximately 50% cache hit rate)
@@ -52,7 +52,7 @@ public sealed class RowByteCacheBenchmarks : IDisposable
             else
             {
                 // Random row outside cache
-                lineIndex = _random.Next(CacheSize + 50, (int)totalLines - 1);
+                lineIndex = _random.Next(Capacity + 50, (int)totalLines - 1);
             }
 
             var bytes = cache.GetRow(lineIndex);
@@ -65,14 +65,14 @@ public sealed class RowByteCacheBenchmarks : IDisposable
     [Benchmark]
     public void Access_SequentialPattern_CacheHit90()
     {
-        var cache = new RowByteCache(_indexer, CacheSize);
+        var cache = new RowByteCache(_indexer, capacity: Capacity, prefetchWindow: 20);
         var totalLines = _indexer.TotalRows;
 
         // Sequential access pattern (approximately 90% cache hit rate)
         for (var i = 0; i < 1000; i++)
         {
             // Sequential access (within the same window)
-            var lineIndex = i % CacheSize;
+            var lineIndex = i % Capacity;
 
             var bytes = cache.GetRow(lineIndex);
             _ = bytes.Length; // Use result (prevent optimization)
@@ -84,7 +84,7 @@ public sealed class RowByteCacheBenchmarks : IDisposable
     [Benchmark]
     public void Access_RepeatedSameLine_CacheHit100()
     {
-        var cache = new RowByteCache(_indexer, CacheSize);
+        var cache = new RowByteCache(_indexer, capacity: Capacity, prefetchWindow: 20);
 
         // Repeated access to the same line (100% cache hit rate)
         for (var i = 0; i < 1000; i++)
@@ -100,7 +100,7 @@ public sealed class RowByteCacheBenchmarks : IDisposable
     public void Access_VaryingCacheSizes()
     {
         // Performance measurement with various cache sizes
-        var cache = new RowByteCache(_indexer, CacheSize);
+        var cache = new RowByteCache(_indexer, capacity: Capacity, prefetchWindow: 20);
         var totalLines = _indexer.TotalRows;
 
         // Mixed access pattern
@@ -118,7 +118,7 @@ public sealed class RowByteCacheBenchmarks : IDisposable
     [Benchmark]
     public void Access_LargeFile_10kLines()
     {
-        var cache = new RowByteCache(_indexer, CacheSize);
+        var cache = new RowByteCache(_indexer, capacity: Capacity, prefetchWindow: 20);
 
         // Random access with large file
         for (var i = 0; i < 200; i++)
@@ -149,7 +149,7 @@ public sealed class RowByteCacheBenchmarks : IDisposable
             var indexer = new RowIndexer(largeFilePath);
             indexer.BuildIndex();
 
-            using var cache = new RowByteCache(indexer, CacheSize);
+            using var cache = new RowByteCache(indexer, capacity: Capacity, prefetchWindow: 20);
 
             // Random access with large file
             for (var i = 0; i < 100; i++)
@@ -169,7 +169,7 @@ public sealed class RowByteCacheBenchmarks : IDisposable
     public void InitializeCache_FirstTime()
     {
         // Measure cache initialization cost
-        var cache = new RowByteCache(_indexer, CacheSize);
+        var cache = new RowByteCache(_indexer, capacity: Capacity, prefetchWindow: 20);
 
         // Initial access
         var bytes = cache.GetRow(0);
@@ -182,10 +182,10 @@ public sealed class RowByteCacheBenchmarks : IDisposable
     public void InitializeCache_AfterDisposal()
     {
         // Measure reinitialization cost after disposal
-        var cache1 = new RowByteCache(_indexer, CacheSize);
+        var cache1 = new RowByteCache(_indexer, capacity: Capacity, prefetchWindow: 20);
         cache1.Dispose();
 
-        var cache2 = new RowByteCache(_indexer, CacheSize);
+        var cache2 = new RowByteCache(_indexer, capacity: Capacity);
         var bytes = cache2.GetRow(0);
         _ = bytes.Length;
 

--- a/tests/DataMorph.Tests/Engine/IO/JsonLines/RowByteCacheTests.cs
+++ b/tests/DataMorph.Tests/Engine/IO/JsonLines/RowByteCacheTests.cs
@@ -37,16 +37,16 @@ public sealed partial class RowByteCacheTests : IDisposable
     }
 
     [Fact]
-    public void GetLineBytes_WithinCachedRange_ReturnsCachedBytes()
+    public void GetRow_WithinCachedRange_ReturnsCachedBytes()
     {
         // Arrange
         using var cache = new RowByteCache(_indexer, cacheSize: 5);
         var expectedLine2 = "{\"id\":2,\"name\":\"Bob\"}"u8.ToArray();
 
         // Act - Get line 2 (within cache)
-        var result1 = cache.GetLineBytes(1).ToArray();
+        var result1 = cache.GetRow(1).ToArray();
         // Get again (cache hit)
-        var result2 = cache.GetLineBytes(1).ToArray();
+        var result2 = cache.GetRow(1).ToArray();
 
         // Assert
         result1.Should().BeEquivalentTo(expectedLine2);
@@ -54,7 +54,7 @@ public sealed partial class RowByteCacheTests : IDisposable
     }
 
     [Fact]
-    public void GetLineBytes_OutsideCachedRange_UpdatesCacheWindow()
+    public void GetRow_OutsideCachedRange_UpdatesCacheWindow()
     {
         // Arrange
         using var cache = new RowByteCache(_indexer, cacheSize: 5);
@@ -62,9 +62,9 @@ public sealed partial class RowByteCacheTests : IDisposable
         var expectedLine8 = "{\"id\":8,\"name\":\"Henry\"}"u8.ToArray();
 
         // Act - First access caches lines 0-4
-        var result1 = cache.GetLineBytes(0).ToArray();
+        var result1 = cache.GetRow(0).ToArray();
         // Next access to line 7 updates cache window
-        var result2 = cache.GetLineBytes(7).ToArray();
+        var result2 = cache.GetRow(7).ToArray();
 
         // Assert
         result1.Should().BeEquivalentTo(expectedLine1);
@@ -72,7 +72,7 @@ public sealed partial class RowByteCacheTests : IDisposable
     }
 
     [Fact]
-    public void GetLineBytes_FirstLineRequested_CachesFromBeginning()
+    public void GetRow_FirstLineRequested_CachesFromBeginning()
     {
         // Arrange
         using var cache = new RowByteCache(_indexer, cacheSize: 3);
@@ -81,9 +81,9 @@ public sealed partial class RowByteCacheTests : IDisposable
         var expectedLine3 = "{\"id\":3,\"name\":\"Charlie\"}"u8.ToArray();
 
         // Act
-        var result1 = cache.GetLineBytes(0).ToArray();
-        var result2 = cache.GetLineBytes(1).ToArray();
-        var result3 = cache.GetLineBytes(2).ToArray();
+        var result1 = cache.GetRow(0).ToArray();
+        var result2 = cache.GetRow(1).ToArray();
+        var result3 = cache.GetRow(2).ToArray();
 
         // Assert
         result1.Should().BeEquivalentTo(expectedLine1);
@@ -92,7 +92,7 @@ public sealed partial class RowByteCacheTests : IDisposable
     }
 
     [Fact]
-    public void GetLineBytes_LastLineRequested_CachesToEnd()
+    public void GetRow_LastLineRequested_CachesToEnd()
     {
         // Arrange
         using var cache = new RowByteCache(_indexer, cacheSize: 3);
@@ -101,14 +101,14 @@ public sealed partial class RowByteCacheTests : IDisposable
         var expectedLastLine = "{\"id\":10,\"name\":\"Jack\"}"u8.ToArray();
 
         // Act
-        var result = cache.GetLineBytes(lastLineIndex).ToArray();
+        var result = cache.GetRow(lastLineIndex).ToArray();
 
         // Assert
         result.Should().BeEquivalentTo(expectedLastLine);
     }
 
     [Fact]
-    public void GetLineBytes_EmptyFile_ThrowsInvalidOperationException()
+    public void GetRow_EmptyFile_ThrowsInvalidOperationException()
     {
         // Arrange
         var emptyFilePath = Path.GetTempFileName();
@@ -137,13 +137,13 @@ public sealed partial class RowByteCacheTests : IDisposable
     [Theory]
     [InlineData(-1)]
     [InlineData(int.MinValue)]
-    public void GetLineBytes_NegativeIndex_ReturnsEmpty(int invalidIndex)
+    public void GetRow_NegativeIndex_ReturnsEmpty(int invalidIndex)
     {
         // Arrange
         using var cache = new RowByteCache(_indexer);
 
         // Act
-        var result = cache.GetLineBytes(invalidIndex);
+        var result = cache.GetRow(invalidIndex);
 
         // Assert
         result.IsEmpty.Should().BeTrue();
@@ -152,39 +152,39 @@ public sealed partial class RowByteCacheTests : IDisposable
     [Theory]
     [InlineData(10)]
     [InlineData(11)]
-    public void GetLineBytes_IndexEqualToOrGreaterThanTotalLines_ReturnsEmpty(int overflowIndex)
+    public void GetRow_IndexEqualToOrGreaterThanTotalLines_ReturnsEmpty(int overflowIndex)
     {
         // Arrange
         using var cache = new RowByteCache(_indexer);
 
         // Act
-        var result = cache.GetLineBytes(overflowIndex);
+        var result = cache.GetRow(overflowIndex);
 
         // Assert
         result.IsEmpty.Should().BeTrue();
     }
 
     [Fact]
-    public void UpdateCache_RequestedAtCacheCenter_KeepsExistingCache()
+    public void GetRow_RequestedAtCacheCenter_ReturnsSameValue()
     {
         // Arrange
         using var cache = new RowByteCache(_indexer, cacheSize: 5);
 
         // First access to line 2 (cache window: 0-4)
-        cache.GetLineBytes(1);
+        cache.GetRow(1);
 
         // Get line 2 again (center of cache)
-        var beforeAccess = cache.GetLineBytes(1).ToArray();
+        var beforeAccess = cache.GetRow(1).ToArray();
 
         // Act - Request same line again
-        var afterAccess = cache.GetLineBytes(1).ToArray();
+        var afterAccess = cache.GetRow(1).ToArray();
 
         // Assert - Cache should be maintained
         afterAccess.Should().BeEquivalentTo(beforeAccess);
     }
 
     [Fact]
-    public void UpdateCache_RequestedNearWindowEdge_ShiftsCacheWindow()
+    public void GetRow_RequestedNearWindowEdge_ReturnsCorrectRows()
     {
         // Arrange
         using var cache = new RowByteCache(_indexer, cacheSize: 5);
@@ -192,12 +192,12 @@ public sealed partial class RowByteCacheTests : IDisposable
         var expectedLine8 = "{\"id\":8,\"name\":\"Henry\"}"u8.ToArray();
 
         // First access sets cache window (lines 0-4)
-        cache.GetLineBytes(0);
+        cache.GetRow(0);
 
         // Act - Access edge of cache window (line 4)
-        var result1 = cache.GetLineBytes(3).ToArray();
+        var result1 = cache.GetRow(3).ToArray();
         // Access line outside cache (line 8)
-        var result2 = cache.GetLineBytes(7).ToArray();
+        var result2 = cache.GetRow(7).ToArray();
 
         // Assert
         result1.Should().BeEquivalentTo(expectedLine4);
@@ -205,15 +205,15 @@ public sealed partial class RowByteCacheTests : IDisposable
     }
 
     [Fact]
-    public void UpdateCache_CacheSizeLargerThanTotalLines_CachesAllLines()
+    public void GetRow_WithCacheLargerThanTotalLines_ReturnsAllLines()
     {
         // Arrange
         var largeCacheSize = 20; // Larger than total lines
         using var cache = new RowByteCache(_indexer, cacheSize: largeCacheSize);
 
         // Act - Get first and last lines
-        var firstLine = cache.GetLineBytes(0).ToArray();
-        var lastLine = cache.GetLineBytes(9).ToArray();
+        var firstLine = cache.GetRow(0).ToArray();
+        var lastLine = cache.GetRow(9).ToArray();
 
         // Assert
         var expectedFirst = "{\"id\":1,\"name\":\"Alice\"}"u8.ToArray();
@@ -228,42 +228,42 @@ public sealed partial class RowByteCacheTests : IDisposable
     {
         // Arrange
         using var cache = new RowByteCache(_indexer);
-        cache.GetLineBytes(0); // Normal access
+        cache.GetRow(0); // Normal access
 
         // Act
         cache.Dispose();
-        var act = () => cache.GetLineBytes(0);
+        var act = () => cache.GetRow(0);
 
         // Assert
         act.Should().Throw<ObjectDisposedException>();
     }
 
     [Fact]
-    public void GetLineBytes_AfterDisposal_ThrowsObjectDisposedException()
+    public void GetRow_AfterDisposal_ThrowsObjectDisposedException()
     {
         // Arrange
         using var cache = new RowByteCache(_indexer);
         cache.Dispose();
 
         // Act
-        var act = () => cache.GetLineBytes(0);
+        var act = () => cache.GetRow(0);
 
         // Assert
         act.Should().Throw<ObjectDisposedException>();
     }
 
     [Fact]
-    public void GetLineBytes_WithExactCacheSize_CachesExactly()
+    public void GetRow_WithExactCacheSize_CachesExactly()
     {
         // Arrange
         var cacheSize = 5;
         using var cache = new RowByteCache(_indexer, cacheSize: cacheSize);
 
         // First access initializes cache (lines 0-4)
-        cache.GetLineBytes(0);
+        cache.GetRow(0);
 
         // Act - Get last line within cache range
-        var result = cache.GetLineBytes(4).ToArray();
+        var result = cache.GetRow(4).ToArray();
 
         // Assert
         var expected = "{\"id\":5,\"name\":\"Eve\"}"u8.ToArray();
@@ -271,22 +271,22 @@ public sealed partial class RowByteCacheTests : IDisposable
     }
 
     [Fact]
-    public void UpdateCache_MultipleOverlaps_ProperlyInvalidatesOldEntries()
+    public void GetRow_WithMultipleWindowShifts_ReturnsCorrectRows()
     {
         // Arrange
         using var cache = new RowByteCache(_indexer, cacheSize: 4);
 
         // First cache (lines 0-3)
-        cache.GetLineBytes(0);
-        var firstCached = cache.GetLineBytes(2).ToArray();
+        cache.GetRow(0);
+        var firstCached = cache.GetRow(2).ToArray();
 
         // New cache (lines 6-9)
-        cache.GetLineBytes(8);
+        cache.GetRow(8);
 
         // Old cache entries should be invalidated
         // Since we cannot inspect internal cache entries,
         // verify by accessing different line
-        var newCached = cache.GetLineBytes(7).ToArray();
+        var newCached = cache.GetRow(7).ToArray();
 
         // Assert
         var expectedOld = "{\"id\":3,\"name\":\"Charlie\"}"u8.ToArray();

--- a/tests/DataMorph.Tests/Engine/IO/JsonLines/RowByteCacheTests.cs
+++ b/tests/DataMorph.Tests/Engine/IO/JsonLines/RowByteCacheTests.cs
@@ -108,7 +108,7 @@ public sealed partial class RowByteCacheTests : IDisposable
     }
 
     [Fact]
-    public void GetRow_EmptyFile_ThrowsInvalidOperationException()
+    public void Constructor_WithEmptyFile_ThrowsInvalidOperationException()
     {
         // Arrange
         using var tempFile = new TempFile();
@@ -162,17 +162,13 @@ public sealed partial class RowByteCacheTests : IDisposable
     {
         // Arrange
         using var cache = new RowByteCache(_indexer, capacity: 5, prefetchWindow: 20);
+        cache.GetRow(1); // prime the cache
+        var beforeAccess = cache.GetRow(1).ToArray(); // baseline from cached value
 
-        // First access to line 2 (cache window: 0-4)
-        cache.GetRow(1);
-
-        // Get line 2 again (center of cache)
-        var beforeAccess = cache.GetRow(1).ToArray();
-
-        // Act - Request same line again
+        // Act
         var afterAccess = cache.GetRow(1).ToArray();
 
-        // Assert - Cache should be maintained
+        // Assert
         afterAccess.Should().BeEquivalentTo(beforeAccess);
     }
 
@@ -219,9 +215,10 @@ public sealed partial class RowByteCacheTests : IDisposable
     [Fact]
     public void Dispose_AfterAccess_PreventsFurtherAccess()
     {
-        // Arrange
+        // Arrange - row 0 is already in cache (cache-hit path) when Dispose is called;
+        // verifies that the dispose guard fires before any cache lookup.
         using var cache = new RowByteCache(_indexer, capacity: 200, prefetchWindow: 20);
-        cache.GetRow(0); // Normal access
+        cache.GetRow(0);
 
         // Act
         cache.Dispose();
@@ -234,7 +231,8 @@ public sealed partial class RowByteCacheTests : IDisposable
     [Fact]
     public void GetRow_AfterDisposal_ThrowsObjectDisposedException()
     {
-        // Arrange
+        // Arrange - cache is empty (cache-miss path) when GetRow is called after Dispose;
+        // verifies that the dispose guard fires before any I/O attempt.
         using var cache = new RowByteCache(_indexer, capacity: 200, prefetchWindow: 20);
         cache.Dispose();
 
@@ -268,23 +266,16 @@ public sealed partial class RowByteCacheTests : IDisposable
     {
         // Arrange
         using var cache = new RowByteCache(_indexer, capacity: 4, prefetchWindow: 20);
-
-        // First cache (lines 0-3)
-        cache.GetRow(0);
+        cache.GetRow(0); // prime first window
         var firstCached = cache.GetRow(2).ToArray();
 
-        // New cache (lines 6-9)
+        // Act - shift window by accessing a row far outside the current cache
         cache.GetRow(8);
-
-        // Old cache entries should be invalidated
-        // Since we cannot inspect internal cache entries,
-        // verify by accessing different line
         var newCached = cache.GetRow(7).ToArray();
 
         // Assert
         var expectedOld = "{\"id\":3,\"name\":\"Charlie\"}"u8.ToArray();
         var expectedNew = "{\"id\":8,\"name\":\"Henry\"}"u8.ToArray();
-
         firstCached.Should().BeEquivalentTo(expectedOld);
         newCached.Should().BeEquivalentTo(expectedNew);
     }

--- a/tests/DataMorph.Tests/Engine/IO/JsonLines/RowByteCacheTests.cs
+++ b/tests/DataMorph.Tests/Engine/IO/JsonLines/RowByteCacheTests.cs
@@ -40,7 +40,7 @@ public sealed partial class RowByteCacheTests : IDisposable
     public void GetRow_WithinCachedRange_ReturnsCachedBytes()
     {
         // Arrange
-        using var cache = new RowByteCache(_indexer, cacheSize: 5);
+        using var cache = new RowByteCache(_indexer, capacity: 5, prefetchWindow: 20);
         var expectedLine2 = "{\"id\":2,\"name\":\"Bob\"}"u8.ToArray();
 
         // Act - Get line 2 (within cache)
@@ -57,7 +57,7 @@ public sealed partial class RowByteCacheTests : IDisposable
     public void GetRow_OutsideCachedRange_UpdatesCacheWindow()
     {
         // Arrange
-        using var cache = new RowByteCache(_indexer, cacheSize: 5);
+        using var cache = new RowByteCache(_indexer, capacity: 5, prefetchWindow: 20);
         var expectedLine1 = "{\"id\":1,\"name\":\"Alice\"}"u8.ToArray();
         var expectedLine8 = "{\"id\":8,\"name\":\"Henry\"}"u8.ToArray();
 
@@ -75,7 +75,7 @@ public sealed partial class RowByteCacheTests : IDisposable
     public void GetRow_FirstLineRequested_CachesFromBeginning()
     {
         // Arrange
-        using var cache = new RowByteCache(_indexer, cacheSize: 3);
+        using var cache = new RowByteCache(_indexer, capacity: 3, prefetchWindow: 20);
         var expectedLine1 = "{\"id\":1,\"name\":\"Alice\"}"u8.ToArray();
         var expectedLine2 = "{\"id\":2,\"name\":\"Bob\"}"u8.ToArray();
         var expectedLine3 = "{\"id\":3,\"name\":\"Charlie\"}"u8.ToArray();
@@ -95,7 +95,7 @@ public sealed partial class RowByteCacheTests : IDisposable
     public void GetRow_LastLineRequested_CachesToEnd()
     {
         // Arrange
-        using var cache = new RowByteCache(_indexer, cacheSize: 3);
+        using var cache = new RowByteCache(_indexer, capacity: 3, prefetchWindow: 20);
         var totalLines = _indexer.TotalRows;
         var lastLineIndex = (int)totalLines - 1;
         var expectedLastLine = "{\"id\":10,\"name\":\"Jack\"}"u8.ToArray();
@@ -111,27 +111,20 @@ public sealed partial class RowByteCacheTests : IDisposable
     public void GetRow_EmptyFile_ThrowsInvalidOperationException()
     {
         // Arrange
-        var emptyFilePath = Path.GetTempFileName();
-        try
+        using var tempFile = new TempFile();
+        File.WriteAllText(tempFile.Path, string.Empty);
+
+        var indexer = new RowIndexer(tempFile.Path);
+        indexer.BuildIndex();
+
+        // Act
+        var act = () =>
         {
-            File.WriteAllText(emptyFilePath, string.Empty);
+            using var cache = new RowByteCache(indexer, capacity: 200, prefetchWindow: 20);
+        };
 
-            var indexer = new RowIndexer(emptyFilePath);
-            indexer.BuildIndex();
-
-            // Act
-            var act = () =>
-            {
-                using var cache = new RowByteCache(indexer);
-            };
-
-            // Assert
-            act.Should().Throw<InvalidOperationException>();
-        }
-        finally
-        {
-            File.Delete(emptyFilePath);
-        }
+        // Assert
+        act.Should().Throw<InvalidOperationException>();
     }
 
     [Theory]
@@ -140,7 +133,7 @@ public sealed partial class RowByteCacheTests : IDisposable
     public void GetRow_NegativeIndex_ReturnsEmpty(int invalidIndex)
     {
         // Arrange
-        using var cache = new RowByteCache(_indexer);
+        using var cache = new RowByteCache(_indexer, capacity: 200, prefetchWindow: 20);
 
         // Act
         var result = cache.GetRow(invalidIndex);
@@ -155,7 +148,7 @@ public sealed partial class RowByteCacheTests : IDisposable
     public void GetRow_IndexEqualToOrGreaterThanTotalLines_ReturnsEmpty(int overflowIndex)
     {
         // Arrange
-        using var cache = new RowByteCache(_indexer);
+        using var cache = new RowByteCache(_indexer, capacity: 200, prefetchWindow: 20);
 
         // Act
         var result = cache.GetRow(overflowIndex);
@@ -168,7 +161,7 @@ public sealed partial class RowByteCacheTests : IDisposable
     public void GetRow_RequestedAtCacheCenter_ReturnsSameValue()
     {
         // Arrange
-        using var cache = new RowByteCache(_indexer, cacheSize: 5);
+        using var cache = new RowByteCache(_indexer, capacity: 5, prefetchWindow: 20);
 
         // First access to line 2 (cache window: 0-4)
         cache.GetRow(1);
@@ -187,7 +180,7 @@ public sealed partial class RowByteCacheTests : IDisposable
     public void GetRow_RequestedNearWindowEdge_ReturnsCorrectRows()
     {
         // Arrange
-        using var cache = new RowByteCache(_indexer, cacheSize: 5);
+        using var cache = new RowByteCache(_indexer, capacity: 5, prefetchWindow: 20);
         var expectedLine4 = "{\"id\":4,\"name\":\"David\"}"u8.ToArray();
         var expectedLine8 = "{\"id\":8,\"name\":\"Henry\"}"u8.ToArray();
 
@@ -208,8 +201,8 @@ public sealed partial class RowByteCacheTests : IDisposable
     public void GetRow_WithCacheLargerThanTotalLines_ReturnsAllLines()
     {
         // Arrange
-        var largeCacheSize = 20; // Larger than total lines
-        using var cache = new RowByteCache(_indexer, cacheSize: largeCacheSize);
+        var largeCapacity = 20; // Larger than total lines
+        using var cache = new RowByteCache(_indexer, capacity: largeCapacity, prefetchWindow: 20);
 
         // Act - Get first and last lines
         var firstLine = cache.GetRow(0).ToArray();
@@ -227,7 +220,7 @@ public sealed partial class RowByteCacheTests : IDisposable
     public void Dispose_AfterAccess_PreventsFurtherAccess()
     {
         // Arrange
-        using var cache = new RowByteCache(_indexer);
+        using var cache = new RowByteCache(_indexer, capacity: 200, prefetchWindow: 20);
         cache.GetRow(0); // Normal access
 
         // Act
@@ -242,7 +235,7 @@ public sealed partial class RowByteCacheTests : IDisposable
     public void GetRow_AfterDisposal_ThrowsObjectDisposedException()
     {
         // Arrange
-        using var cache = new RowByteCache(_indexer);
+        using var cache = new RowByteCache(_indexer, capacity: 200, prefetchWindow: 20);
         cache.Dispose();
 
         // Act
@@ -256,8 +249,8 @@ public sealed partial class RowByteCacheTests : IDisposable
     public void GetRow_WithExactCacheSize_CachesExactly()
     {
         // Arrange
-        var cacheSize = 5;
-        using var cache = new RowByteCache(_indexer, cacheSize: cacheSize);
+        var capacity = 5;
+        using var cache = new RowByteCache(_indexer, capacity: capacity, prefetchWindow: 20);
 
         // First access initializes cache (lines 0-4)
         cache.GetRow(0);
@@ -274,7 +267,7 @@ public sealed partial class RowByteCacheTests : IDisposable
     public void GetRow_WithMultipleWindowShifts_ReturnsCorrectRows()
     {
         // Arrange
-        using var cache = new RowByteCache(_indexer, cacheSize: 4);
+        using var cache = new RowByteCache(_indexer, capacity: 4, prefetchWindow: 20);
 
         // First cache (lines 0-3)
         cache.GetRow(0);
@@ -304,4 +297,11 @@ public sealed partial class RowByteCacheTests : IDisposable
             _disposed = true;
         }
     }
+}
+
+sealed file class TempFile : IDisposable
+{
+    private readonly string _path = System.IO.Path.GetTempFileName();
+    public string Path => _path;
+    public void Dispose() => System.IO.File.Delete(_path);
 }

--- a/tests/DataMorph.Tests/Engine/IO/LinkedListExtensionsTests.cs
+++ b/tests/DataMorph.Tests/Engine/IO/LinkedListExtensionsTests.cs
@@ -1,0 +1,177 @@
+using AwesomeAssertions;
+using DataMorph.Engine.IO;
+
+namespace DataMorph.Tests.Engine.IO;
+
+public sealed class LinkedListExtensionsTests
+{
+    [Fact]
+    public void MoveToFront_WhenNodeIsAlreadyAtHead_ListRemainsUnchanged()
+    {
+        // Arrange
+        var list = new LinkedList<CacheEntry<int>>();
+        var headNode = list.AddLast(new CacheEntry<int> { RowIndex = 1, Value = 10 });
+        list.AddLast(new CacheEntry<int> { RowIndex = 2, Value = 20 });
+
+        // Act
+        list.MoveToFront(headNode);
+
+        // Assert
+        list.First.Should().NotBeNull();
+        list.First.Value.RowIndex.Should().Be(1);
+        list.Last.Should().NotBeNull();
+        list.Last.Value.RowIndex.Should().Be(2);
+        list.Count.Should().Be(2);
+    }
+
+    [Fact]
+    public void MoveToFront_WithSingleElementList_ListRemainsUnchanged()
+    {
+        // Arrange
+        var list = new LinkedList<CacheEntry<int>>();
+        var onlyNode = list.AddLast(new CacheEntry<int> { RowIndex = 1, Value = 10 });
+
+        // Act
+        list.MoveToFront(onlyNode);
+
+        // Assert
+        list.Count.Should().Be(1);
+        list.First.Should().NotBeNull();
+        list.First.Value.RowIndex.Should().Be(1);
+    }
+
+    [Fact]
+    public void MoveToFront_WhenNodeIsInMiddle_MovesToHead()
+    {
+        // Arrange
+        var list = new LinkedList<CacheEntry<int>>();
+        list.AddLast(new CacheEntry<int> { RowIndex = 1, Value = 10 });
+        var middleNode = list.AddLast(new CacheEntry<int> { RowIndex = 2, Value = 20 });
+        list.AddLast(new CacheEntry<int> { RowIndex = 3, Value = 30 });
+
+        // Act
+        list.MoveToFront(middleNode);
+
+        // Assert
+        list.First.Should().NotBeNull();
+        list.First.Value.RowIndex.Should().Be(2);
+
+        list.First.Next.Should().NotBeNull();
+        list.First.Next.Value.RowIndex.Should().Be(1);
+
+        list.Last.Should().NotBeNull();
+        list.Last.Value.RowIndex.Should().Be(3);
+    }
+
+    [Fact]
+    public void MoveToFront_WhenNodeIsAtTail_MovesToHead()
+    {
+        // Arrange
+        var list = new LinkedList<CacheEntry<int>>();
+        list.AddLast(new CacheEntry<int> { RowIndex = 1, Value = 10 });
+        list.AddLast(new CacheEntry<int> { RowIndex = 2, Value = 20 });
+        var tailNode = list.AddLast(new CacheEntry<int> { RowIndex = 3, Value = 30 });
+
+        // Act
+        list.MoveToFront(tailNode);
+
+        // Assert
+        list.First.Should().NotBeNull();
+        list.First.Value.RowIndex.Should().Be(3);
+        list.First.Next.Should().NotBeNull();
+        list.First.Next.Value.RowIndex.Should().Be(1);
+        list.Last.Should().NotBeNull();
+        list.Last.Value.RowIndex.Should().Be(2);
+    }
+
+    [Fact]
+    public void ReuseTail_WithSingleElementList_NodeIsReusedAtFront()
+    {
+        // Arrange
+        var list = new LinkedList<CacheEntry<int>>();
+        var cache = new Dictionary<int, LinkedListNode<CacheEntry<int>>>();
+        var node1 = new LinkedListNode<CacheEntry<int>>(new CacheEntry<int> { RowIndex = 1, Value = 10 });
+        list.AddLast(node1);
+        cache[1] = node1;
+
+        // Act
+        list.ReuseTail(cache, rowIndex: 2, rowValue: 20, emptyValue: -1);
+
+        // Assert
+        list.Count.Should().Be(1);
+        list.First.Should().NotBeNull();
+        list.First.Value.RowIndex.Should().Be(2);
+        list.First.Value.Value.Should().Be(20);
+        cache.ContainsKey(1).Should().BeFalse();
+        cache.ContainsKey(2).Should().BeTrue();
+    }
+
+    [Fact]
+    public void ReuseTail_WithMultiElementList_EvictsTailAndMovesNewNodeToFront()
+    {
+        // Arrange
+        var list = new LinkedList<CacheEntry<int>>();
+        var cache = new Dictionary<int, LinkedListNode<CacheEntry<int>>>();
+
+        var node1 = new LinkedListNode<CacheEntry<int>>(new CacheEntry<int> { RowIndex = 1, Value = 10 });
+        var node2 = new LinkedListNode<CacheEntry<int>>(new CacheEntry<int> { RowIndex = 2, Value = 20 });
+
+        list.AddLast(node1);
+        list.AddLast(node2);
+        cache[1] = node1;
+        cache[2] = node2;
+
+        // Act
+        list.ReuseTail(cache, rowIndex: 3, rowValue: 30, emptyValue: -1);
+
+        // Assert
+        cache.ContainsKey(2).Should().BeFalse(); // RowIndex 2 was at tail and should be evicted
+        cache.ContainsKey(3).Should().BeTrue();
+        list.First.Should().NotBeNull();
+        list.First.Should().BeSameAs(cache[3]);
+        list.First.Value.RowIndex.Should().Be(3);
+        list.First.Value.Value.Should().Be(30);
+
+        list.Last.Should().NotBeNull();
+        list.Last.Value.RowIndex.Should().Be(1);
+        list.Count.Should().Be(2);
+    }
+
+    [Fact]
+    public void AddNew_WithEmptyList_AddsNodeToFrontAndUpdatesDictionary()
+    {
+        // Arrange
+        var list = new LinkedList<CacheEntry<int>>();
+        var cache = new Dictionary<int, LinkedListNode<CacheEntry<int>>>();
+
+        // Act
+        list.AddNew(cache, rowIndex: 1, rowValue: 10);
+
+        // Assert
+        list.Should().HaveCount(1);
+        cache.ContainsKey(1).Should().BeTrue();
+        list.First.Should().NotBeNull();
+        list.First.Should().BeSameAs(cache[1]);
+        list.First.Value.RowIndex.Should().Be(1);
+        list.First.Value.Value.Should().Be(10);
+    }
+
+    [Fact]
+    public void AddNew_WhenListIsNotEmpty_NewNodeIsAtFront()
+    {
+        // Arrange
+        var list = new LinkedList<CacheEntry<int>>();
+        var cache = new Dictionary<int, LinkedListNode<CacheEntry<int>>>();
+        list.AddNew(cache, rowIndex: 1, rowValue: 10);
+
+        // Act
+        list.AddNew(cache, rowIndex: 2, rowValue: 20);
+
+        // Assert
+        list.Count.Should().Be(2);
+        list.First.Should().NotBeNull();
+        list.First.Value.RowIndex.Should().Be(2);
+        list.Last.Should().NotBeNull();
+        list.Last.Value.RowIndex.Should().Be(1);
+    }
+}

--- a/tests/DataMorph.Tests/Engine/IO/SlidingWindowLruCacheTests.cs
+++ b/tests/DataMorph.Tests/Engine/IO/SlidingWindowLruCacheTests.cs
@@ -1,124 +1,276 @@
+using AwesomeAssertions;
+using DataMorph.Engine.IO;
+
 namespace DataMorph.Tests.Engine.IO;
 
 public sealed class SlidingWindowLruCacheTests
 {
-    [Fact]
-    public void Clear_WhenCalled_SetsRowIndexToMinusOne()
+    private sealed class MockIndexer(long totalRows) : IRowIndexer
     {
-        // Arrange
+#pragma warning disable CS0067
+        public event Action? FirstCheckpointReached;
+        public event Action<long, long>? ProgressChanged;
+        public event Action? BuildIndexCompleted;
+#pragma warning restore CS0067
 
-        // Act
+        public string FilePath => "mock.csv";
+        public long TotalRows => totalRows;
+        public long BytesRead => 0;
+        public long FileSize => totalRows * 10;
 
-        // Assert
+        public void BuildIndex(CancellationToken ct = default) { }
+
+        public (long byteOffset, int rowOffset) GetCheckPoint(long targetRow)
+        {
+            var byteOffset = targetRow * 10L;
+            return (byteOffset, 0);
+        }
     }
 
-    [Fact]
-    public void Clear_WhenCalled_SetsValueToEmptyValue()
+    private sealed class TestRowCache(
+        MockIndexer indexer,
+        int capacity = 10,
+        int prefetchWindow = 4)
+        : SlidingWindowLruCache<int>(indexer, capacity, prefetchWindow)
     {
-        // Arrange
+        public List<(long ByteOffset, int RowOffset, int RowsToFetch)> LoadCalls = [];
 
-        // Act
+        protected override int EmptyValue => -1;
 
-        // Assert
+        protected override IEnumerable<int> LoadRows(
+            long byteOffset,
+            int rowOffsetToSkip,
+            int rowsToFetch)
+        {
+            LoadCalls.Add((byteOffset, rowOffsetToSkip, rowsToFetch));
+            var startRow = (int)(byteOffset / 10);
+            return Enumerable.Range(startRow, rowsToFetch);
+        }
     }
 
     [Fact]
     public void GetRow_OnCacheMiss_LoadsPrefetchWindow()
     {
         // Arrange
+        var indexer = new MockIndexer(100);
+        var cache = new TestRowCache(indexer, capacity: 10, prefetchWindow: 4);
 
         // Act
+        var result = cache.GetRow(10);
 
         // Assert
+        result.Should().Be(10);
+        cache.LoadCalls.Should().HaveCount(1);
+        var (byteOffset, rowOffset, rows) = cache.LoadCalls[0];
+        byteOffset.Should().Be(80);
+        rowOffset.Should().Be(0);
+        rows.Should().Be(4);
     }
 
     [Fact]
     public void GetRow_OnCacheHit_UpdatesLruWithoutIo()
     {
         // Arrange
+        var indexer = new MockIndexer(100);
+        var cache = new TestRowCache(indexer, capacity: 10, prefetchWindow: 4);
+        cache.GetRow(10);
 
         // Act
+        var result = cache.GetRow(10);
 
         // Assert
+        result.Should().Be(10);
+        cache.LoadCalls.Should().HaveCount(1);
     }
 
     [Fact]
     public void GetRow_WindowAtFileStart_ClampsPrefetchWindowToStart()
     {
         // Arrange
+        var indexer = new MockIndexer(100);
+        var cache = new TestRowCache(indexer, capacity: 10, prefetchWindow: 4);
 
         // Act
+        var result = cache.GetRow(0);
 
         // Assert
+        result.Should().Be(0);
+        var (byteOffset, rowOffset, rows) = cache.LoadCalls[0];
+        byteOffset.Should().Be(0);
+        rowOffset.Should().Be(0);
+        rows.Should().Be(4);
     }
 
     [Fact]
     public void GetRow_WindowAtFileEnd_ClampsPrefetchWindowToEnd()
     {
         // Arrange
+        var indexer = new MockIndexer(100);
+        var cache = new TestRowCache(indexer, capacity: 10, prefetchWindow: 4);
 
         // Act
+        var result = cache.GetRow(99);
 
         // Assert
+        result.Should().Be(99);
+        var (_, _, rows) = cache.LoadCalls[0];
+        rows.Should().Be(4);
+        cache.GetRow(96).Should().Be(96);
+        cache.GetRow(99).Should().Be(99);
     }
 
     [Fact]
     public void GetRow_WhenCacheFull_EvictsLruTail()
     {
         // Arrange
+        var indexer = new MockIndexer(100);
+        var cache = new TestRowCache(indexer, capacity: 10, prefetchWindow: 2);
+        WarmupCache(cache, Enumerable.Range(0, 5).Select(i => i * 2));
 
         // Act
+        var result = cache.GetRow(10);
 
         // Assert
-    }
-
-    [Fact]
-    public void GetRow_AfterCacheWarmup_ReusesEvictedNode()
-    {
-        // Arrange
-
-        // Act
-
-        // Assert
+        result.Should().Be(10);
+        cache.LoadCalls.Count.Should().Be(6);
+        cache.GetRow(0);                            // reload occurs if row 0 was evicted
+        cache.LoadCalls.Count.Should().Be(7);       // I/O increased = proof of eviction
     }
 
     [Fact]
     public void GetRow_AlreadyCachedRowInPrefetchWindow_UpdatesLruWithoutDuplicate()
     {
         // Arrange
+        var indexer = new MockIndexer(100);
+        var cache = new TestRowCache(indexer, capacity: 10, prefetchWindow: 4);
+        cache.GetRow(10);
 
         // Act
+        var result = cache.GetRow(11);
 
         // Assert
+        result.Should().Be(11);
+        cache.LoadCalls.Should().HaveCount(1);
     }
 
     [Fact]
     public void GetRow_FileSmallerThanCapacity_NoExcessAllocations()
     {
         // Arrange
+        var indexer = new MockIndexer(10);
+        var cache = new TestRowCache(indexer, capacity: 20, prefetchWindow: 4);
 
         // Act
+        WarmupCache(cache, Enumerable.Range(0, 10));
 
         // Assert
+        cache.LoadCalls.Count.Should().Be(4);
     }
 
     [Fact]
     public void GetRow_OutOfRangeIndex_ReturnsDefaultValue()
     {
         // Arrange
+        var indexer = new MockIndexer(100);
+        var cache = new TestRowCache(indexer);
 
         // Act
+        var result = cache.GetRow(100);
 
         // Assert
+        result.Should().Be(-1);
     }
 
     [Fact]
     public void GetRow_WhenTotalRowsIsZero_ReturnsDefaultValue()
     {
         // Arrange
+        var indexer = new MockIndexer(0);
+        var cache = new TestRowCache(indexer);
 
         // Act
+        var result = cache.GetRow(0);
 
         // Assert
+        result.Should().Be(-1);
+    }
+
+    [Fact]
+    public void GetRow_CapacitySmallerThanPrefetchWindow_RequestedRowIsNotEvicted()
+    {
+        // Arrange
+        var indexer = new MockIndexer(100);
+        var cache = new TestRowCache(indexer, capacity: 2, prefetchWindow: 4);
+
+        // Act
+        var result = cache.GetRow(10);
+
+        // Assert
+        result.Should().Be(10);
+        cache.GetRow(10).Should().Be(10);           // can be re-retrieved
+        cache.LoadCalls.Should().HaveCount(1);      // I/O has not increased = proof that row was not evicted
+    }
+
+    [Theory]
+    [InlineData(-1)]
+    [InlineData(int.MinValue)]
+    public void GetRow_NegativeIndex_ReturnsDefaultValue(int negativeIndex)
+    {
+        // Arrange
+        var indexer = new MockIndexer(100);
+        var cache = new TestRowCache(indexer);
+
+        // Act
+        var result = cache.GetRow(negativeIndex);
+
+        // Assert
+        result.Should().Be(-1);
+    }
+
+    [Fact]
+    public void Constructor_WithNullIndexer_ThrowsArgumentNullException()
+    {
+        // Arrange
+        MockIndexer indexer = null!;
+
+        // Act
+        Action act = () => _ = new TestRowCache(indexer!, capacity: 10, prefetchWindow: 5);
+
+        // Assert
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void Constructor_WithZeroCapacity_ThrowsArgumentOutOfRangeException()
+    {
+        // Arrange
+        var indexer = new MockIndexer(10);
+
+        // Act
+        Action act = () => _ = new TestRowCache(indexer, capacity: 0, prefetchWindow: 5);
+
+        // Assert
+        act.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    [Fact]
+    public void Constructor_WithZeroPrefetchWindow_ThrowsArgumentOutOfRangeException()
+    {
+        // Arrange
+        var indexer = new MockIndexer(10);
+
+        // Act
+        Action act = () => _ = new TestRowCache(indexer, capacity: 10, prefetchWindow: 0);
+
+        // Assert
+        act.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    private static void WarmupCache(TestRowCache cache, IEnumerable<int> rows)
+    {
+        foreach (var row in rows)
+        {
+            cache.GetRow(row);
+        }
     }
 }

--- a/tests/DataMorph.Tests/Engine/IO/SlidingWindowLruCacheTests.cs
+++ b/tests/DataMorph.Tests/Engine/IO/SlidingWindowLruCacheTests.cs
@@ -1,0 +1,124 @@
+namespace DataMorph.Tests.Engine.IO;
+
+public sealed class SlidingWindowLruCacheTests
+{
+    [Fact]
+    public void Clear_WhenCalled_SetsRowIndexToMinusOne()
+    {
+        // Arrange
+
+        // Act
+
+        // Assert
+    }
+
+    [Fact]
+    public void Clear_WhenCalled_SetsValueToEmptyValue()
+    {
+        // Arrange
+
+        // Act
+
+        // Assert
+    }
+
+    [Fact]
+    public void GetRow_OnCacheMiss_LoadsPrefetchWindow()
+    {
+        // Arrange
+
+        // Act
+
+        // Assert
+    }
+
+    [Fact]
+    public void GetRow_OnCacheHit_UpdatesLruWithoutIo()
+    {
+        // Arrange
+
+        // Act
+
+        // Assert
+    }
+
+    [Fact]
+    public void GetRow_WindowAtFileStart_ClampsPrefetchWindowToStart()
+    {
+        // Arrange
+
+        // Act
+
+        // Assert
+    }
+
+    [Fact]
+    public void GetRow_WindowAtFileEnd_ClampsPrefetchWindowToEnd()
+    {
+        // Arrange
+
+        // Act
+
+        // Assert
+    }
+
+    [Fact]
+    public void GetRow_WhenCacheFull_EvictsLruTail()
+    {
+        // Arrange
+
+        // Act
+
+        // Assert
+    }
+
+    [Fact]
+    public void GetRow_AfterCacheWarmup_ReusesEvictedNode()
+    {
+        // Arrange
+
+        // Act
+
+        // Assert
+    }
+
+    [Fact]
+    public void GetRow_AlreadyCachedRowInPrefetchWindow_UpdatesLruWithoutDuplicate()
+    {
+        // Arrange
+
+        // Act
+
+        // Assert
+    }
+
+    [Fact]
+    public void GetRow_FileSmallerThanCapacity_NoExcessAllocations()
+    {
+        // Arrange
+
+        // Act
+
+        // Assert
+    }
+
+    [Fact]
+    public void GetRow_OutOfRangeIndex_ReturnsDefaultValue()
+    {
+        // Arrange
+
+        // Act
+
+        // Assert
+    }
+
+    [Fact]
+    public void GetRow_WhenTotalRowsIsZero_ReturnsDefaultValue()
+    {
+        // Arrange
+
+        // Act
+
+        // Assert
+    }
+}


### PR DESCRIPTION
## Summary

- Replace the clear-all-and-reload caching strategy with a sliding window prefetch combined with LRU eviction
- Unify `DataRowCache` and `RowByteCache` under a shared abstract base class `SlidingWindowLruCache<TRow>`
- Add `LinkedListExtensions` for zero-allocation node reuse on eviction

## Changes

- `SlidingWindowLruCache<TRow>`: abstract base class with prefetch + LRU eviction logic
- `CacheEntry<TRow>`: value-type cache entry with `Clear()` support
- `LinkedListExtensions`: `MoveToFront`, `AddNew`, `ReuseTail` helpers
- `DataRowCache`, `RowByteCache`: migrated to inherit from `SlidingWindowLruCache<TRow>`

## Test plan

- [ ] `dotnet build` passes with zero warnings
- [ ] `dotnet test` passes (1038/1038)
- [ ] Cache miss triggers prefetch window load
- [ ] Cache hit skips I/O
- [ ] Window clamps correctly at file start/end
- [ ] LRU tail is evicted when cache is full
- [ ] Requested row is never self-evicted when prefetchWindow > capacity

Closes #80