### PR TITLE
feat: implement CLI startup options (--file / --recipe)

### DIFF
--- a/docs/design_cli_startup_options.md
+++ b/docs/design_cli_startup_options.md
@@ -1,0 +1,186 @@
+# Design: CLI Options to Specify Input File and Recipe on Startup
+
+## Requirements
+
+- `--file <path>` — loads the given file on startup, bypassing the file selection dialog
+- `--recipe <path>` — loads the given recipe on startup, bypassing the load recipe dialog
+- Both options can be combined
+- Invalid paths produce a clear error to stderr before the TUI launches
+- No arguments → existing interactive behavior is preserved
+
+## Affected Files
+
+### New Files
+
+| File | Purpose |
+|------|---------|
+| `src/App/TuiStartupOptions.cs` | Record holding optional startup arguments for TUI mode |
+| `src/App/TuiArgumentParser.cs` | Parses `--file` / `--recipe` from `args[]` in TUI mode |
+| `tests/DataMorph.Tests/App/Cli/TuiArgumentParserTests.cs` | Unit tests for `TuiArgumentParser` |
+
+### Modified Files
+
+| File | Change |
+|------|--------|
+| `src/App/Program.cs` | Parse TUI args; validate paths; call `ScheduleStartupLoad()` |
+| `src/App/MainWindow.cs` | Add `ScheduleStartupLoad(TuiStartupOptions)` method |
+| `src/App/RecipeCommandHandler.cs` | Add `LoadFromPathAsync(string path)` (dialog-free overload) |
+
+## Design Details
+
+### `TuiStartupOptions` Record
+
+```csharp
+namespace DataMorph.App;
+
+internal sealed record TuiStartupOptions(string? InputFile = null, string? RecipeFile = null)
+{
+    public bool HasAny => InputFile is not null || RecipeFile is not null;
+}
+```
+
+Both properties are nullable because all flags are optional in TUI mode. Primary constructor syntax is used per C# coding standards.
+
+---
+
+### `TuiArgumentParser`
+
+Parses args when `--cli` is absent. Returns `Result<TuiStartupOptions>` so errors can be reported before the TUI starts.
+
+Accepted flags:
+
+| Flag | Value | Effect |
+|------|-------|--------|
+| `--file` | `<path>` | Sets `InputFile` |
+| `--recipe` | `<path>` | Sets `RecipeFile` |
+
+Unknown flags → `Result.Failure` with a descriptive message.  
+Missing value for a known flag → `Result.Failure`.
+
+---
+
+### `Program.cs` Changes
+
+```
+if args contain --cli  → existing CLI path (unchanged)
+
+else:
+  parseResult = TuiArgumentParser.Parse(args)
+  if parseResult.IsFailure → stderr + exit(1)
+
+  options = parseResult.Value
+  if options.InputFile is not null && !File.Exists(options.InputFile)
+      → stderr "Error: File not found: <path>" + exit(1)
+  if options.RecipeFile is not null && !File.Exists(options.RecipeFile)
+      → stderr "Error: Recipe file not found: <path>" + exit(1)
+
+  Create TuiApplication, init, subscribe key handler
+  if options.HasAny → mainWindow.ScheduleStartupLoad(options)
+  app.Run(mainWindow)
+```
+
+Path validation happens **before** `app.Init()` so the TUI never starts if arguments are bad.
+
+---
+
+### `MainWindow.ScheduleStartupLoad(TuiStartupOptions options)`
+
+Queues async startup loading to run once the Terminal.Gui event loop is active.
+
+```
+ScheduleStartupLoad(options):
+  // Guard: recipe-only without file is not supported
+  if (options.InputFile is null) return;
+
+  // Decompose here to ensure null-safety for ExecuteStartupLoadAsync
+  _app.Invoke(() => { _ = ExecuteStartupLoadAsync(options.InputFile, options.RecipeFile); })
+
+ExecuteStartupLoadAsync(string inputFile, string? recipeFile):
+  await _fileDialogHandler.HandleFileSelectedAsync(inputFile)
+  // Guard: file load failed (CurrentFilePath not set)
+  if (string.IsNullOrWhiteSpace(_state.CurrentFilePath)) return;
+  if (recipeFile is not null)
+      await _recipeCommandHandler.LoadFromPathAsync(recipeFile)
+```
+
+`HandleFileSelectedAsync` already exists as `internal` and handles format detection, schema scanning, and view switching — no duplication needed.
+`_state.CurrentFilePath` is set synchronously inside `HandleFileSelectedAsync` before the first `await`, so it is available by the time `LoadFromPathAsync` is called.
+
+**Note:** Async void is avoided by using fire-and-forget pattern with `_ = ExecuteStartupLoadAsync(options.InputFile, options.RecipeFile)`. `TuiStartupOptions` is decomposed into typed parameters at the call site so the compiler can prove `inputFile` is non-null without using the forbidden `!` operator.
+
+---
+
+### `RecipeCommandHandler.LoadFromPathAsync(string path)`
+
+A dialog-free overload extracted from the existing `LoadAsync()` body. Returns `ValueTask` for better async efficiency.
+
+```
+LoadFromPathAsync(path):
+  // Precondition: CurrentFilePath must be set (file must be loaded first)
+  if (string.IsNullOrWhiteSpace(_state.CurrentFilePath))
+      throw new InvalidOperationException("Cannot load recipe: no input file is currently loaded.")
+
+  result = await _recipeManager.LoadAsync(path)
+  _app.Invoke(() =>
+      if result.IsFailure → _viewManager.ShowError(result.Error)
+      else
+          _state.ActionStack = result.Value.Actions
+          _viewManager.RefreshCurrentTableView()
+  )
+```
+
+The existing `LoadAsync()` is refactored to delegate to `LoadFromPathAsync` to avoid logic duplication.
+
+---
+
+## Interaction Flow (with both options)
+
+```
+$ data-morph --file data.csv --recipe transforms.yaml
+
+Program.cs
+  ├── TuiArgumentParser.Parse → TuiStartupOptions { InputFile, RecipeFile }
+  ├── File.Exists checks → OK
+  ├── TuiApplication.Create → (app, mainWindow)
+  ├── app.Init()
+  ├── mainWindow.SubscribeKeyHandler()
+  ├── mainWindow.ScheduleStartupLoad(options)   ← queued
+  └── app.Run(mainWindow)                        ← event loop starts
+
+  [Event loop first tick]
+  └── Invoke fires:
+      ├── FileDialogHandler.HandleFileSelectedAsync("data.csv")
+      │   ├── Format detection → CSV
+      │   ├── _state.CurrentFilePath = "data.csv"
+      │   ├── IncrementalSchemaScanner.InitialScanAsync()
+      │   └── ViewManager.SwitchToCsvTable(...)
+      └── RecipeCommandHandler.LoadFromPathAsync("transforms.yaml")
+          ├── RecipeManager.LoadAsync(...)
+          └── ViewManager.RefreshCurrentTableView()
+```
+
+## Error Scenarios
+
+| Scenario | Behavior |
+|----------|----------|
+| `--file` path does not exist | stderr error before TUI; exit code 1 |
+| `--recipe` path does not exist | stderr error before TUI; exit code 1 |
+| `--file` path exists but unsupported format | TUI shows error dialog via `ViewManager.ShowError()` |
+| `--recipe` path exists but invalid YAML | TUI shows error dialog via `ViewManager.ShowError()` |
+| `--recipe` specified without `--file` | `ScheduleStartupLoad` returns early (InputFile is null guard); treated as if `--recipe` were absent |
+| Unknown TUI flag (e.g. `--foo`) | stderr error before TUI; exit code 1 |
+
+## Test Plan
+
+`TuiArgumentParserTests`:
+- No args → success with both null
+- `--file path.csv` → `InputFile = "path.csv"`, `RecipeFile = null`
+- `--recipe recipe.yaml` → `RecipeFile = "recipe.yaml"`, `InputFile = null`
+- Both flags → both set correctly
+- `--file` without value → failure
+- `--recipe` without value → failure
+- Unknown flag → failure
+- Flag order independence (recipe before file)
+- `--file` specified twice (duplicate flag) → failure
+- Path with spaces (e.g., `--file "my file.csv"`) → success with correct path
+- Empty array input → success with both null

