### PR TITLE
refactor: establish IDisposable chain for all data sources in table view mode

### DIFF
--- a/src/App/Views/JsonLinesTableSource.cs
+++ b/src/App/Views/JsonLinesTableSource.cs
@@ -9,13 +9,14 @@ namespace DataMorph.App.Views;
 /// Provides virtual table data source for Terminal.Gui's TableView for JSON Lines files.
 /// Delegates to RowByteCache for line retrieval and CellExtractor for cell value parsing.
 /// </summary>
-internal sealed class JsonLinesTableSource : ITableSource
+internal sealed class JsonLinesTableSource : ITableSource, IDisposable
 {
     private readonly RowByteCache _cache;
     private volatile TableSchema _schema;
     private volatile string[] _columnNames;
     private volatile string[] _rawColumnNames;
     private volatile byte[][] _columnNameUtf8;
+    private bool _disposed;
 
     /// <summary>
     /// Initializes a new instance of <see cref="JsonLinesTableSource"/>.
@@ -49,6 +50,8 @@ internal sealed class JsonLinesTableSource : ITableSource
     {
         get
         {
+            ObjectDisposedException.ThrowIf(_disposed, this);
+
             if (row < 0 || row >= Rows)
             {
                 throw new ArgumentOutOfRangeException(nameof(row));
@@ -96,4 +99,15 @@ internal sealed class JsonLinesTableSource : ITableSource
 
     private static byte[][] BuildColumnNamesUtf8(TableSchema schema) =>
         [.. schema.Columns.Select(c => Encoding.UTF8.GetBytes(c.Name))];
+
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _cache.Dispose();
+        _disposed = true;
+    }
 }

--- a/src/App/Views/LazyTransformer.cs
+++ b/src/App/Views/LazyTransformer.cs
@@ -17,7 +17,7 @@ namespace DataMorph.App.Views;
 /// <see cref="IFilterRowIndexer"/> (provided via a factory in the constructor)
 /// to map filtered row indices to source rows.
 /// </summary>
-internal sealed class LazyTransformer : ITableSource
+internal sealed class LazyTransformer : ITableSource, IDisposable
 {
     private readonly ITableSource _source;
     private readonly IReadOnlyList<int> _sourceColumnIndices;
@@ -319,4 +319,12 @@ internal sealed class LazyTransformer : ITableSource
         string? FillValue = null,
         string? FormatString = null
     );
+
+    public void Dispose()
+    {
+        if (_source is IDisposable d)
+        {
+            d.Dispose();
+        }
+    }
 }

--- a/src/App/Views/MorphTableView.cs
+++ b/src/App/Views/MorphTableView.cs
@@ -73,4 +73,14 @@ internal abstract class MorphTableView : TableView
 
         return base.OnKeyDown(key);
     }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing && Table is IDisposable disposableTable)
+        {
+            disposableTable.Dispose();
+        }
+
+        base.Dispose(disposing);
+    }
 }

--- a/src/App/Views/VirtualTableSource.cs
+++ b/src/App/Views/VirtualTableSource.cs
@@ -9,12 +9,13 @@ namespace DataMorph.App.Views;
 /// Provides virtual table data source for Terminal.Gui's TableView.
 /// Delegates to DataRowCache for efficient row retrieval.
 /// </summary>
-internal sealed class VirtualTableSource : ITableSource
+internal sealed class VirtualTableSource : ITableSource, IDisposable
 {
     private readonly DataRowCache _cache;
     private readonly TableSchema _schema;
     private readonly string[] _columnNames;
     private readonly string[] _rawColumnNames;
+    private bool _disposed;
 
     public VirtualTableSource(IRowIndexer indexer, TableSchema schema)
     {
@@ -33,6 +34,8 @@ internal sealed class VirtualTableSource : ITableSource
     {
         get
         {
+            ObjectDisposedException.ThrowIf(_disposed, this);
+
             if (row < 0 || row >= Rows)
             {
                 throw new ArgumentOutOfRangeException(nameof(row));
@@ -54,5 +57,16 @@ internal sealed class VirtualTableSource : ITableSource
             // Return empty string for columns that might not exist in a ragged CSV row
             return string.Empty;
         }
+    }
+
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _cache.Dispose();
+        _disposed = true;
     }
 }

--- a/src/Engine/IO/Csv/DataRowCache.cs
+++ b/src/Engine/IO/Csv/DataRowCache.cs
@@ -9,12 +9,20 @@ public sealed class DataRowCache(
     int columnCount,
     int capacity = 200,
     int prefetchWindow = 20)
-    : SlidingWindowLruCache<CsvDataRow>(indexer, capacity, prefetchWindow)
+    : SlidingWindowLruCache<CsvDataRow>(indexer, capacity, prefetchWindow), IDisposable
 {
     private readonly DataRowReader _reader = new(indexer.FilePath, columnCount);
+    private bool _disposed;
 
     /// <inheritdoc/>
     protected override CsvDataRow EmptyValue => [];
+
+    /// <inheritdoc/>
+    public override CsvDataRow GetRow(int index)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        return base.GetRow(index);
+    }
 
     /// <inheritdoc/>
     protected override IEnumerable<CsvDataRow> LoadRows(
@@ -22,4 +30,16 @@ public sealed class DataRowCache(
         int rowOffsetToSkip,
         int rowsToFetch) =>
         _reader.ReadRows(byteOffset, rowOffsetToSkip, rowsToFetch);
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _reader.Dispose();
+        _disposed = true;
+    }
 }

--- a/src/Engine/IO/Csv/DataRowReader.cs
+++ b/src/Engine/IO/Csv/DataRowReader.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using nietras.SeparatedValues;
 
 namespace DataMorph.Engine.IO.Csv;
@@ -6,10 +7,27 @@ namespace DataMorph.Engine.IO.Csv;
 /// Low-level CSV row reader that reads raw CSV data from a file stream.
 /// Returns rows as read-only lists of ReadOnlyMemory for memory efficiency.
 /// </summary>
