### PR TITLE
fix: await FirstCheckpointReached before switching to JSONL tree view

### DIFF
--- a/src/App/FileDialogHandler.cs
+++ b/src/App/FileDialogHandler.cs
@@ -40,7 +40,12 @@ internal sealed class FileDialogHandler(
             return;
         }
 
-        var detectionResult = FormatDetector.Detect(dialog.Path);
+        await HandleFileSelectedAsync(dialog.Path);
+    }
+
+    internal async Task HandleFileSelectedAsync(string path)
+    {
+        var detectionResult = FormatDetector.Detect(path);
         if (detectionResult.IsFailure)
         {
             _viewManager.ShowError(detectionResult.Error);
@@ -48,7 +53,6 @@ internal sealed class FileDialogHandler(
         }
 
         var format = detectionResult.Value;
-        var path = dialog.Path;
 
         // Reset state for new file
         _state.CurrentFilePath = path;
@@ -111,9 +115,17 @@ internal sealed class FileDialogHandler(
             _state.JsonLinesSchemaScanner = null;
             _state.Schema = null;
             _state.OnSchemaRefined = null;
-            _state.CurrentMode = ViewMode.JsonLinesTree;
 
+            var tcs = new TaskCompletionSource(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            indexer.FirstCheckpointReached += () => tcs.TrySetResult();
+
+            _onIndexerStart(indexer);
+            await tcs.Task;
+
+            _state.CurrentMode = ViewMode.JsonLinesTree;
             _viewManager.SwitchToJsonLinesTree(indexer);
+            return;
         }
 
         _onIndexerStart(indexer);

--- a/tests/DataMorph.Tests/App/FileDialogHandlerTests.cs
+++ b/tests/DataMorph.Tests/App/FileDialogHandlerTests.cs
@@ -1,13 +1,32 @@
 using AwesomeAssertions;
 using DataMorph.App;
+using DataMorph.App.Views;
+using DataMorph.Engine.IO;
 using Terminal.Gui.App;
 using Terminal.Gui.Drivers;
 using Terminal.Gui.Views;
 
 namespace DataMorph.Tests.App;
 
-public sealed class FileDialogHandlerTests
+public sealed class FileDialogHandlerTests : IDisposable
 {
+    private readonly string _testFile;
+
+    public FileDialogHandlerTests()
+    {
+        _testFile = Path.ChangeExtension(Path.GetTempFileName(), ".jsonl");
+        // Add enough data to ensure we can control the flow
+        File.WriteAllText(_testFile, "{\"id\":1}\n");
+    }
+
+    public void Dispose()
+    {
+        if (File.Exists(_testFile))
+        {
+            File.Delete(_testFile);
+        }
+    }
+
     private static IApplication CreateTestApp()
     {
         var app = Application.Create();
@@ -28,10 +47,70 @@ public sealed class FileDialogHandlerTests
         // Act
         Action act = () =>
         {
-            var handler = new FileDialogHandler(app, state, viewManager, _ => { });
+            _ = new FileDialogHandler(app, state, viewManager, _ => { });
         };
 
         // Assert
         act.Should().NotThrow();
+    }
+
+    [Fact]
+    public async Task HandleFileSelectedAsync_JsonLinesFile_SwitchesToTreeViewAfterFirstCheckpoint()
+    {
+        // Arrange
+        using var app = CreateTestApp();
+        using var state = new AppState();
+        using var window = new Window();
+        var modeController = new ModeController(state);
+        using var viewManager = new ViewManager(window, state, modeController);
+
+        IRowIndexer? capturedIndexer = null;
+        var handler = new FileDialogHandler(app, state, viewManager, indexer =>
+        {
+            capturedIndexer = indexer;
+            // Simulate indexing start
+            Task.Run(() => indexer.BuildIndex());
+        });
+
+        // Act
+        await handler.HandleFileSelectedAsync(_testFile);
+
+        // Assert
+        state.CurrentMode.Should().Be(ViewMode.JsonLinesTree);
+        viewManager.GetCurrentView().Should().BeOfType<JsonLinesTreeView>();
+        Assert.NotNull(capturedIndexer);
+        capturedIndexer.TotalRows.Should().BeGreaterThan(0);
+    }
+
+    [Fact]
+    public async Task HandleFileSelectedAsync_JsonLinesFileBeforeFirstCheckpoint_DoesNotSwitchToTreeView()
+    {
+        // Arrange
+        using var app = CreateTestApp();
+        using var state = new AppState();
+        using var window = new Window();
+        var modeController = new ModeController(state);
+        using var viewManager = new ViewManager(window, state, modeController);
+        viewManager.SwitchToFileSelection(); // Ensure initial view is not null
+
+        var tcs = new TaskCompletionSource();
+        var handler = new FileDialogHandler(app, state, viewManager, _ =>
+        {
+            // Do NOT start indexing yet, so FirstCheckpointReached won't fire
+            tcs.TrySetResult();
+        });
+
+        // Act
+        var handleTask = handler.HandleFileSelectedAsync(_testFile);
+        await tcs.Task; // Wait until _onIndexerStart is called
+
+        // Assert
+        state.CurrentMode.Should().NotBe(ViewMode.JsonLinesTree);
+        viewManager.GetCurrentView().Should().NotBeOfType<JsonLinesTreeView>();
+
+        // Cleanup: actually start indexing to let the task complete
+        Assert.NotNull(state.RowIndexer);
+        state.RowIndexer.BuildIndex();
+        await handleTask;
     }
 }


### PR DESCRIPTION
## Summary

- `FileDialogHandler` now subscribes to `FirstCheckpointReached` via `TaskCompletionSource` before calling `SwitchToJsonLinesTree`
- `_onIndexerStart` is called first so indexing begins, then the handler awaits the first checkpoint before switching the view
- File processing logic extracted to `HandleFileSelectedAsync` for testability

## Test plan

- [ ] Open a JSONL file and verify the Tree view displays data immediately on load
- [ ] Verify all 1048 existing tests pass (`dotnet test`)

Closes #185