--- a/src/App/MainWindow.cs
+++ b/src/App/MainWindow.cs
@@ -245,4 +245,14 @@ internal sealed class MainWindow : Window
             _ => $"{bytes} B",
         };
     }
+
+    internal void ScheduleStartupLoad(TuiStartupOptions options)
+    {
+        throw new NotImplementedException();
+    }
+
+    private Task ExecuteStartupLoadAsync(string inputFile, string? recipeFile)
+    {
+        throw new NotImplementedException();
+    }
 }

--- a/src/App/MainWindow.cs
+++ b/src/App/MainWindow.cs
@@ -248,11 +248,26 @@ internal sealed class MainWindow : Window
 
     internal void ScheduleStartupLoad(TuiStartupOptions options)
     {
-        throw new NotImplementedException();
+        if (options.InputFile is null)
+        {
+            return;
+        }
+
+        _app.Invoke(() => { _ = ExecuteStartupLoadAsync(options.InputFile, options.RecipeFile); });
     }
 
-    private Task ExecuteStartupLoadAsync(string inputFile, string? recipeFile)
+    private async Task ExecuteStartupLoadAsync(string inputFile, string? recipeFile)
     {
-        throw new NotImplementedException();
+        await _fileDialogHandler.HandleFileSelectedAsync(inputFile);
+
+        if (string.IsNullOrWhiteSpace(_state.CurrentFilePath))
+        {
+            return;
+        }
+
+        if (recipeFile is not null)
+        {
+            await _recipeCommandHandler.LoadFromPathAsync(recipeFile);
+        }
     }
 }