-public sealed class DataRowReader(string filePath, int columnCount)
+public sealed class DataRowReader : IDisposable
 {
-    private readonly string _filePath = filePath;
-    private readonly int _columnCount = columnCount;
+    private readonly FileStream _fileStream;
+    private readonly int _columnCount;
+    private bool _disposed;
+
+    /// <summary>
+    /// Initializes a new instance of <see cref="DataRowReader"/>.
+    /// </summary>
+    /// <param name="filePath">The path to the CSV file.</param>
+    /// <param name="columnCount">The number of columns in the CSV file.</param>
+    public DataRowReader(string filePath, int columnCount)
+    {
+        _columnCount = columnCount;
+        _fileStream = new FileStream(
+            filePath,
+            FileMode.Open,
+            FileAccess.Read,
+            FileShare.Read
+        );
+    }
 
     /// <summary>
     /// Reads a specified number of rows from the CSV file starting at the given byte offset.
@@ -20,6 +38,8 @@ public sealed class DataRowReader(string filePath, int columnCount)
     /// <returns>A list of CSV rows.</returns>
     public IReadOnlyList<CsvDataRow> ReadRows(long byteOffset, int rowsToSkip, int rowsToRead)
     {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+
         if (byteOffset < 0)
         {
             return [];
@@ -34,16 +54,10 @@ public sealed class DataRowReader(string filePath, int columnCount)
 
         try
         {
-            using var fileStream = new FileStream(
-                _filePath,
-                FileMode.Open,
-                FileAccess.Read,
-                FileShare.Read
-            );
+            _fileStream.Seek(byteOffset, SeekOrigin.Begin);
 
-            fileStream.Seek(byteOffset, SeekOrigin.Begin);
-
-            using var reader = Sep.New(',').Reader(o => o with { HasHeader = false }).From(fileStream);
+            using var streamReader = new StreamReader(_fileStream, Encoding.UTF8, leaveOpen: true);
+            using var reader = Sep.New(',').Reader(o => o with { HasHeader = false }).From(streamReader);
 
             // Skip rows until the actual start row
             var skipped = 0;
@@ -101,5 +115,17 @@ public sealed class DataRowReader(string filePath, int columnCount)
         }
 
         return rows;
+    }
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _fileStream.Dispose();
+        _disposed = true;
     }
 }

--- a/src/Engine/IO/Csv/FilterRowIndexer.cs
+++ b/src/Engine/IO/Csv/FilterRowIndexer.cs
@@ -72,7 +72,7 @@ public sealed class FilterRowIndexer : IFilterRowIndexer
             return;
         }
 
-        var reader = new DataRowReader(_indexer.FilePath, _sourceColumnCount);
+        using var reader = new DataRowReader(_indexer.FilePath, _sourceColumnCount);
         var (startByteOffset, startRowOffset) = _indexer.GetCheckPoint(0);
 
         if (startByteOffset < 0)

--- a/tests/DataMorph.Tests/App/Views/JsonLinesTableSourceTests.cs
+++ b/tests/DataMorph.Tests/App/Views/JsonLinesTableSourceTests.cs
@@ -56,7 +56,7 @@ public sealed class JsonLinesTableSourceTests : IDisposable
             ],
             SourceFormat = DataFormat.JsonLines,
         };
-        var source = new JsonLinesTableSource(cache, schema);
+        using var source = new JsonLinesTableSource(cache, schema);
 
         // Act
         var result = source[0, 1]; // row 0, col 1 ("name")
@@ -96,7 +96,7 @@ public sealed class JsonLinesTableSourceTests : IDisposable
             ],
             SourceFormat = DataFormat.JsonLines,
         };
-        var source = new JsonLinesTableSource(cache, schema);
+        using var source = new JsonLinesTableSource(cache, schema);
 
         // Act
         var result = source[0, 2]; // "email" does not exist in the JSON line
@@ -155,7 +155,7 @@ public sealed class JsonLinesTableSourceTests : IDisposable
             ],
             SourceFormat = DataFormat.JsonLines,
         };
-        var source = new JsonLinesTableSource(cache, originalSchema);
+        using var source = new JsonLinesTableSource(cache, originalSchema);
 
         // Act
         source.UpdateSchema(refinedSchema);
@@ -183,7 +183,7 @@ public sealed class JsonLinesTableSourceTests : IDisposable
             ],
             SourceFormat = DataFormat.JsonLines,
         };
-        var source = new JsonLinesTableSource(cache, schema);
+        using var source = new JsonLinesTableSource(cache, schema);
 
         // Act
         var act = () => _ = source[-1, 0];
@@ -210,7 +210,7 @@ public sealed class JsonLinesTableSourceTests : IDisposable
             ],
             SourceFormat = DataFormat.JsonLines,
         };
-        var source = new JsonLinesTableSource(cache, schema);
+        using var source = new JsonLinesTableSource(cache, schema);
 
         // Act
         var act = () => _ = source[0, -1];
@@ -237,7 +237,7 @@ public sealed class JsonLinesTableSourceTests : IDisposable
             ],
             SourceFormat = DataFormat.JsonLines,
         };
-        var source = new JsonLinesTableSource(cache, schema);
+        using var source = new JsonLinesTableSource(cache, schema);
 
         // Act
         var act = () => _ = source[2, 0]; // Only 2 rows (index 0 and 1), so row 2 is out of range
@@ -264,7 +264,7 @@ public sealed class JsonLinesTableSourceTests : IDisposable
             ],
             SourceFormat = DataFormat.JsonLines,
         };
-        var source = new JsonLinesTableSource(cache, schema);
+        using var source = new JsonLinesTableSource(cache, schema);
 
         // Act
         var act = () => _ = source[0, 1]; // Only 1 column (index 0), so col 1 is out of range
@@ -291,12 +291,36 @@ public sealed class JsonLinesTableSourceTests : IDisposable
             ],
             SourceFormat = DataFormat.JsonLines,
         };
-        var source = new JsonLinesTableSource(cache, schema);
+        using var source = new JsonLinesTableSource(cache, schema);
 
         // Act
         var rows = source.Rows;
 
         // Assert
         rows.Should().Be(2); // Two lines written in test setup
