### PR TITLE
refactor: add IncrementalSchemaScannerBase and remove scanner properties from AppState

### DIFF
--- a/src/App/AppState.cs
+++ b/src/App/AppState.cs
@@ -1,8 +1,6 @@
-using DataMorph.App.Schema.Csv;
 using DataMorph.Engine.IO;
 using DataMorph.Engine.Models;
 using DataMorph.Engine.Models.Actions;
-using JsonLinesSchema = DataMorph.App.Schema.JsonLines;
 
 namespace DataMorph.App;
 
@@ -36,21 +34,9 @@ internal sealed class AppState : IDisposable
     public IRowIndexer? RowIndexer { get; set; }
 
     /// <summary>
-    /// Gets or sets the incremental schema scanner for background schema refinement.
-    /// Null if no CSV file is loaded.
-    /// </summary>
-    public IncrementalSchemaScanner? CsvSchemaScanner { get; set; }
-
-    /// <summary>
     /// Gets or sets the cancellation token source for the background schema scanner.
     /// </summary>
-    public CancellationTokenSource Cts { get; set; } = new();
-
-    /// <summary>
-    /// Gets or sets the JSON Lines schema scanner for the current file.
-    /// Null until the user switches to Table mode for the first time (lazy initialization).
-    /// </summary>
-    public JsonLinesSchema.IncrementalSchemaScanner? JsonLinesSchemaScanner { get; set; }
+    public CancellationTokenSource Cts { get; private set; } = new();
 
     /// <summary>
     /// Gets or sets the callback invoked when the background schema scan completes.
@@ -64,6 +50,20 @@ internal sealed class AppState : IDisposable
     /// An empty list means no transformations are active (passthrough).
     /// </summary>
     public IReadOnlyList<MorphAction> ActionStack { get; set; } = [];
+
+    /// <summary>
+    /// Renews the cancellation token source by cancelling the current one and creating a new one.
+    /// This should be called when loading a new file to ensure the previous file's background scan
+    /// is cancelled and does not interfere with the new file.
+    /// </summary>
+    public void RenewCtsWithCancel()
+    {
+        // Cancel must precede Dispose: any captured CancellationToken derived from the old Cts
+        // will reflect IsCancellationRequested = true, keeping polling-based checks safe after disposal.
+        Cts.Cancel();
+        Cts.Dispose();
+        Cts = new CancellationTokenSource();
+    }
 
     /// <summary>
     /// Appends a morph action to the Action Stack.