--- a/src/App/Program.cs
+++ b/src/App/Program.cs
@@ -22,11 +22,35 @@ if (args.Contains("--cli"))
     return (int)await Runner.RunAsync(parseResult.Value, logger, cts.Token);
 }
 
+var parseTuiResult = TuiArgumentParser.Parse(args);
+if (parseTuiResult.IsFailure)
+{
+    await Console.Error.WriteLineAsync(parseTuiResult.Error);
+    return (int)ExitCode.Failure;
+}
+
+var tuiOptions = parseTuiResult.Value;
+if (tuiOptions.InputFile is not null && !File.Exists(tuiOptions.InputFile))
+{
+    await Console.Error.WriteLineAsync($"Error: File not found: {tuiOptions.InputFile}");
+    return (int)ExitCode.Failure;
+}
+
+if (tuiOptions.RecipeFile is not null && !File.Exists(tuiOptions.RecipeFile))
+{
+    await Console.Error.WriteLineAsync($"Error: Recipe file not found: {tuiOptions.RecipeFile}");
+    return (int)ExitCode.Failure;
+}
+
 var result = TuiApplication.Create();
 using var app = result.app;
 using var mainWindow = result.mainWindow;
 
 app.Init();
 mainWindow.SubscribeKeyHandler();
+if (tuiOptions.HasAny)
+{
+    mainWindow.ScheduleStartupLoad(tuiOptions);
+}
 app.Run(mainWindow);
 return (int)ExitCode.Success;

--- a/src/App/RecipeCommandHandler.cs
+++ b/src/App/RecipeCommandHandler.cs
@@ -103,4 +103,9 @@ internal sealed class RecipeCommandHandler(
             _viewManager.RefreshCurrentTableView();
         });
     }
+
+    internal ValueTask LoadFromPathAsync(string path)
+    {
+        throw new NotImplementedException();
+    }
 }

--- a/src/App/RecipeCommandHandler.cs
+++ b/src/App/RecipeCommandHandler.cs
@@ -89,7 +89,17 @@ internal sealed class RecipeCommandHandler(
             return;
         }
 