+    }
+
+    [Fact]
+    public void Dispose_DisposesRowByteCache()
+    {
+        // Arrange
+#pragma warning disable CA2000 // Ownership transferred to source
+        var cache = new RowByteCache(_indexer);
+#pragma warning restore CA2000
+        var schema = new TableSchema
+        {
+            Columns = [new ColumnSchema { Name = "id", Type = ColumnType.WholeNumber, ColumnIndex = 0 }],
+            SourceFormat = DataFormat.JsonLines,
+        };
+        var source = new JsonLinesTableSource(cache, schema);
+        _ = source[0, 0]; // Ensure MmapService is initialized
+
+        // Act
+        source.Dispose();
+
+        // Assert
+        // Verify indexer throws ObjectDisposedException
+        var act = () => _ = source[0, 0];
+        act.Should().Throw<ObjectDisposedException>();
     }
 }

--- a/tests/DataMorph.Tests/App/Views/LazyTransformerTests.cs
+++ b/tests/DataMorph.Tests/App/Views/LazyTransformerTests.cs
@@ -34,6 +34,17 @@ public sealed class LazyTransformerTests
         public Task BuildIndexAsync(CancellationToken ct) => Task.CompletedTask;
     }
 
+    private sealed class DisposableFakeTableSource(string[][] data, string[] columnNames)
+        : ITableSource, IDisposable
+    {
+        public bool IsDisposed { get; private set; }
+        public int Rows => data.Length;
+        public int Columns => columnNames.Length;
+        public string[] ColumnNames => columnNames;
+        public object this[int row, int col] => data[row][col];
+        public void Dispose() => IsDisposed = true;
+    }
+
     private static TableSchema MakeSchema(params (string name, ColumnType type)[] cols) =>
         new TableSchema
         {
@@ -134,7 +145,7 @@ public sealed class LazyTransformerTests
         ];
 
         // Act
-        var transformer = new LazyTransformer(source, schema, actions);
+        using var transformer = new LazyTransformer(source, schema, actions);
 
         // Assert
         transformer.ColumnNames[0].Should().Be("X (text)");
@@ -156,7 +167,7 @@ public sealed class LazyTransformerTests
         [
             new RenameColumnAction { OldName = "A", NewName = "X" },
         ];
-        var transformer = new LazyTransformer(source, schema, actions);
+        using var transformer = new LazyTransformer(source, schema, actions);
 
         // Act
         var result = transformer[0, 0];
@@ -187,7 +198,7 @@ public sealed class LazyTransformerTests
         IReadOnlyList<MorphAction> actions = [new DeleteColumnAction { ColumnName = "B" }];
 
         // Act
-        var transformer = new LazyTransformer(source, schema, actions);
+        using var transformer = new LazyTransformer(source, schema, actions);
 
         // Assert
         transformer.Columns.Should().Be(2);
@@ -210,7 +221,7 @@ public sealed class LazyTransformerTests
             ("C", ColumnType.Text)
         );
         IReadOnlyList<MorphAction> actions = [new DeleteColumnAction { ColumnName = "B" }];
-        var transformer = new LazyTransformer(source, schema, actions);
+        using var transformer = new LazyTransformer(source, schema, actions);
 
         // Act
         var result = transformer[0, 1]; // output col 1 → source col 2 (C)
@@ -233,7 +244,7 @@ public sealed class LazyTransformerTests
         IReadOnlyList<MorphAction> actions = [new DeleteColumnAction { ColumnName = "A" }];
 
         // Act
-        var transformer = new LazyTransformer(source, schema, actions);
+        using var transformer = new LazyTransformer(source, schema, actions);
 
         // Assert
         transformer.Columns.Should().Be(0);
@@ -260,7 +271,7 @@ public sealed class LazyTransformerTests
         ];
 
         // Act
-        var transformer = new LazyTransformer(source, schema, actions);
+        using var transformer = new LazyTransformer(source, schema, actions);
 
         // Assert
         // ColumnType is reflected through FormatCellValue behaviour: valid integer is returned as-is
@@ -289,7 +300,7 @@ public sealed class LazyTransformerTests
         ];
 
         // Act
-        var transformer = new LazyTransformer(source, schema, actions);
+        using var transformer = new LazyTransformer(source, schema, actions);
 
         // Assert
         transformer.Columns.Should().Be(1);
@@ -311,7 +322,7 @@ public sealed class LazyTransformerTests
             ["A"]
         );
         var schema = MakeSchema(("A", ColumnType.Text));
-        var transformer = new LazyTransformer(source, schema, []);
+        using var transformer = new LazyTransformer(source, schema, []);
 
         // Act
         var result = transformer[0, 0];
@@ -346,7 +357,7 @@ public sealed class LazyTransformerTests
         [
             new CastColumnAction { ColumnName = "A", TargetType = targetType },
         ];
-        var transformer = new LazyTransformer(source, schema, actions);
+        using var transformer = new LazyTransformer(source, schema, actions);
 
         // Act
         var result = transformer[0, 0];
@@ -376,7 +387,7 @@ public sealed class LazyTransformerTests
         [
             new CastColumnAction { ColumnName = "A", TargetType = targetType },
         ];
-        var transformer = new LazyTransformer(source, schema, actions);
+        using var transformer = new LazyTransformer(source, schema, actions);
 
         // Act
         var result = transformer[0, 0];
@@ -406,7 +417,7 @@ public sealed class LazyTransformerTests
         ];
 
         // Act
-        var transformer = new LazyTransformer(source, schema, actions);
+        using var transformer = new LazyTransformer(source, schema, actions);
 
         // Assert
         transformer.Columns.Should().Be(1);
@@ -427,7 +438,7 @@ public sealed class LazyTransformerTests
             ["A"]
         );
         var schema = MakeSchema(("A", ColumnType.Text));
-        var transformer = new LazyTransformer(source, schema, []);
+        using var transformer = new LazyTransformer(source, schema, []);
 
         // Act
         var act = () => _ = transformer[-1, 0];
@@ -447,7 +458,7 @@ public sealed class LazyTransformerTests
             ["A"]
         );
         var schema = MakeSchema(("A", ColumnType.Text));
-        var transformer = new LazyTransformer(source, schema, []);
+        using var transformer = new LazyTransformer(source, schema, []);
 
         // Act
         var act = () => _ = transformer[0, -1];