--- a/src/App/FileDialogHandler.cs
+++ b/src/App/FileDialogHandler.cs
@@ -57,6 +57,7 @@ internal sealed class FileDialogHandler(
         // Reset state for new file
         _state.CurrentFilePath = path;
         _state.ActionStack = [];
+        _state.RenewCtsWithCancel();
 
         // Create indexer from factory
         var indexer = RowIndexerFactory.Create(format, path);
@@ -78,7 +79,6 @@ internal sealed class FileDialogHandler(
 
                     _state.Schema = schema;
                     _state.RowIndexer = indexer;
-                    _state.CsvSchemaScanner = schemaScanner;
                     _state.CurrentMode = ViewMode.CsvTable;
 
                     _viewManager.SwitchToCsvTable(indexer, schema);
@@ -120,7 +120,6 @@ internal sealed class FileDialogHandler(
             try
             {
                 _state.RowIndexer = indexer;
-                _state.JsonLinesSchemaScanner = null;
                 _state.Schema = null;
                 _state.OnSchemaRefined = null;
 

--- a/src/App/ModeController.cs
+++ b/src/App/ModeController.cs
@@ -1,5 +1,5 @@
+using DataMorph.App.Schema.JsonLines;
 using DataMorph.Engine;
-using JsonLinesSchema = DataMorph.App.Schema.JsonLines;
 
 namespace DataMorph.App;
 
@@ -40,7 +40,7 @@ internal sealed class ModeController
         }
 
         // Subsequent switch: reuse cached schema
-        if (_state.JsonLinesSchemaScanner is not null && _state.Schema is not null)
+        if (_state.Schema is not null)
         {
             _state.CurrentMode = ViewMode.JsonLinesTable;
             return Results.Success();
@@ -52,13 +52,12 @@ internal sealed class ModeController
             return Results.Failure("No file is currently open");
         }
 
-        var scanner = new JsonLinesSchema.IncrementalSchemaScanner(_state.CurrentFilePath);
+        var scanner = new IncrementalSchemaScanner(_state.CurrentFilePath);
 
         try
         {
             var schema = await scanner.InitialScanAsync();
             _state.Schema = schema;
-            _state.JsonLinesSchemaScanner = scanner;
             _state.CurrentMode = ViewMode.JsonLinesTable;
 
             _ = scanner

--- a/src/App/Schema/Csv/IncrementalSchemaScanner.cs
+++ b/src/App/Schema/Csv/IncrementalSchemaScanner.cs
@@ -6,15 +6,12 @@ namespace DataMorph.App.Schema.Csv;
 
 /// <summary>
 /// Performs incremental schema inference for CSV files.
-/// - Initial scan: first 200 rows (synchronous)
-/// - Background scan: remaining rows (asynchronous)
+/// - Initial scan: first 200 rows
+/// - Background scan: remaining rows in batches of 1000
 /// - Thread-safe schema updates via Copy-on-Write
 /// </summary>
-internal sealed class IncrementalSchemaScanner
+internal sealed class IncrementalSchemaScanner : IncrementalSchemaScannerBase
 {
-    private const int InitialScanCount = 200;
-    private const int BackgroundBatchSize = 1000;
-
     private readonly string _filePath;
 
     /// <summary>
@@ -26,59 +23,30 @@ internal sealed class IncrementalSchemaScanner
         _filePath = filePath ?? throw new ArgumentNullException(nameof(filePath));
     }
 
-    /// <summary>
-    /// Performs initial scan on first 200 rows synchronously.
-    /// Must be awaited before UI can display schema.
-    /// </summary>
-    public async Task<TableSchema> InitialScanAsync()
+    /// <inheritdoc/>
+    protected override TableSchema ExecuteInitialScan()
     {
-        return await Task.Run(() =>
+        var rows = ReadRows(0, InitialScanCount);
+        var columnNames = ReadColumnNames();
+        var scanResult = SchemaScanner.ScanSchema(columnNames, rows, InitialScanCount);
+
+        if (scanResult.IsFailure)
         {
-            var rows = ReadRows(0, InitialScanCount);
-            var columnNames = ReadColumnNames();
-            var scanResult = SchemaScanner.ScanSchema(columnNames, rows, InitialScanCount);
+            throw new InvalidOperationException(scanResult.Error);
+        }
 
-            if (scanResult.IsFailure)
-            {
-                throw new InvalidOperationException(scanResult.Error);
-            }
-
-            return scanResult.Value;
-        });
+        return scanResult.Value;
     }
 
-    /// <summary>
-    /// Starts background scan from row 201 onwards.
-    /// Fire-and-forget - returns Task but should not be awaited.
-    /// </summary>
-    public Task<TableSchema> StartBackgroundScanAsync(
+    /// <inheritdoc/>
+    protected override TableSchema ExecuteBackgroundScan(
         TableSchema currentSchema,
-        CancellationToken cancellationToken
-    )
-    {
-        return Task.Run(
-            () =>
-            {
-                try
-                {
-                    return ProcessRemainingRows(currentSchema, cancellationToken);
-                }
-                catch (OperationCanceledException)
-                {
-                    // Expected when cancelled
-                    return currentSchema;
-                }
-            },
-            cancellationToken
-        );
-    }
-
-    private TableSchema ProcessRemainingRows(TableSchema currentSchema, CancellationToken token)
+        CancellationToken cancellationToken)
     {
         var rowIndex = InitialScanCount;
         var refinedSchema = currentSchema;
 
-        while (!token.IsCancellationRequested)
+        while (!cancellationToken.IsCancellationRequested)
         {
             var rows = ReadRows(rowIndex, BackgroundBatchSize);
             if (rows.Count == 0)
@@ -88,7 +56,7 @@ internal sealed class IncrementalSchemaScanner
 
             foreach (var row in rows)
             {
-                if (token.IsCancellationRequested)
+                if (cancellationToken.IsCancellationRequested)
                 {
                     break;
                 }

--- a/src/App/Schema/IncrementalSchemaScannerBase.cs
+++ b/src/App/Schema/IncrementalSchemaScannerBase.cs
@@ -1,0 +1,67 @@
+using DataMorph.Engine.Models;
+
+namespace DataMorph.App.Schema;
+
+/// <summary>
+/// Base class for incremental schema scanners that perform initial scan and background refinement.
+/// - Initial scan: reads initial rows/lines in a single pass; awaited by the caller before displaying the table
+/// - Background scan: continues refinement on remaining data in batches
+/// - Thread-safe schema updates via Copy-on-Write pattern
+/// </summary>
+internal abstract class IncrementalSchemaScannerBase
+{
+    protected const int InitialScanCount = 200;
+    protected const int BackgroundBatchSize = 1000;
+    /// <summary>
+    /// Performs initial scan to provide the first schema for UI display.
+    /// Must complete before UI can render the initial table view.
+    /// </summary>
+    /// <returns>The initial table schema.</returns>
+    public Task<TableSchema> InitialScanAsync()
+    {
+        return Task.Run(ExecuteInitialScan);
+    }
+
+    /// <summary>
+    /// Starts background scan to refine schema with remaining data.
+    /// Fire-and-forget operation - returns Task but should not be awaited.
+    /// </summary>
+    /// <param name="currentSchema">The schema produced by <see cref="InitialScanAsync"/>.</param>
+    /// <param name="cancellationToken">Token to stop the background scan.</param>
+    /// <returns>Task that completes with the final refined schema.</returns>
+    public Task<TableSchema> StartBackgroundScanAsync(
+        TableSchema currentSchema,
+        CancellationToken cancellationToken)
+    {
+        return Task.Run(
+            () =>
+            {
+                try
+                {
+                    return ExecuteBackgroundScan(currentSchema, cancellationToken);
+                }
+                catch (OperationCanceledException)
+                {
+                    return currentSchema;
+                }
+            },
+            cancellationToken
+        );
+    }
+
+    /// <summary>
+    /// Executes the initial scan logic. Must be implemented by derived classes.
+    /// </summary>
+    /// <returns>The initial table schema.</returns>
+    protected abstract TableSchema ExecuteInitialScan();
+
+    /// <summary>
+    /// Executes the background scan logic. Must be implemented by derived classes.
+    /// </summary>
+    /// <param name="currentSchema">The current schema to refine.</param>
+    /// <param name="cancellationToken">Token to cancel the scan.</param>
+    /// <returns>The refined table schema.</returns>
+    protected abstract TableSchema ExecuteBackgroundScan(
+        TableSchema currentSchema,
+        CancellationToken cancellationToken);
+}

--- a/src/App/Schema/JsonLines/IncrementalSchemaScanner.cs
+++ b/src/App/Schema/JsonLines/IncrementalSchemaScanner.cs
@@ -9,11 +9,8 @@ namespace DataMorph.App.Schema.JsonLines;
 /// - Background scan: remaining lines in batches of 1000
 /// - Thread-safe schema updates via Copy-on-Write
 /// </summary>
-internal sealed class IncrementalSchemaScanner
+internal sealed class IncrementalSchemaScanner : IncrementalSchemaScannerBase
 {
-    private const int InitialScanCount = 200;
-    private const int BackgroundBatchSize = 1000;
-
     private readonly string _filePath;
 
     /// <summary>
@@ -26,65 +23,34 @@ internal sealed class IncrementalSchemaScanner
         _filePath = filePath;
     }
 
-    /// <summary>
-    /// Performs initial scan on first 200 lines.
-    /// Reads lines directly via RowReader independent of RowIndexer to avoid race conditions.
-    /// Must be awaited before UI can display schema.
-    /// </summary>
-    public Task<TableSchema> InitialScanAsync()
+    /// <inheritdoc/>
+    protected override TableSchema ExecuteInitialScan()
     {
-        return Task.Run(() =>
-        {
-            using var reader = new RowReader(_filePath);
-            var lines = reader.ReadLineBytes(
-                byteOffset: 0,
-                linesToSkip: 0,
-                linesToRead: InitialScanCount
-            );
-            var scanResult = SchemaScanner.ScanSchema(lines, InitialScanCount);
-
-            if (scanResult.IsFailure)
-            {
-                throw new InvalidOperationException(scanResult.Error);
-            }
-
-            return scanResult.Value;
-        });
-    }
-
-    /// <summary>
-    /// Starts background scan from line 201 onwards in batches of 1000.
-    /// Calls SchemaScanner.RefineSchema() per line and returns the final refined schema.
-    /// </summary>
-    /// <param name="currentSchema">The schema produced by <see cref="InitialScanAsync"/>.</param>
-    /// <param name="cancellationToken">Token to stop the background scan.</param>
-    public Task<TableSchema> StartBackgroundScanAsync(
-        TableSchema currentSchema,
-        CancellationToken cancellationToken
-    )
-    {
-        return Task.Run(
-            () =>
-            {
-                try
-                {
-                    return ProcessRemainingLines(currentSchema, cancellationToken);
-                }
-                catch (OperationCanceledException)
-                {
-                    return currentSchema;
-                }
-            },
-            cancellationToken
+        using var reader = new RowReader(_filePath);
+        var lines = reader.ReadLineBytes(
+            byteOffset: 0,
+            linesToSkip: 0,
+            linesToRead: InitialScanCount
         );
+        var scanResult = SchemaScanner.ScanSchema(lines, InitialScanCount);
+
+        if (scanResult.IsFailure)
+        {
+            throw new InvalidOperationException(scanResult.Error);
+        }
+
+        return scanResult.Value;
     }
 
-    private TableSchema ProcessRemainingLines(TableSchema currentSchema, CancellationToken token)
+    /// <inheritdoc/>
+    protected override TableSchema ExecuteBackgroundScan(
+        TableSchema currentSchema,
+        CancellationToken cancellationToken)
     {
         var lineIndex = InitialScanCount;
         var refinedSchema = currentSchema;
 
-        while (!token.IsCancellationRequested)
+        while (!cancellationToken.IsCancellationRequested)
         {
             using var reader = new RowReader(_filePath);
             var lines = reader.ReadLineBytes(
@@ -100,7 +66,7 @@ internal sealed class IncrementalSchemaScanner
 
             foreach (var line in lines)
             {
-                if (token.IsCancellationRequested)
+                if (cancellationToken.IsCancellationRequested)
                 {
                     break;
                 }

--- a/tests/DataMorph.Tests/App/ModeControllerTests.cs
+++ b/tests/DataMorph.Tests/App/ModeControllerTests.cs
@@ -75,7 +75,6 @@ public sealed class ModeControllerTests : IDisposable
     public async Task ToggleJsonLinesModeAsync_WithCachedSchema_ReusesSchema()
     {
         // Arrange
-        var cachedScanner = new DataMorph.App.Schema.JsonLines.IncrementalSchemaScanner(_jsonlFilePath);
         var cachedSchema = new DataMorph.Engine.Models.TableSchema
         {
             Columns = [new DataMorph.Engine.Models.ColumnSchema { Name = "id", Type = DataMorph.Engine.Types.ColumnType.WholeNumber }],
@@ -87,7 +86,6 @@ public sealed class ModeControllerTests : IDisposable
             CurrentFilePath = _jsonlFilePath,
             CurrentMode = ViewMode.JsonLinesTree,
             RowIndexer = new RowIndexer(_jsonlFilePath),
-            JsonLinesSchemaScanner = cachedScanner,
             Schema = cachedSchema
         };
         var controller = new ModeController(state);
@@ -98,8 +96,7 @@ public sealed class ModeControllerTests : IDisposable
         // Assert
         result.IsSuccess.Should().BeTrue();
         state.CurrentMode.Should().Be(ViewMode.JsonLinesTable);
-        // Should have reused the cached scanner and schema
-        state.JsonLinesSchemaScanner.Should().BeSameAs(cachedScanner);
+        // Should have reused the cached schema
         state.Schema.Should().BeSameAs(cachedSchema);
     }
 
@@ -123,7 +120,6 @@ public sealed class ModeControllerTests : IDisposable
         result.IsSuccess.Should().BeTrue();
         state.CurrentMode.Should().Be(ViewMode.JsonLinesTable);
         state.Schema.Should().NotBeNull();
-        state.JsonLinesSchemaScanner.Should().NotBeNull();
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- Add `IncrementalSchemaScannerBase` abstract class to remove duplicated `Task.Run` / `OperationCanceledException` boilerplate
- Remove `CsvSchemaScanner` and `JsonLinesSchemaScanner` properties from `AppState` (served no functional purpose)
- Add `RenewCtsWithCancel()` method to properly cancel and renew `CancellationTokenSource` when loading a new file
- Update `ModeController` and `FileDialogHandler` to use the new pattern

Closes #100