-        var result = await _recipeManager.LoadAsync(dialog.Path);
+        await LoadFromPathAsync(dialog.Path);
+    }
+
+    internal async ValueTask LoadFromPathAsync(string path)
+    {
+        if (string.IsNullOrWhiteSpace(_state.CurrentFilePath))
+        {
+            throw new InvalidOperationException("Cannot load recipe: no input file is currently loaded.");
+        }
+
+        var result = await _recipeManager.LoadAsync(path);
 
         _app.Invoke(() =>
         {
@@ -102,10 +112,5 @@ internal sealed class RecipeCommandHandler(
             _state.ActionStack = result.Value.Actions;
             _viewManager.RefreshCurrentTableView();
         });
-    }
-
-    internal ValueTask LoadFromPathAsync(string path)
-    {
-        throw new NotImplementedException();
     }
 }

--- a/src/App/TuiArgumentParser.cs
+++ b/src/App/TuiArgumentParser.cs
@@ -7,12 +7,10 @@ namespace DataMorph.App;
 /// Accepts optional flags: <c>--file</c> and <c>--recipe</c>.
 /// Unknown flags are rejected.
 /// </summary>
-#pragma warning disable CA1823
 internal static class TuiArgumentParser
 {
     private const string FileFlag = "--file";
     private const string RecipeFlag = "--recipe";
-#pragma warning restore CA1823
 
     /// <summary>
     /// Parses the given command-line argument array into a <see cref="TuiStartupOptions"/> record.
@@ -24,6 +22,64 @@ internal static class TuiArgumentParser
     /// </returns>
     internal static Result<TuiStartupOptions> Parse(IReadOnlyList<string> args)
     {
-        throw new NotImplementedException();
+        string? inputFile = null;
+        string? recipeFile = null;
+
+        var argsIndex = 0;
+        while (argsIndex < args.Count)
+        {
+            var arg = args[argsIndex];
+
+            if (arg == FileFlag)
+            {
+                argsIndex++;
+                var consumeResult = ConsumeValue(args, argsIndex, FileFlag, inputFile);
+                if (consumeResult.IsFailure)
+                {
+                    return Results.Failure<TuiStartupOptions>(consumeResult.Error);
+                }
+                inputFile = args[argsIndex++];
+                continue;
+            }
+
+            if (arg == RecipeFlag)
+            {
+                argsIndex++;
+                var consumeResult = ConsumeValue(args, argsIndex, RecipeFlag, recipeFile);
+                if (consumeResult.IsFailure)
+                {
+                    return Results.Failure<TuiStartupOptions>(consumeResult.Error);
+                }
+                recipeFile = args[argsIndex++];
+                continue;
+            }
+
+            if (arg.StartsWith("--", StringComparison.Ordinal))
+            {
+                return Results.Failure<TuiStartupOptions>(
+                    $"Unknown option: {arg}");
+            }
+
+            argsIndex++;
+        }
+
+        return Results.Success(new TuiStartupOptions(inputFile, recipeFile));
+    }
+
+    private static Result ConsumeValue(IReadOnlyList<string> args, int currentIndex, string flag, string? currentValue)
+    {
+        if (currentValue is not null)
+        {
+            return Results.Failure(
+                $"{flag} specified more than once.");
+        }
+
+        if (currentIndex >= args.Count || args[currentIndex].StartsWith("--", StringComparison.Ordinal))
+        {
+            return Results.Failure(
+                $"{flag} requires a value.");
+        }
+
+        return Results.Success();
     }
 }