@@ -467,7 +478,7 @@ public sealed class LazyTransformerTests
             ["A"]
         );
         var schema = MakeSchema(("A", ColumnType.Text));
-        var transformer = new LazyTransformer(source, schema, []);
+        using var transformer = new LazyTransformer(source, schema, []);
 
         // Act
         var act = () => _ = transformer[1, 0]; // only row 0 exists
@@ -487,7 +498,7 @@ public sealed class LazyTransformerTests
             ["A"]
         );
         var schema = MakeSchema(("A", ColumnType.Text));
-        var transformer = new LazyTransformer(source, schema, []);
+        using var transformer = new LazyTransformer(source, schema, []);
 
         // Act
         var act = () => _ = transformer[0, 1]; // only col 0 exists
@@ -515,7 +526,7 @@ public sealed class LazyTransformerTests
             ["A"]
         );
         var schema = MakeSchema(("A", ColumnType.Text));
-        var transformer = new LazyTransformer(source, schema, []);
+        using var transformer = new LazyTransformer(source, schema, []);
 
         // Act
         var rows = transformer.Rows;
@@ -540,7 +551,7 @@ public sealed class LazyTransformerTests
             ("C", ColumnType.Text)
         );
         IReadOnlyList<MorphAction> actions = [new DeleteColumnAction { ColumnName = "B" }];
-        var transformer = new LazyTransformer(source, schema, actions);
+        using var transformer = new LazyTransformer(source, schema, actions);
 
         // Act
         var columns = transformer.Columns;
@@ -564,7 +575,7 @@ public sealed class LazyTransformerTests
         [
             new RenameColumnAction { OldName = "A", NewName = "X" },
         ];
-        var transformer = new LazyTransformer(source, schema, actions);
+        using var transformer = new LazyTransformer(source, schema, actions);
 
         // Act
         var names = transformer.ColumnNames;
@@ -601,7 +612,7 @@ public sealed class LazyTransformerTests
         ];
 
         // Act — rows 0 and 2 match "Alice"
-        var transformer = MakeFilteredTransformer(source, schema, actions, [0, 2]);
+        using var transformer = MakeFilteredTransformer(source, schema, actions, [0, 2]);
 
         // Assert
         transformer.Rows.Should().Be(2);
@@ -634,7 +645,7 @@ public sealed class LazyTransformerTests
         ];
 
         // Act — rows 0 ("apple") and 2 ("apricot") contain "ap"
-        var transformer = MakeFilteredTransformer(source, schema, actions, [0, 2]);
+        using var transformer = MakeFilteredTransformer(source, schema, actions, [0, 2]);
 
         // Assert
         transformer.Rows.Should().Be(2);
@@ -677,7 +688,7 @@ public sealed class LazyTransformerTests
         ];
 
         // Act — only row 0 ("Alice", "30") matches both filters
-        var transformer = MakeFilteredTransformer(source, schema, actions, [0]);
+        using var transformer = MakeFilteredTransformer(source, schema, actions, [0]);
 
         // Assert
         transformer.Rows.Should().Be(1);
@@ -708,7 +719,7 @@ public sealed class LazyTransformerTests
         ];
 
         // Act — no rows match "Charlie"
-        var transformer = MakeFilteredTransformer(source, schema, actions, []);
+        using var transformer = MakeFilteredTransformer(source, schema, actions, []);
 
         // Assert
         transformer.Rows.Should().Be(0);
@@ -742,7 +753,7 @@ public sealed class LazyTransformerTests
         ];
 
         // Act — only row 0 ("Alice") matches
-        var transformer = MakeFilteredTransformer(source, schema, actions, [0]);
+        using var transformer = MakeFilteredTransformer(source, schema, actions, [0]);
 
         // Assert
         transformer.Rows.Should().Be(1);
@@ -775,7 +786,7 @@ public sealed class LazyTransformerTests
 
         // Act — the filter spec is skipped (Status column was deleted), so no FilterSpec
         // is generated and the factory is never called; all source rows are exposed
-        var transformer = MakeFilteredTransformer(source, schema, actions, []);
+        using var transformer = MakeFilteredTransformer(source, schema, actions, []);
 
         // Assert — both rows retained because the filter was silently skipped
         transformer.Rows.Should().Be(2);
@@ -810,7 +821,7 @@ public sealed class LazyTransformerTests
         ];
 
         // Act — rows 1 (50) and 2 (30) are greater than 20
-        var transformer = MakeFilteredTransformer(source, schema, actions, [1, 2]);
+        using var transformer = MakeFilteredTransformer(source, schema, actions, [1, 2]);
 
         // Assert
         transformer.Rows.Should().Be(2);
@@ -841,7 +852,7 @@ public sealed class LazyTransformerTests
         ];
 
         // Act — numeric operators on Text columns always return false, so no rows match
-        var transformer = MakeFilteredTransformer(source, schema, actions, []);
+        using var transformer = MakeFilteredTransformer(source, schema, actions, []);
 
         // Assert — all rows excluded because numeric operators are unsupported on Text columns
         transformer.Rows.Should().Be(0);
@@ -870,7 +881,7 @@ public sealed class LazyTransformerTests
         ];
 
         // Act
-        var transformer = new LazyTransformer(source, schema, actions);
+        using var transformer = new LazyTransformer(source, schema, actions);
 
         // Assert
         transformer[0, 0].Should().Be("FILLED");
@@ -895,7 +906,7 @@ public sealed class LazyTransformerTests
         ];
 
         // Act
-        var transformer = new LazyTransformer(source, schema, actions);
+        using var transformer = new LazyTransformer(source, schema, actions);
 
         // Assert
         transformer[0, 0].Should().Be("a1");
@@ -919,7 +930,7 @@ public sealed class LazyTransformerTests
         ];
 
         // Act
-        var transformer = new LazyTransformer(source, schema, actions);
+        using var transformer = new LazyTransformer(source, schema, actions);
 
         // Assert
         transformer[0, 0].Should().Be(string.Empty);
@@ -944,7 +955,7 @@ public sealed class LazyTransformerTests
         ];
 
         // Act
