### PR TITLE
chore: update .gitignore to ignore .working file and directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,4 +97,4 @@ Desktop.ini
 *.local.*
 
 .aider*
-.working/
+.working


### PR DESCRIPTION
Update .gitignore pattern to ignore both .working files (including symlinks) and directories by removing the trailing slash from the .working/ pattern.