--- a/src/App/TuiArgumentParser.cs
+++ b/src/App/TuiArgumentParser.cs
@@ -1,0 +1,29 @@
+using DataMorph.Engine;
+
+namespace DataMorph.App;
+
+/// <summary>
+/// Parses TUI-specific command-line arguments.
+/// Accepts optional flags: <c>--file</c> and <c>--recipe</c>.
+/// Unknown flags are rejected.
+/// </summary>
+#pragma warning disable CA1823
+internal static class TuiArgumentParser
+{
+    private const string FileFlag = "--file";
+    private const string RecipeFlag = "--recipe";
+#pragma warning restore CA1823
+
+    /// <summary>
+    /// Parses the given command-line argument array into a <see cref="TuiStartupOptions"/> record.
+    /// </summary>
+    /// <param name="args">The raw command-line arguments.</param>
+    /// <returns>
+    /// A successful <see cref="Result{T}"/> containing the parsed arguments,
+    /// or a failure with a human-readable error message.
+    /// </returns>
+    internal static Result<TuiStartupOptions> Parse(IReadOnlyList<string> args)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/src/App/TuiStartupOptions.cs
+++ b/src/App/TuiStartupOptions.cs
@@ -1,0 +1,9 @@
+namespace DataMorph.App;
+
+/// <summary>
+/// Holds optional startup arguments for TUI mode.
+/// </summary>
+internal sealed record TuiStartupOptions(string? InputFile = null, string? RecipeFile = null)
+{
+    public bool HasAny => InputFile is not null || RecipeFile is not null;
+}

--- a/tests/DataMorph.Tests/App/TuiArgumentParserTests.cs
+++ b/tests/DataMorph.Tests/App/TuiArgumentParserTests.cs
@@ -1,3 +1,4 @@
+using AwesomeAssertions;
 using DataMorph.App;
 
 namespace DataMorph.Tests.App;
@@ -14,6 +15,9 @@ public sealed class TuiArgumentParserTests
         var result = TuiArgumentParser.Parse(args);
 
         // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.InputFile.Should().BeNull();
+        result.Value.RecipeFile.Should().BeNull();
     }
 
     [Fact]
@@ -26,6 +30,9 @@ public sealed class TuiArgumentParserTests
         var result = TuiArgumentParser.Parse(args);
 
         // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.InputFile.Should().Be("path.csv");
+        result.Value.RecipeFile.Should().BeNull();
     }
 
     [Fact]
@@ -38,6 +45,9 @@ public sealed class TuiArgumentParserTests
         var result = TuiArgumentParser.Parse(args);
 
         // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.InputFile.Should().BeNull();
+        result.Value.RecipeFile.Should().Be("recipe.yaml");
     }
 
     [Fact]
@@ -50,6 +60,9 @@ public sealed class TuiArgumentParserTests
         var result = TuiArgumentParser.Parse(args);
 
         // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.InputFile.Should().Be("path.csv");
+        result.Value.RecipeFile.Should().Be("recipe.yaml");
     }
 
     [Fact]
@@ -62,6 +75,8 @@ public sealed class TuiArgumentParserTests
         var result = TuiArgumentParser.Parse(args);
 
         // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Contain("--file");
     }
 
     [Fact]
@@ -74,6 +89,8 @@ public sealed class TuiArgumentParserTests
         var result = TuiArgumentParser.Parse(args);
 
         // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Contain("--recipe");
     }
 
     [Fact]
@@ -86,6 +103,8 @@ public sealed class TuiArgumentParserTests
         var result = TuiArgumentParser.Parse(args);
 
         // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Contain("--unknown");
     }
 
     [Fact]
@@ -98,6 +117,9 @@ public sealed class TuiArgumentParserTests
         var result = TuiArgumentParser.Parse(args);
 
         // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.InputFile.Should().Be("path.csv");
+        result.Value.RecipeFile.Should().Be("recipe.yaml");
     }
 
     [Fact]
@@ -110,6 +132,8 @@ public sealed class TuiArgumentParserTests
         var result = TuiArgumentParser.Parse(args);
 
         // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Contain("--file");
     }
 
     [Fact]
@@ -122,6 +146,8 @@ public sealed class TuiArgumentParserTests
         var result = TuiArgumentParser.Parse(args);
 
         // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Contain("--recipe");
     }
 
     [Fact]
@@ -134,5 +160,8 @@ public sealed class TuiArgumentParserTests
         var result = TuiArgumentParser.Parse(args);
 
         // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.InputFile.Should().Be("my file.csv");
+        result.Value.RecipeFile.Should().BeNull();
     }
 }