-        var transformer = new LazyTransformer(source, schema, actions);
+        using var transformer = new LazyTransformer(source, schema, actions);
 
         // Assert
         transformer.ColumnNames[0].Should().Be("X (text)");
@@ -970,7 +981,7 @@ public sealed class LazyTransformerTests
         ];
 
         // Act
-        var transformer = new LazyTransformer(source, schema, actions);
+        using var transformer = new LazyTransformer(source, schema, actions);
 
         // Assert
         transformer[0, 0].Should().Be("second");
@@ -997,7 +1008,7 @@ public sealed class LazyTransformerTests
         ];
 
         // Act
-        var transformer = new LazyTransformer(source, schema, actions);
+        using var transformer = new LazyTransformer(source, schema, actions);
 
         // Assert
         transformer[0, 0].Should().Be("a1");
@@ -1023,7 +1034,7 @@ public sealed class LazyTransformerTests
         ];
 
         // Act
-        var transformer = new LazyTransformer(source, schema, actions);
+        using var transformer = new LazyTransformer(source, schema, actions);
 
         // Assert
         transformer.ColumnNames[0].Should().Be("X (text)");
@@ -1048,7 +1059,7 @@ public sealed class LazyTransformerTests
         ];
 
         // Act
-        var transformer = new LazyTransformer(source, schema, actions);
+        using var transformer = new LazyTransformer(source, schema, actions);
 
         // Assert
         // FillValue takes precedence over cast formatting
@@ -1076,7 +1087,7 @@ public sealed class LazyTransformerTests
         ];
 
         // Act
-        var transformer = new LazyTransformer(source, schema, actions);
+        using var transformer = new LazyTransformer(source, schema, actions);
 
         // Assert
         // All three columns should be present after fill action
@@ -1104,7 +1115,7 @@ public sealed class LazyTransformerTests
         var schema = MakeSchema(("Age", ColumnType.WholeNumber), ("Name", ColumnType.Text));
 
         // Act
-        var transformer = new LazyTransformer(source, schema, []);
+        using var transformer = new LazyTransformer(source, schema, []);
 
         // Assert
         transformer.RawColumnNames[0].Should().Be("Age");
@@ -1128,7 +1139,7 @@ public sealed class LazyTransformerTests
         ];
 
         // Act
-        var transformer = new LazyTransformer(source, schema, actions);
+        using var transformer = new LazyTransformer(source, schema, actions);
 
         // Assert
         transformer.RawColumnNames[0].Should().Be("X");
@@ -1153,7 +1164,7 @@ public sealed class LazyTransformerTests
         IReadOnlyList<MorphAction> actions = [new DeleteColumnAction { ColumnName = "B" }];
 
         // Act
-        var transformer = new LazyTransformer(source, schema, actions);
+        using var transformer = new LazyTransformer(source, schema, actions);
 
         // Assert
         transformer.RawColumnNames.Should().BeEquivalentTo(["A", "C"], o => o.WithStrictOrdering());
@@ -1171,7 +1182,7 @@ public sealed class LazyTransformerTests
         ];
 
         // Act
-        var transformer = new LazyTransformer(source, schema, actions);
+        using var transformer = new LazyTransformer(source, schema, actions);
 
         // Assert
         transformer.ColumnNames[0].Should().Be("A (number)");
@@ -1191,7 +1202,7 @@ public sealed class LazyTransformerTests
         var schema = MakeSchema(("Age", ColumnType.WholeNumber), ("Name", ColumnType.Text));
 
         // Act
-        var transformer = new LazyTransformer(source, schema, []);
+        using var transformer = new LazyTransformer(source, schema, []);
 
         // Assert
         transformer.ColumnNames[0].Should().Be("Age (number)");
@@ -1227,7 +1238,7 @@ public sealed class LazyTransformerTests
         ];
 
         // Act
-        var transformer = new LazyTransformer(source, schema, actions);
+        using var transformer = new LazyTransformer(source, schema, actions);
 
         // Assert
         transformer.ColumnNames[0].Should().Be($"A ({expectedLabel})");
@@ -1246,7 +1257,7 @@ public sealed class LazyTransformerTests
         ];
 
         // Act
-        var transformer = new LazyTransformer(source, schema, actions);
+        using var transformer = new LazyTransformer(source, schema, actions);
 
         // Assert
         transformer.ColumnNames[0].Should().Be("Price (text)");
@@ -1265,7 +1276,7 @@ public sealed class LazyTransformerTests
         ];
 
         // Act
-        var transformer = new LazyTransformer(source, schema, actions);
+        using var transformer = new LazyTransformer(source, schema, actions);
 
         // Assert
         transformer.ColumnNames[0].Should().Be("Value (number)");
@@ -1295,7 +1306,7 @@ public sealed class LazyTransformerTests
                 TargetFormat = "yyyy/MM/dd",
             },
         ];
-        var transformer = new LazyTransformer(source, schema, actions);
+        using var transformer = new LazyTransformer(source, schema, actions);
 
         // Act
         var result = transformer[0, 0];
@@ -1325,7 +1336,7 @@ public sealed class LazyTransformerTests
         ];
 
         // Act
-        var transformer = new LazyTransformer(source, schema, actions);
+        using var transformer = new LazyTransformer(source, schema, actions);
 
         // Assert
         transformer[0, 0].Should().Be("hello");
@@ -1353,7 +1364,7 @@ public sealed class LazyTransformerTests
         ];
 
         // Act
-        var transformer = new LazyTransformer(source, schema, actions);
+        using var transformer = new LazyTransformer(source, schema, actions);
 
         // Assert
         transformer[0, 0].Should().Be("2024/01/15");
@@ -1385,7 +1396,7 @@ public sealed class LazyTransformerTests
         ];
 
         // Act
-        var transformer = new LazyTransformer(source, schema, actions);
+        using var transformer = new LazyTransformer(source, schema, actions);
 
         // Assert
         transformer[0, 0].Should().Be("01/15/2024");
@@ -1412,7 +1423,7 @@ public sealed class LazyTransformerTests
         ];
 
         // Act
-        var transformer = new LazyTransformer(source, schema, actions);
+        using var transformer = new LazyTransformer(source, schema, actions);
 
         // Assert
         transformer[0, 0].Should().Be("<invalid>");