--- a/tests/DataMorph.Tests/App/TuiArgumentParserTests.cs
+++ b/tests/DataMorph.Tests/App/TuiArgumentParserTests.cs
@@ -1,0 +1,138 @@
+using DataMorph.App;
+
+namespace DataMorph.Tests.App;
+
+public sealed class TuiArgumentParserTests
+{
+    [Fact]
+    public void Parse_NoArgs_ReturnsBothNull()
+    {
+        // Arrange
+        string[] args = [];
+
+        // Act
+        var result = TuiArgumentParser.Parse(args);
+
+        // Assert
+    }
+
+    [Fact]
+    public void Parse_FileFlag_SetsInputFile()
+    {
+        // Arrange
+        string[] args = ["--file", "path.csv"];
+
+        // Act
+        var result = TuiArgumentParser.Parse(args);
+
+        // Assert
+    }
+
+    [Fact]
+    public void Parse_RecipeFlag_SetsRecipeFile()
+    {
+        // Arrange
+        string[] args = ["--recipe", "recipe.yaml"];
+
+        // Act
+        var result = TuiArgumentParser.Parse(args);
+
+        // Assert
+    }
+
+    [Fact]
+    public void Parse_BothFlags_SetsBothProperties()
+    {
+        // Arrange
+        string[] args = ["--file", "path.csv", "--recipe", "recipe.yaml"];
+
+        // Act
+        var result = TuiArgumentParser.Parse(args);
+
+        // Assert
+    }
+
+    [Fact]
+    public void Parse_FileFlag_WithoutValue_ReturnsFailure()
+    {
+        // Arrange
+        string[] args = ["--file"];
+
+        // Act
+        var result = TuiArgumentParser.Parse(args);
+
+        // Assert
+    }
+
+    [Fact]
+    public void Parse_RecipeFlag_WithoutValue_ReturnsFailure()
+    {
+        // Arrange
+        string[] args = ["--recipe"];
+
+        // Act
+        var result = TuiArgumentParser.Parse(args);
+
+        // Assert
+    }
+
+    [Fact]
+    public void Parse_UnknownFlag_ReturnsFailure()
+    {
+        // Arrange
+        string[] args = ["--unknown"];
+
+        // Act
+        var result = TuiArgumentParser.Parse(args);
+
+        // Assert
+    }
+
+    [Fact]
+    public void Parse_RecipeBeforeFile_SetsCorrectly()
+    {
+        // Arrange
+        string[] args = ["--recipe", "recipe.yaml", "--file", "path.csv"];
+
+        // Act
+        var result = TuiArgumentParser.Parse(args);
+
+        // Assert
+    }
+
+    [Fact]
+    public void Parse_DuplicateFileFlag_ReturnsFailure()
+    {
+        // Arrange
+        string[] args = ["--file", "path1.csv", "--file", "path2.csv"];
+
+        // Act
+        var result = TuiArgumentParser.Parse(args);
+
+        // Assert
+    }
+
+    [Fact]
+    public void Parse_DuplicateRecipeFlag_ReturnsFailure()
+    {
+        // Arrange
+        string[] args = ["--recipe", "r1.yaml", "--recipe", "r2.yaml"];
+
+        // Act
+        var result = TuiArgumentParser.Parse(args);
+
+        // Assert
+    }
+
+    [Fact]
+    public void Parse_FilePathWithSpaces_SetsCorrectPath()
+    {
+        // Arrange
+        string[] args = ["--file", "my file.csv"];
+
+        // Act
+        var result = TuiArgumentParser.Parse(args);
+
+        // Assert
+    }
+}


### PR DESCRIPTION
## Summary
Add command-line argument parsing for `--file` and `--recipe` flags to allow users to bypass interactive file/recipe selection dialogs when launching the TUI.

## Changes
- **TuiStartupOptions**: New record to hold optional CLI-specified file paths
- **TuiArgumentParser**: Parses CLI arguments, validates flags, and returns descriptive errors
- **MainWindow**: Implements `ScheduleStartupLoad` and `ExecuteStartupLoadAsync` for startup file loading
- **RecipeCommandHandler**: Adds `LoadFromPathAsync` with pre-condition validation
- **Program.cs**: Integrates CLI parsing before TUI initialization
- **Tests**: 11 comprehensive test cases covering all scenarios

Closes #179