@@ -1437,12 +1448,27 @@ public sealed class LazyTransformerTests
                 TargetFormat = string.Empty,
             },
         ];
-        var transformer = new LazyTransformer(source, schema, actions);
+        using var transformer = new LazyTransformer(source, schema, actions);
 
         // Act
         var result = transformer[0, 0];
 
         // Assert
         result.Should().Be("2024-01-15 09:30:00");
+    }
+
+    [Fact]
+    public void Dispose_DisposesUnderlyingSource()
+    {
+        // Arrange
+        using var source = new DisposableFakeTableSource([["a"]], ["A"]);
+        var schema = MakeSchema(("A", ColumnType.Text));
+        var transformer = new LazyTransformer(source, schema, []);
+
+        // Act
+        transformer.Dispose();
+
+        // Assert
+        source.IsDisposed.Should().BeTrue();
     }
 }

--- a/tests/DataMorph.Tests/App/Views/MorphTableViewTests.cs
+++ b/tests/DataMorph.Tests/App/Views/MorphTableViewTests.cs
@@ -1,0 +1,60 @@
+using AwesomeAssertions;
+using DataMorph.App.Views;
+using Terminal.Gui.Views;
+
+namespace DataMorph.Tests.App.Views;
+
+public sealed class MorphTableViewTests
+{
+    private sealed class ConcreteMorphTableView : MorphTableView
+    {
+    }
+
+    private sealed class DisposableTableSource : ITableSource, IDisposable
+    {
+        public bool IsDisposed { get; private set; }
+        public int Rows => 0;
+        public int Columns => 0;
+        public string[] ColumnNames => [];
+        public object this[int row, int col] => throw new NotImplementedException();
+        public void Dispose() => IsDisposed = true;
+    }
+
+    private sealed class NonDisposableTableSource : ITableSource
+    {
+        public int Rows => 0;
+        public int Columns => 0;
+        public string[] ColumnNames => [];
+        public object this[int row, int col] => throw new NotImplementedException();
+    }
+
+    [Fact]
+    public void Dispose_DisposesTableIfIDisposable()
+    {
+        // Arrange
+        using var view = new ConcreteMorphTableView();
+        using var table = new DisposableTableSource();
+        view.Table = table;
+
+        // Act
+        view.Dispose();
+
+        // Assert
+        table.IsDisposed.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Dispose_DoesNotThrow_WhenTableIsNotIDisposable()
+    {
+        // Arrange
+        using var view = new ConcreteMorphTableView();
+        var table = new NonDisposableTableSource();
+        view.Table = table;
+
+        // Act
+        var act = () => view.Dispose();
+
+        // Assert
+        act.Should().NotThrow();
+    }
+}

--- a/tests/DataMorph.Tests/App/Views/VirtualTableSourceTests.cs
+++ b/tests/DataMorph.Tests/App/Views/VirtualTableSourceTests.cs
@@ -1,0 +1,53 @@
+using AwesomeAssertions;
+using DataMorph.App.Views;
+using DataMorph.Engine.IO.Csv;
+using DataMorph.Engine.Models;
+
+namespace DataMorph.Tests.App.Views;
+
+public sealed class VirtualTableSourceTests : IDisposable
+{
+    private readonly string _testFilePath;
+
+    public VirtualTableSourceTests()
+    {
+        _testFilePath = Path.Combine(Path.GetTempPath(), $"virtualTableSource_{Guid.NewGuid()}.csv");
+    }
+
+    public void Dispose()
+    {
+        if (File.Exists(_testFilePath))
+        {
+            File.Delete(_testFilePath);
+        }
+    }
+
+    [Fact]
+    public void Dispose_DisposesCacheAndReader()
+    {
+        // Arrange
+        var csvContent = "col1,col2\nval1,val2";
+        File.WriteAllText(_testFilePath, csvContent);
+        var indexer = new DataRowIndexer(_testFilePath);
+        indexer.BuildIndex();
+        var schema = new TableSchema
+        {
+            Columns =
+            [
+                new ColumnSchema { ColumnIndex = 0, Name = "col1", Type = DataMorph.Engine.Types.ColumnType.Text },
+                new ColumnSchema { ColumnIndex = 1, Name = "col2", Type = DataMorph.Engine.Types.ColumnType.Text }
+            ],
+            SourceFormat = DataMorph.Engine.Types.DataFormat.Csv
+        };
+        using var source = new VirtualTableSource(indexer, schema);
+        _ = source[0, 0]; // Ensure cache and reader are initialized
+
+        // Act
+        source.Dispose();
+
+        // Assert
+        // Verify indexer throws ObjectDisposedException
+        var act = () => _ = source[0, 0];
+        act.Should().Throw<ObjectDisposedException>();
+    }
+}

--- a/tests/DataMorph.Tests/Engine/IO/Csv/DataRowCacheTests.cs
+++ b/tests/DataMorph.Tests/Engine/IO/Csv/DataRowCacheTests.cs
@@ -46,7 +46,7 @@ public sealed class DataRowCacheTests : IDisposable
         File.WriteAllText(_testFilePath, csvContent);
         var indexer = new DataRowIndexer(_testFilePath);
         indexer.BuildIndex();
-        var cache = new DataRowCache(indexer, columnCount: 3, capacity: 10, prefetchWindow: 20);
+        using var cache = new DataRowCache(indexer, columnCount: 3, capacity: 10, prefetchWindow: 20);
 
         // Act
         var row = cache.GetRow(0);
@@ -63,7 +63,7 @@ public sealed class DataRowCacheTests : IDisposable
         File.WriteAllText(_testFilePath, csvContent);
         var indexer = new DataRowIndexer(_testFilePath);
         indexer.BuildIndex();
-        var cache = new DataRowCache(indexer, columnCount: 2, capacity: 10, prefetchWindow: 20);
+        using var cache = new DataRowCache(indexer, columnCount: 2, capacity: 10, prefetchWindow: 20);
 
         // Act - Request same row multiple times
         var row1 = cache.GetRow(0);
@@ -84,7 +84,7 @@ public sealed class DataRowCacheTests : IDisposable
         File.WriteAllText(_testFilePath, csvContent);
         var indexer = new DataRowIndexer(_testFilePath);
         indexer.BuildIndex();
-        var cache = new DataRowCache(indexer, columnCount: 2, capacity: 200, prefetchWindow: 20);
+        using var cache = new DataRowCache(indexer, columnCount: 2, capacity: 200, prefetchWindow: 20);
 
         // Act
         var row = cache.GetRow(-1);
@@ -101,7 +101,7 @@ public sealed class DataRowCacheTests : IDisposable
         File.WriteAllText(_testFilePath, csvContent);
         var indexer = new DataRowIndexer(_testFilePath);
         indexer.BuildIndex();
-        var cache = new DataRowCache(indexer, columnCount: 2, capacity: 200, prefetchWindow: 20);
+        using var cache = new DataRowCache(indexer, columnCount: 2, capacity: 200, prefetchWindow: 20);
 
         // Act
         var row = cache.GetRow(100);
@@ -118,7 +118,7 @@ public sealed class DataRowCacheTests : IDisposable
         File.WriteAllText(_testFilePath, csvContent);
         var indexer = new DataRowIndexer(_testFilePath);
         indexer.BuildIndex();
-        var cache = new DataRowCache(indexer, columnCount: 2, capacity: 5, prefetchWindow: 20);
+        using var cache = new DataRowCache(indexer, columnCount: 2, capacity: 5, prefetchWindow: 20);
 
         // Act - Request rows outside the initial cache window
         var row0 = cache.GetRow(0);
@@ -139,7 +139,7 @@ public sealed class DataRowCacheTests : IDisposable
         File.WriteAllText(_testFilePath, csvContent);
         var indexer = new DataRowIndexer(_testFilePath);
         indexer.BuildIndex();
-        var cache = new DataRowCache(indexer, columnCount: 2, capacity: 200, prefetchWindow: 20);
+        using var cache = new DataRowCache(indexer, columnCount: 2, capacity: 200, prefetchWindow: 20);
 
         // Act & Assert - DataRowIndexer counts data rows excluding header
         cache.TotalRows.Should().Be(4);
@@ -153,7 +153,7 @@ public sealed class DataRowCacheTests : IDisposable
         File.WriteAllText(_testFilePath, csvContent);
         var indexer = new DataRowIndexer(_testFilePath);
         indexer.BuildIndex();
-        var cache = new DataRowCache(indexer, columnCount: 3, capacity: 200, prefetchWindow: 20);
+        using var cache = new DataRowCache(indexer, columnCount: 3, capacity: 200, prefetchWindow: 20);
 
         // Act & Assert
         // Sep.Reader enforces strict column count matching by default
@@ -168,12 +168,31 @@ public sealed class DataRowCacheTests : IDisposable
         File.WriteAllText(_testFilePath, "col1,col2");
         var indexer = new DataRowIndexer(_testFilePath);
         indexer.BuildIndex();
-        var cache = new DataRowCache(indexer, columnCount: 2, capacity: 200, prefetchWindow: 20);
+        using var cache = new DataRowCache(indexer, columnCount: 2, capacity: 200, prefetchWindow: 20);
 
         // Act & Assert - No data rows exist (only header), so TotalRows should be 0
         // row 0 is out of bounds (no data rows)
         cache.TotalRows.Should().Be(0);
         var row = cache.GetRow(0);
         row.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Dispose_DisposesReader()
+    {
+        // Arrange
+        var csvContent = "col1,col2\nval1,val2";
+        File.WriteAllText(_testFilePath, csvContent);
+        var indexer = new DataRowIndexer(_testFilePath);
+        indexer.BuildIndex();
+        var cache = new DataRowCache(indexer, columnCount: 2);
+        cache.GetRow(0);
+
+        // Act
+        cache.Dispose();
+
+        // Assert — verify the underlying FileStream was released by acquiring exclusive access
+        using var stream = new FileStream(_testFilePath, FileMode.Open, FileAccess.Read, FileShare.None);
+        stream.Should().NotBeNull();
     }
 }

--- a/tests/DataMorph.Tests/Engine/IO/Csv/DataRowReaderTests.cs
+++ b/tests/DataMorph.Tests/Engine/IO/Csv/DataRowReaderTests.cs
@@ -37,7 +37,7 @@ public sealed class DataRowReaderTests : IDisposable
         // Arrange
         var csvContent = "col1,col2,col3\nval1,val2,val3\nval4,val5,val6\nval7,val8,val9";
         File.WriteAllText(_testFilePath, csvContent);
-        var reader = new DataRowReader(_testFilePath, columnCount: 3);
+        using var reader = new DataRowReader(_testFilePath, columnCount: 3);
         var offsetAfterHeader = csvContent.IndexOf('\n', StringComparison.Ordinal) + 1;
 
         // Act - Skip header by using offset, then start reading data rows
@@ -55,7 +55,7 @@ public sealed class DataRowReaderTests : IDisposable
         // Arrange
         var csvContent = "col1,col2\nval1,val2";
         File.WriteAllText(_testFilePath, csvContent);
-        var reader = new DataRowReader(_testFilePath, columnCount: 2);
+        using var reader = new DataRowReader(_testFilePath, columnCount: 2);
         var offsetAfterHeader = csvContent.IndexOf('\n', StringComparison.Ordinal) + 1;
 
         // Act - Use offset after header for consistency, but negative offset should still return empty
@@ -71,7 +71,7 @@ public sealed class DataRowReaderTests : IDisposable
         // Arrange
         var csvContent = "col1,col2\nval1,val2";
         File.WriteAllText(_testFilePath, csvContent);
-        var reader = new DataRowReader(_testFilePath, columnCount: 2);
+        using var reader = new DataRowReader(_testFilePath, columnCount: 2);
         var offsetAfterHeader = csvContent.IndexOf('\n', StringComparison.Ordinal) + 1;
 
         // Act
@@ -87,7 +87,7 @@ public sealed class DataRowReaderTests : IDisposable
         // Arrange
         var csvContent = "col1,col2,col3\nval1,val2\nval3";
         File.WriteAllText(_testFilePath, csvContent);
-        var reader = new DataRowReader(_testFilePath, columnCount: 3);
+        using var reader = new DataRowReader(_testFilePath, columnCount: 3);
         var offsetAfterHeader = csvContent.IndexOf('\n', StringComparison.Ordinal) + 1;
 
         // Act & Assert
@@ -102,7 +102,7 @@ public sealed class DataRowReaderTests : IDisposable
         // Arrange
         var csvContent = "col1,col2\nval1,val2\nval3,val4\nval5,val6";
         File.WriteAllText(_testFilePath, csvContent);
-        var reader = new DataRowReader(_testFilePath, columnCount: 2);
+        using var reader = new DataRowReader(_testFilePath, columnCount: 2);
         var offsetAfterHeader = csvContent.IndexOf('\n', StringComparison.Ordinal) + 1;
 
         // Act - When reading from offset after header, the first line at that offset is treated as data (HasHeader = false)
@@ -120,7 +120,7 @@ public sealed class DataRowReaderTests : IDisposable
         // Arrange
         var csvContent = "col1,col2\nval1,val2\nval3,val4\nval5,val6\nval7,val8";
         File.WriteAllText(_testFilePath, csvContent);
-        var reader = new DataRowReader(_testFilePath, columnCount: 2);
+        using var reader = new DataRowReader(_testFilePath, columnCount: 2);
         var offsetAfterHeader = csvContent.IndexOf('\n', StringComparison.Ordinal) + 1;
 
         // Act - Skip header by using offset, then skip additional rows
@@ -133,17 +133,16 @@ public sealed class DataRowReaderTests : IDisposable
     }
 
     [Fact]
-    public void ReadRows_WhenFileDoesNotExist_ReturnsEmptyList()
+    public void Constructor_WhenFileDoesNotExist_ThrowsFileNotFoundException()
     {
         // Arrange
         var nonExistentPath = Path.Combine(Path.GetTempPath(), $"nonexistent_{Guid.NewGuid()}.csv");
-        var reader = new DataRowReader(nonExistentPath, columnCount: 2);
 
         // Act
-        var rows = reader.ReadRows(byteOffset: 0, rowsToSkip: 0, rowsToRead: 10);
+        var act = () => new DataRowReader(nonExistentPath, columnCount: 2);
 
         // Assert
-        rows.Should().BeEmpty();
+        act.Should().Throw<FileNotFoundException>();
     }
 
     [Fact]
@@ -152,7 +151,7 @@ public sealed class DataRowReaderTests : IDisposable
         // Arrange
         var csvContent = "col1,col2\nval1,val2\nval3,val4";
         File.WriteAllText(_testFilePath, csvContent);
-        var reader = new DataRowReader(_testFilePath, columnCount: 2);
+        using var reader = new DataRowReader(_testFilePath, columnCount: 2);
         var offsetAfterHeader = csvContent.IndexOf('\n', StringComparison.Ordinal) + 1;
 
         // Act - Request 100 rows but only 2 data rows available
@@ -162,5 +161,39 @@ public sealed class DataRowReaderTests : IDisposable
         rows.Count.Should().Be(2);
         ToStringArray(rows[0]).Should().Equal(["val1", "val2"]);
         ToStringArray(rows[1]).Should().Equal(["val3", "val4"]);
+    }
+
+    [Fact]
+    public void Dispose_ReleasesFileStream()
+    {
+        // Arrange
+        var csvContent = "col1,col2\nval1,val2";
+        File.WriteAllText(_testFilePath, csvContent);
+        var reader = new DataRowReader(_testFilePath, columnCount: 2);
+        reader.ReadRows(0, 0, 1);
+
+        // Act
+        reader.Dispose();
+
+        // Assert
+        // Try opening file with FileShare.None - should succeed if stream was released
+        using var stream = new FileStream(_testFilePath, FileMode.Open, FileAccess.Read, FileShare.None);
+        stream.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void ReadRows_AfterDispose_ThrowsObjectDisposedException()
+    {
+        // Arrange
+        var csvContent = "col1,col2\nval1,val2";
+        File.WriteAllText(_testFilePath, csvContent);
+        using var reader = new DataRowReader(_testFilePath, columnCount: 2);
+        reader.Dispose();
+
+        // Act
+        var act = () => reader.ReadRows(0, 0, 1);
+
+        // Assert
+        act.Should().Throw<ObjectDisposedException>();
     }
 }


### PR DESCRIPTION
## Summary

- Establishes a complete `IDisposable` chain from `MorphTableView` down to `DataRowReader`'s `FileStream`, ensuring OS resources are released immediately when views are swapped or the application terminates
- Keeps `DataRowReader`'s `FileStream` open persistently (opened in constructor, closed in `Dispose`) instead of opening/closing on every cache miss, improving CSV scrolling performance
- Adds `ObjectDisposedException` guards on public methods of all newly disposable classes

## Changes

| File | Change |
|---|---|
| `DataRowReader.cs` | Persistent `FileStream`; implement `IDisposable` |
| `DataRowCache.cs` | Implement `IDisposable`; dispose `_reader` |
| `VirtualTableSource.cs` | Implement `IDisposable`; dispose `_cache` |
| `JsonLinesTableSource.cs` | Implement `IDisposable`; dispose `_cache` |
| `LazyTransformer.cs` | Implement `IDisposable`; dispose `_source` |
| `MorphTableView.cs` | Override `Dispose(bool)`; dispose `Table` if `IDisposable` |
| `FilterRowIndexer.cs` | Fix: wrap locally-created `DataRowReader` with `using var` |

## Test plan

- `DataRowReaderTests`: `Dispose_ReleasesFileStream`, `ReadRows_AfterDispose_ThrowsObjectDisposedException`
- `DataRowCacheTests`: `Dispose_DisposesReader` (verified via `FileShare.None` exclusive access)
- `VirtualTableSourceTests`: `Dispose_DisposesCacheAndReader`
- `JsonLinesTableSourceTests`: `Dispose_DisposesRowByteCache`
- `LazyTransformerTests`: `Dispose_DisposesUnderlyingSource`
- `MorphTableViewTests`: `Dispose_DisposesTableIfIDisposable`, `Dispose_DoesNotThrow_WhenTableIsNotIDisposable`
- All 1046 tests pass

Closes #183