### PR TITLE
feat: implement JSON Array element boundary indexing

### DIFF
--- a/docs/design_json_array_element_boundary_indexing.md
+++ b/docs/design_json_array_element_boundary_indexing.md
@@ -1,0 +1,388 @@
+# JSON Array Element Boundary Indexing — Design Document
+
+## Scope
+Implement element boundary indexing for JSON Array format (`[{...}, {...}, ...]`).
+The design mirrors `JsonLines.RowIndexer` as closely as possible; the only structural
+difference is that element boundaries are detected with `Utf8JsonReader` instead of
+scanning for `\n` bytes.
+
+---
+
+## 1. Requirements
+
+### Functional Requirements
+- Index each top-level element of a JSON Array file by its byte offset (checkpoint-based)
+- Support background indexing while unblocking display after the first checkpoint
+- Provide the same `IRowIndexer` contract as `JsonLines.RowIndexer`, enabling reuse of
+  `SlidingWindowLruCache` and the rest of the viewer pipeline without modification
+
+### Non-Functional Requirements
+- **Zero allocations** during the indexing hot path (`ArrayPool<byte>` for buffers)
+- **Native AOT compatible** (`Utf8JsonReader` is AOT-safe; no reflection)
+- **Thread-safe** checkpoint reads during background indexing
+- **Streaming**: fixed-size rolling buffer; file is never fully loaded into memory
+
+---
+
+## 2. Format Characteristics
+
+### Comparison with JSON Lines
+
+| Aspect | JSON Lines | JSON Array |
+|--------|-----------|------------|
+| Root structure | Sequence of top-level values | Single root `[...]` |
+| Element boundary | `\n` byte | `Utf8JsonReader` token at depth 1 |
+| Self-contained rows | Yes — each line is independent | No — structural context required |
+| Buffer strategy | Fixed sequential reads | Rolling window (elements may span buffer boundaries) |
+
+### Why `Utf8JsonReader` is required
+A `\n` byte inside a JSON string is always escaped (`\n`), so a literal newline is a
+reliable boundary. In JSON Array files, there is no single-byte boundary marker;
+elements may span multiple lines and the only safe way to find their end is to parse
+the JSON structure.
+
+---
+
+## 3. Design
+
+### 3.1 Class: `JsonArray.RowIndexer`
+
+```csharp
+namespace DataMorph.Engine.IO.JsonArray;
+
+public sealed class RowIndexer : RowIndexerBase
+{
+    private const int BufferSize = 1024 * 1024;   // 1 MB — same as JsonLines
+    private const int CheckPointInterval = 1000;   // same as JsonLines
+
+    public RowIndexer(string filePath);
+
+    // IRowIndexer — identical contract to JsonLines.RowIndexer
+    public override string FilePath { get; }
+    public override long TotalRows { get; }        // element count
+    public override long BytesRead { get; }
+    public override void BuildIndex(CancellationToken ct = default);
+    public override (long byteOffset, int rowOffset) GetCheckPoint(long targetRow);
+}
+```
+
+`TotalRows` semantically maps to "total elements indexed so far." Callers (including
+`SlidingWindowLruCache`) are unaware of the format difference.
+
+### 3.2 Checkpoint Strategy
+
+Identical to `JsonLines.RowIndexer`:
+
+| Trigger | Action |
+|---------|--------|
+| First element found | Set `_checkpoints[0]` to its byte offset |
+| Every 1000th element | Add checkpoint; update `TotalRows`; fire `FirstCheckpointReached` / `ProgressChanged` |
+| End of file | Finalise `TotalRows`; fire `FirstCheckpointReached` (guard for small files); fire `BuildIndexCompleted` |
+
+`_checkpoints` stores the byte offset of the element that starts each interval
+(element 0, 1000, 2000, …). `GetCheckPoint(n)` returns
+`(_checkpoints[n / 1000], (int)(n % 1000))` — same arithmetic as JsonLines.
+
+Unlike `JsonLines.RowIndexer` which pre-seeds `_checkpoints = [0]` (the file starts
+with the first row), `JsonArray.RowIndexer` initialises `_checkpoints` as empty and
+populates index 0 when element 0 is found. `GetCheckPoint` returns `(-1, 0)` when
+the list is empty; `SlidingWindowLruCache.Prefetch` already guards against negative
+offsets with `if (byteOffset < 0) return`.
+
+**Required implementation detail**: `GetCheckPoint` must include an explicit empty-list
+guard as the first statement to prevent `IndexOutOfRangeException` when called before
+any element is indexed:
+
+```csharp
+if (_checkpoints.Count == 0) return (-1L, 0);
+```
+
+### 3.3 Rolling Buffer Algorithm
+
+`Utf8JsonReader` requires a contiguous `ReadOnlySpan<byte>`. To handle elements that
+span buffer boundaries, unconsumed bytes are compacted to the front of the buffer
+before each refill:
+
+```
+After reader pass:
+  [####consumed####][---remaining---][ empty ]
+   0                ^consumed        ^dataEnd
+
+After compaction + refill:
+  [---remaining---][---new data---][ empty ]
+   0                ^remainingLen   ^newDataEnd
+```
+
+`bufferOriginFileOffset` tracks the file position corresponding to `buffer[0]` and
+is advanced by `reader.BytesConsumed` after each pass. The absolute byte offset of
+any token is `bufferOriginFileOffset + reader.TokenStartIndex`.
+
+`JsonReaderState` is preserved across buffer refills so that the reader correctly
+maintains depth tracking through the root `[...]`.
+
+### 3.4 Element Detection
+
+```
+Depth 0: before / after the root `[`
+Depth 1: top-level elements of the root array  ← element starts recorded here
+Depth 2+: interior of an element
+```
+
+Element boundaries are detected with `Read()` and explicit depth tracking rather than
+`TrySkip()`. This allows any element to span multiple buffer fills regardless of its
+total size, because only one token at a time needs to fit in the buffer.
+
+Token classification at depth 1:
+
+1. `reader.Read()` returns `false` → more data needed; save `JsonReaderState`,
+   compact the buffer, and refill. `currentElementStart` (if already set) persists
+   across the refill because it is declared outside the inner loop.
+2. `EndArray` at depth 0 → root array is complete; exit.
+3. Tokens at depth > 1 → interior of a structured element; skip (`continue`).
+4. `StartObject` / `StartArray` at depth 1 → record `currentElementStart` and
+   continue reading. The element is complete when the matching `EndObject` /
+   `EndArray` returns the reader to depth 1.
+5. `EndObject` / `EndArray` at depth 1 → the structured element is complete;
+   record it and clear `currentElementStart`.
+6. Primitive tokens (String, Number, True, False, Null) at depth 1 → the token
+   itself is a complete element; record it immediately.
+
+**Oversized string detection**: if `reader.Read()` returns `false` and
+`reader.BytesConsumed == 0` while the buffer is already full (`remainingLen ==
+BufferSize`), the current token exceeds the buffer capacity and no progress is
+possible. This can only happen for string values larger than 1 MB. In that case,
+throw `NotSupportedException("JSON string value exceeds maximum supported size.")`,
+mirroring the naming style of `JsonLines.RowReader`.
+
+### 3.5 Thread Safety
+
+Identical model to `JsonLines.RowIndexer`:
+
+| Member | Mechanism |
+|--------|-----------|
+| `_checkpoints` writes | `Lock` |
+| `_checkpoints` reads (`GetCheckPoint`) | `Lock` |
+| `TotalRows`, `BytesRead` | `Interlocked` |
+| Event invocations | Fired from `BuildIndex` thread; subscribers marshal if needed |
+
+### 3.6 Pipeline Integration
+
+`JsonArray.RowIndexer` implements `IRowIndexer`, so the entire existing pipeline
+works unchanged:
+
+```
+JsonArray.RowIndexer  (this issue)
+        ↓
+SlidingWindowLruCache  (no changes)
+        ↓
+ElementByteCache  (future — mirrors RowByteCache, uses ElementReader)
+        ↓
+TableView / TUI
+```
+
+`RowIndexerFactory.Create(DataFormat.JsonArray)` is updated in this issue to return a
+`new JsonArray.RowIndexer(filePath)`.
+
+---
+
+## 4. Implementation Plan
+
+### 4.1 Core Algorithm (Pseudocode)
+
+```
+fileSize = FileInfo(filePath).Length
+buffer = ArrayPool.Rent(BufferSize)
+try:
+  FileSize = fileSize          // assign base class property (consumed by OnProgressChanged)
+  using var handle = File.OpenHandle(filePath, FileMode.Open, FileAccess.Read, FileShare.Read)
+  state = default(JsonReaderState)
+  bufferOriginFileOffset = 0L
+  fileReadOffset = 0L
+  remainingLen = 0
+  elementCount = 0L
+  currentElementStart = -1L    // -1 = not currently inside an element
+
+loop:
+  ct.ThrowIfCancellationRequested()
+
+  // Detect stuck: buffer full and nothing consumable (oversized string token)
+  if remainingLen == BufferSize:
+    throw NotSupportedException("JSON string value exceeds maximum supported size.")
+
+  bytesRead = RandomAccess.Read(handle, buffer[remainingLen..], fileReadOffset)
+  if bytesRead == 0: break
+  fileReadOffset += bytesRead
+  dataEnd = remainingLen + bytesRead
+  isFinalBlock = (fileReadOffset >= fileSize)
+  Interlocked.Add(ref _bytesRead, bytesRead)
+
+  reader = new Utf8JsonReader(buffer[0..dataEnd], isFinalBlock, state)
+
+  innerLoop:
+    if not reader.Read(): break innerLoop
+
+    if reader.CurrentDepth == 0 && reader.TokenType == EndArray: goto done
+    if reader.CurrentDepth != 1: continue innerLoop   // skip root markers (depth 0) AND element interior (depth 2+)
+
+    // --- depth 1 tokens ---
+
+    if reader.TokenType in {StartObject, StartArray}:
+      if currentElementStart < 0:
+        currentElementStart = bufferOriginFileOffset + reader.TokenStartIndex
+      continue innerLoop    // wait for matching End* to come back to depth 1
+
+    if reader.TokenType in {EndObject, EndArray}:
+      RecordElement(currentElementStart)
+      currentElementStart = -1L
+      continue innerLoop
+
+    // Primitive token at depth 1: self-contained element
+    RecordElement(bufferOriginFileOffset + reader.TokenStartIndex)
+
+  state = reader.CurrentState
+  consumed = (int)reader.BytesConsumed
+  bufferOriginFileOffset += consumed
+  remainingLen = dataEnd - consumed
+  Buffer.BlockCopy(buffer, consumed, buffer, 0, remainingLen)
+
+RecordElement(elementStart):
+  if elementCount == 0:
+    lock(_lock): _checkpoints.Add(elementStart)            // checkpoint 0 at E0
+  else if elementCount % CheckPointInterval == 0:
+    Interlocked.Exchange(ref _totalRows, elementCount)
+    lock(_lock): _checkpoints.Add(elementStart)            // checkpoint k at E(k×1000)
+    OnFirstCheckpointReached()
+    OnProgressChanged(BytesRead, FileSize)
+  elementCount++                                           // increment after checkpoint check (0-based index)
+
+done:
+  Interlocked.Exchange(ref _totalRows, elementCount)
+  OnFirstCheckpointReached()   // guard for small files (<1000 elements); fires after TotalRows is finalised
+
+finally:
+  OnFirstCheckpointReached()   // guarantee event fires even on cancellation or error
+  ArrayPool.Return(buffer)     // must be in finally to prevent pool leak on exception
+  OnBuildIndexCompleted()      // unconditional
+```
+
+### 4.2 Edge Cases
+
+| Case | Handling |
+|------|----------|
+| Empty array `[]` | `TotalRows = 0`; `OnFirstCheckpointReached()` fires at `done:` label (after `TotalRows` finalised) and in `finally` (idempotent); `ArrayPool.Return` and `OnBuildIndexCompleted()` fire in `finally` |
+| Single element | `_checkpoints = [element0Offset]`; fires at end of scan |
+| Primitives as elements | Handled as self-contained depth-1 tokens; no special skip needed |
+| Structured element spans buffer boundary | `Read()` returns `false`; `JsonReaderState` + `currentElementStart` preserved; buffer compacted and refilled |
+| Deeply nested or large structured elements | Depth tracking processes one token at a time regardless of total element size; no buffer size limit for structured elements |
+| String value > 1 MB | `Read()` returns `false` with `BytesConsumed == 0` and `remainingLen == BufferSize`; throws `NotSupportedException` |
+| Cancellation | `OperationCanceledException`; `FirstCheckpointReached` fires via `finally` guard; `BuildIndexCompleted` still fires |
+
+---
+
+## 5. Files to Create / Modify
+
+| File | Action | Purpose |
+|------|--------|---------|
+| `src/Engine/IO/JsonArray/RowIndexer.cs` | Create | Core streaming indexer |
+| `src/App/RowIndexerFactory.cs` | Modify | Add `DataFormat.JsonArray` case |
+| `tests/DataMorph.Tests/Engine/IO/JsonArray/RowIndexerTests.cs` | Create | Shared fixtures |
+| `tests/DataMorph.Tests/Engine/IO/JsonArray/RowIndexerTests.BuildIndex.cs` | Create | `BuildIndex` correctness tests |
+| `tests/DataMorph.Tests/Engine/IO/JsonArray/RowIndexerTests.GetCheckPoint.cs` | Create | `GetCheckPoint` correctness + concurrency tests |
+| `tests/DataMorph.Tests/Engine/IO/JsonArray/RowIndexerBenchmarks.cs` | Create | BenchmarkDotNet perf tests |
+
+---
+
+## 6. Testing Strategy
+
+### 6.1 Unit Tests
+
+**BuildIndex**
+
+| Test | Input | Expected |
+|------|-------|----------|
+| Empty array | `[]` | `TotalRows = 0`; `BuildIndexCompleted` fired |
+| Single primitive | `[42]` | `TotalRows = 1`; 1 checkpoint |
+| Single object | `[{"a":1}]` | `TotalRows = 1`; checkpoint offset points to `{` |
+| Byte-level offset (leading whitespace) | `  [{"a":1}]` (2-byte leading whitespace) | `byteOffset` equals exact byte offset of `{`, not `[` |
+| Mixed types | `[{}, [], 1, "s", null, true]` | `TotalRows = 6`; correct checkpoint |
+| Deeply nested | `[{"a":{"b":{"c":1}}}]` | `TotalRows = 1`; depth tracking traverses all levels without error |
+| 1 001 elements | 1001-element array | 2 checkpoints; `FirstCheckpointReached` fired once |
+| Checkpoint 1 byte-level offset | 1001-element array where element 1000 has a known, unique byte offset | `_checkpoints[1]` equals the offset of E1000, not E999 |
+| Structured element spans buffer | Object whose tokens span a buffer boundary | Correctly indexed; `JsonReaderState` + `currentElementStart` resume across refill |
+| String value > 1 MB | Single string element `> 1 MB` | `NotSupportedException` thrown |
+| Cancellation | Any array | `OperationCanceledException`; `BuildIndexCompleted` still fires |
+
+**GetCheckPoint**
+
+| Test | Scenario | Expected |
+|------|----------|----------|
+| Before any indexing | `GetCheckPoint(0)` on fresh instance | `byteOffset = -1` |
+| Element 0 | After first element indexed | `byteOffset` = offset of `{`; `rowOffset = 0` |
+| Element 500 | Fewer than 1000 elements | `byteOffset` = checkpoint 0; `rowOffset = 500` |
+| Element 1000 | Exactly at checkpoint | `byteOffset` = checkpoint 1; `rowOffset = 0` |
+| Concurrent read | `GetCheckPoint` from second thread during `BuildIndex` | No exception |
+| Out of range | `GetCheckPoint` beyond `TotalRows` | Clamped to last checkpoint |
+
+### 6.2 Benchmarks
+
+```csharp
+[MemoryDiagnoser]
+class RowIndexerBenchmarks
+```
+
+| Benchmark | Description |
+|-----------|-------------|
+| `BuildIndex_1kElements` | 1 000 small objects |
+| `BuildIndex_100kElements` | 100 000 small objects |
+| `BuildIndex_1mElements` | 1 000 000 small objects |
+| `GetCheckPoint_First` | `GetCheckPoint(0)` |
+| `GetCheckPoint_Middle` | `GetCheckPoint(N / 2)` |
+| `GetCheckPoint_Last` | `GetCheckPoint(N - 1)` |
+
+Target: zero heap allocations in `BuildIndex` hot path.
+
+---
+
+## 7. Decision Record
+
+### Rationale
+The design mirrors `JsonLines.RowIndexer` — same interface, same checkpoint interval,
+same thread-safety model — so the entire viewer pipeline (`SlidingWindowLruCache`,
+`RowIndexerFactory`, progress events) works without modification.
+
+`Utf8JsonReader` is the only BCL JSON reader that is AOT-safe, allocation-free in the
+hot path, and supports stateful resumption across buffer boundaries via
+`JsonReaderState`. Element boundaries are detected with `Read()` + explicit depth
+tracking rather than `TrySkip()`. This approach processes one token at a time,
+meaning only a single token needs to fit in the 1 MB buffer; structured elements of
+any size are handled correctly regardless of buffer boundaries.
+
+### Alternatives Considered
+
+**A. Dedicated `IElementBoundaryIndexer` interface storing `(Offset, Length)` per element**
+- Rejected: requires a parallel viewer pipeline for JsonArray. Memory grows linearly
+  with element count (12 MB per 1 M elements vs. ~8 KB for checkpoints).
+  `SlidingWindowLruCache` already handles random access via its LRU eviction for `u/d`
+  jumps and other non-sequential access patterns.
+
+**B. Load entire file, then scan with `JsonDocument`**
+- Rejected: violates zero-allocation and streaming requirements; `JsonDocument`
+  builds a full in-memory DOM.
+
+**C. Reuse `JsonLines.RowIndexer` with a pre-processing step**
+- Rejected: JSON Array is not line-oriented; no reliable single-byte boundary exists.
+
+### Consequences
+- **Easier**: `SlidingWindowLruCache`, `RowIndexerFactory`, and all progress UI work
+  immediately with no changes.
+- **Easier**: Future `ElementByteCache` follows the same pattern as `RowByteCache` —
+  extend `SlidingWindowLruCache<ReadOnlyMemory<byte>>`, override `LoadRows` with an
+  `ElementReader` that uses `Utf8JsonReader` to scan forward from a checkpoint.
+- **Trade-off**: `u/d` jumps that miss the LRU cache require scanning up to 999
+  elements with `Utf8JsonReader` (slower than JsonLines' `IndexOf('\n')`). Acceptable
+  for typical JSON data; a future per-element full index can be added if profiling
+  shows a bottleneck.
+- **Note**: `GetCheckPoint` stores only byte offsets, not `JsonReaderState`. A future
+  `ElementReader` will need to either re-derive structural context from byte 0 of the
+  checkpoint element, or this type can be extended with a `GetCheckPointWithState`
+  method when that work begins.

--- a/docs/design_json_array_element_boundary_indexing.md
+++ b/docs/design_json_array_element_boundary_indexing.md
@@ -83,6 +83,13 @@ Identical to `JsonLines.RowIndexer`:
 (element 0, 1000, 2000, …). `GetCheckPoint(n)` returns
 `(_checkpoints[n / 1000], (int)(n % 1000))` — same arithmetic as JsonLines.
 
+**Out-of-range clamping**: when `n / 1000 >= _checkpoints.Count`, the ideal
+checkpoint index is clamped to `_checkpoints.Count - 1`. The `rowOffset` is then
+computed as `(int)(n - clampedIndex * 1000)` (not `n % 1000`), which preserves the
+full distance from the last available checkpoint. This ensures that the caller can
+still seek forward from the checkpoint to the target element (or detect EOF when the
+file has fewer elements than requested).
+
 Unlike `JsonLines.RowIndexer` which pre-seeds `_checkpoints = [0]` (the file starts
 with the first row), `JsonArray.RowIndexer` initialises `_checkpoints` as empty and
 populates index 0 when element 0 is found. `GetCheckPoint` returns `(-1, 0)` when

--- a/src/App/RowIndexerFactory.cs
+++ b/src/App/RowIndexerFactory.cs
@@ -2,6 +2,7 @@ using DataMorph.Engine.IO;
 using DataMorph.Engine.IO.Csv;
 using DataMorph.Engine.IO.JsonLines;
 using DataMorph.Engine.Types;
+using JsonArray = DataMorph.Engine.IO.JsonArray;
 
 namespace DataMorph.App;
 
@@ -22,6 +23,7 @@ internal static class RowIndexerFactory
         {
             DataFormat.Csv => new DataRowIndexer(filePath),
             DataFormat.JsonLines => new RowIndexer(filePath),
+            DataFormat.JsonArray => new JsonArray.RowIndexer(filePath),
             _ => throw new NotSupportedException($"Unsupported format: {format}"),
         };
     }

--- a/src/Engine/IO/JsonArray/RowIndexer.cs
+++ b/src/Engine/IO/JsonArray/RowIndexer.cs
@@ -1,0 +1,84 @@
+namespace DataMorph.Engine.IO.JsonArray;
+
+/// <summary>
+/// Indexes JSON Array files by element position for efficient random access.
+/// Each top-level element in the root <c>[...]</c> array is tracked by its byte offset.
+/// </summary>
+/// <remarks>
+/// <para>Thread-safety model:</para>
+/// <list type="table">
+///   <listheader><term>Member</term><description>Mechanism</description></listheader>
+///   <item><term>_checkpoints writes</term><description>Lock</description></item>
+///   <item><term>_checkpoints reads (GetCheckPoint)</term><description>Lock</description></item>
+///   <item><term>TotalRows, BytesRead</term><description>Interlocked</description></item>
+///   <item><term>Event invocations</term><description>BuildIndex thread; subscribers marshal if needed</description></item>
+/// </list>
+/// </remarks>
+public sealed class RowIndexer : RowIndexerBase
+{
+    private readonly string _filePath;
+
+    // Step 2 will write these fields in BuildIndex.
+    // 'readonly' is intentionally omitted — Interlocked.Read requires a ref parameter (CS0192).
+#pragma warning disable CS0649, IDE0044 // Skeleton: fields written in Step 2; non-readonly for Interlocked.Read ref
+    private long _totalRows;
+    private long _bytesRead;
+#pragma warning restore CS0649, IDE0044
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RowIndexer"/> class.
+    /// </summary>
+    /// <param name="filePath">The path to the JSON Array file to index.</param>
+    /// <exception cref="ArgumentException">Thrown when filePath is null or whitespace.</exception>
+    public RowIndexer(string filePath)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(filePath);
+        _filePath = filePath;
+    }
+
+    /// <summary>
+    /// Gets the path to the JSON Array file being indexed.
+    /// </summary>
+    public override string FilePath => _filePath;
+
+    /// <summary>
+    /// Gets the total number of elements indexed so far.
+    /// Updated periodically during <see cref="BuildIndex"/> (every 1000 elements) and finalized upon completion.
+    /// Thread-safe via Interlocked operations.
+    /// </summary>
+    public override long TotalRows => Interlocked.Read(ref _totalRows);
+
+    /// <summary>
+    /// Gets the total bytes read so far. Updated atomically after each buffer read.
+    /// Safe to read from any thread.
+    /// </summary>
+    public override long BytesRead => Interlocked.Read(ref _bytesRead);
+
+    /// <summary>
+    /// Builds the element index by streaming through the entire JSON Array file.
+    /// Exits cooperatively when <paramref name="ct"/> is cancelled.
+    /// NOT thread-safe — call once from a single background thread.
+    /// <see cref="RowIndexerBase.BuildIndexCompleted"/> fires unconditionally when this method
+    /// returns, regardless of whether it completed, was cancelled, or threw.
+    /// </summary>
+    public override void BuildIndex(CancellationToken ct = default)
+    {
+        throw new NotImplementedException();
+    }
+
+    /// <summary>
+    /// Gets the nearest checkpoint for random access to a target element.
+    /// Returns the file byte offset and row offset from that checkpoint.
+    /// This method is thread-safe.
+    /// </summary>
+    /// <param name="targetRow">The zero-based element index to seek to.</param>
+    /// <returns>
+    /// A tuple of (byteOffset, rowOffset) where byteOffset is the file position in bytes
+    /// and rowOffset is the number of elements to advance from the checkpoint.
+    /// Returns (-1, 0) when no elements have been indexed yet.
+    /// </returns>
+    public override (long byteOffset, int rowOffset) GetCheckPoint(long targetRow)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/src/Engine/IO/JsonArray/RowIndexer.cs
+++ b/src/Engine/IO/JsonArray/RowIndexer.cs
@@ -1,3 +1,6 @@
+using System.Buffers;
+using System.Text.Json;
+
 namespace DataMorph.Engine.IO.JsonArray;
 
 /// <summary>
@@ -16,14 +19,15 @@ namespace DataMorph.Engine.IO.JsonArray;
 /// </remarks>
 public sealed class RowIndexer : RowIndexerBase
 {
+    private readonly Lock _lock = new();
     private readonly string _filePath;
+    private readonly List<long> _checkpoints = [];
 
-    // Step 2 will write these fields in BuildIndex.
-    // 'readonly' is intentionally omitted — Interlocked.Read requires a ref parameter (CS0192).
-#pragma warning disable CS0649, IDE0044 // Skeleton: fields written in Step 2; non-readonly for Interlocked.Read ref
     private long _totalRows;
     private long _bytesRead;
-#pragma warning restore CS0649, IDE0044
+
+    private const int BufferSize = 1024 * 1024; // 1 MB — same as JsonLines
+    private const int CheckPointInterval = 1000;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="RowIndexer"/> class.
@@ -63,7 +67,152 @@ public sealed class RowIndexer : RowIndexerBase
     /// </summary>
     public override void BuildIndex(CancellationToken ct = default)
     {
-        throw new NotImplementedException();
+        var buffer = ArrayPool<byte>.Shared.Rent(BufferSize);
+
+        try
+        {
+            FileSize = new FileInfo(_filePath).Length;
+
+            using var handle = File.OpenHandle(
+                _filePath,
+                FileMode.Open,
+                FileAccess.Read,
+                FileShare.Read
+            );
+
+            var state = default(JsonReaderState);
+            var bufferOriginFileOffset = 0L;
+            var fileReadOffset = 0L;
+            var remainingLen = 0;
+            var elementCount = 0L;
+            var currentElementStart = -1L;
+
+            while (true)
+            {
+                ct.ThrowIfCancellationRequested();
+
+                if (remainingLen == BufferSize)
+                {
+                    throw new NotSupportedException(
+                        "JSON string value exceeds maximum supported size."
+                    );
+                }
+
+                var bytesRead = RandomAccess.Read(
+                    handle,
+                    buffer.AsSpan(remainingLen, BufferSize - remainingLen),
+                    fileReadOffset
+                );
+
+                if (bytesRead == 0)
+                {
+                    break;
+                }
+
+                fileReadOffset += bytesRead;
+                var dataEnd = remainingLen + bytesRead;
+                var isFinalBlock = fileReadOffset >= FileSize;
+                Interlocked.Add(ref _bytesRead, bytesRead);
+
+                var reader = new Utf8JsonReader(
+                    buffer.AsSpan(0, dataEnd),
+                    isFinalBlock,
+                    state
+                );
+
+                var rootArrayComplete = false;
+
+                while (reader.Read())
+                {
+                    if (reader.CurrentDepth == 0 && reader.TokenType == JsonTokenType.EndArray)
+                    {
+                        rootArrayComplete = true;
+                        break;
+                    }
+
+                    if (reader.CurrentDepth != 1)
+                    {
+                        continue;
+                    }
+
+                    // Depth-1 tokens — element boundary detection
+                    if (reader.TokenType is JsonTokenType.StartObject or JsonTokenType.StartArray)
+                    {
+                        // Guard against overwriting an already-set start position.
+                        // In valid JSON this condition is always true, but the check
+                        // prevents silent data corruption if this invariant is ever violated.
+                        if (currentElementStart < 0)
+                        {
+                            currentElementStart =
+                                bufferOriginFileOffset + reader.TokenStartIndex;
+                        }
+
+                        continue;
+                    }
+
+                    if (reader.TokenType is JsonTokenType.EndObject or JsonTokenType.EndArray)
+                    {
+                        RecordElement(currentElementStart, elementCount);
+                        elementCount++;
+                        currentElementStart = -1L;
+                        continue;
+                    }
+
+                    // Primitive token at depth 1 — self-contained element
+                    RecordElement(bufferOriginFileOffset + reader.TokenStartIndex, elementCount);
+                    elementCount++;
+                }
+
+                if (rootArrayComplete)
+                {
+                    break;
+                }
+
+                ct.ThrowIfCancellationRequested();
+
+                state = reader.CurrentState;
+                var consumed = (int)reader.BytesConsumed;
+                bufferOriginFileOffset += consumed;
+                remainingLen = dataEnd - consumed;
+                buffer.AsSpan(consumed, remainingLen).CopyTo(buffer);
+            }
+
+            Interlocked.Exchange(ref _totalRows, elementCount);
+            OnFirstCheckpointReached();
+        }
+        finally
+        {
+            OnFirstCheckpointReached();
+            ArrayPool<byte>.Shared.Return(buffer);
+            OnBuildIndexCompleted();
+        }
+    }
+
+    private void RecordElement(long elementStart, long elementCount)
+    {
+        if (elementCount == 0)
+        {
+            lock (_lock)
+            {
+                _checkpoints.Add(elementStart);
+            }
+
+            return;
+        }
+
+        if (elementCount % CheckPointInterval != 0)
+        {
+            return;
+        }
+
+        Interlocked.Exchange(ref _totalRows, elementCount);
+        lock (_lock)
+        {
+            _checkpoints.Add(elementStart);
+        }
+
+        OnFirstCheckpointReached();
+        OnProgressChanged(Interlocked.Read(ref _bytesRead), FileSize);
     }
 
     /// <summary>
@@ -71,14 +220,35 @@ public sealed class RowIndexer : RowIndexerBase
     /// Returns the file byte offset and row offset from that checkpoint.
     /// This method is thread-safe.
     /// </summary>
-    /// <param name="targetRow">The zero-based element index to seek to.</param>
+    /// <param name="targetRow">The zero-based element index to seek to. Must be non-negative.</param>
     /// <returns>
     /// A tuple of (byteOffset, rowOffset) where byteOffset is the file position in bytes
     /// and rowOffset is the number of elements to advance from the checkpoint.
     /// Returns (-1, 0) when no elements have been indexed yet.
     /// </returns>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="targetRow"/> is negative.</exception>
     public override (long byteOffset, int rowOffset) GetCheckPoint(long targetRow)
     {
-        throw new NotImplementedException();
+        ArgumentOutOfRangeException.ThrowIfNegative(targetRow);
+
+        lock (_lock)
+        {
+            if (_checkpoints.Count == 0)
+            {
+                return (-1L, 0);
+            }
+
+            var idealCheckPointIndex = (int)(targetRow / CheckPointInterval);
+            var actualCheckPointIndex = Math.Clamp(
+                idealCheckPointIndex,
+                0,
+                _checkpoints.Count - 1
+            );
+            var byteOffset = _checkpoints[actualCheckPointIndex];
+            var actualCheckPointRow = (long)actualCheckPointIndex * CheckPointInterval;
+            var rowOffset = (int)(targetRow - actualCheckPointRow);
+
+            return (byteOffset, rowOffset);
+        }
     }
 }

--- a/tests/DataMorph.Tests/Engine/IO/JsonArray/RowIndexerBenchmarks.cs
+++ b/tests/DataMorph.Tests/Engine/IO/JsonArray/RowIndexerBenchmarks.cs
@@ -1,64 +1,106 @@
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Jobs;
+using DataMorph.Engine.IO.JsonArray;
 
 namespace DataMorph.Tests.Engine.IO.JsonArray;
 
 [SimpleJob(RuntimeMoniker.NativeAot80)]
 [MemoryDiagnoser]
-public class RowIndexerBenchmarks
+public sealed class RowIndexerBenchmarks : IDisposable
 {
-    private readonly string _tempFilePath;
+    private const int ElementCount1k = 1_000;
+    private const int ElementCount100k = 100_000;
+    private const int ElementCount1m = 1_000_000;
+
+    private readonly string _tempFilePath1k;
+    private readonly string _tempFilePath100k;
+    private readonly string _tempFilePath1m;
+    private readonly RowIndexer _prebuiltIndexer;
 
     public RowIndexerBenchmarks()
     {
-        _tempFilePath = Path.Combine(Path.GetTempPath(), $"jsonarray_benchmark_{Guid.NewGuid()}.json");
-    }
+        var id = Guid.NewGuid();
+        _tempFilePath1k = Path.Combine(
+            Path.GetTempPath(),
+            $"jsonarray_bench_1k_{id}.json"
+        );
+        _tempFilePath100k = Path.Combine(
+            Path.GetTempPath(),
+            $"jsonarray_bench_100k_{id}.json"
+        );
+        _tempFilePath1m = Path.Combine(
+            Path.GetTempPath(),
+            $"jsonarray_bench_1m_{id}.json"
+        );
 
-    [GlobalSetup]
-    public void Setup()
-    {
-        throw new NotImplementedException();
-    }
+        WriteElements(_tempFilePath1k, ElementCount1k);
+        WriteElements(_tempFilePath100k, ElementCount100k);
+        WriteElements(_tempFilePath1m, ElementCount1m);
 
-    [GlobalCleanup]
-    public void Cleanup()
-    {
-        throw new NotImplementedException();
+        _prebuiltIndexer = new RowIndexer(_tempFilePath1m);
+        _prebuiltIndexer.BuildIndex();
     }
 
     [Benchmark]
     public void BuildIndex_1kElements()
     {
-        throw new NotImplementedException();
+        var indexer = new RowIndexer(_tempFilePath1k);
+        indexer.BuildIndex();
     }
 
     [Benchmark]
     public void BuildIndex_100kElements()
     {
-        throw new NotImplementedException();
+        var indexer = new RowIndexer(_tempFilePath100k);
+        indexer.BuildIndex();
     }
 
     [Benchmark]
     public void BuildIndex_1mElements()
     {
-        throw new NotImplementedException();
+        var indexer = new RowIndexer(_tempFilePath1m);
+        indexer.BuildIndex();
     }
 
     [Benchmark]
     public void GetCheckPoint_First()
     {
-        throw new NotImplementedException();
+        _prebuiltIndexer.GetCheckPoint(0);
     }
 
     [Benchmark]
     public void GetCheckPoint_Middle()
     {
-        throw new NotImplementedException();
+        _prebuiltIndexer.GetCheckPoint(ElementCount1m / 2);
     }
 
     [Benchmark]
     public void GetCheckPoint_Last()
     {
-        throw new NotImplementedException();
+        _prebuiltIndexer.GetCheckPoint(ElementCount1m - 1);
+    }
+
+    public void Dispose()
+    {
+        File.Delete(_tempFilePath1k);
+        File.Delete(_tempFilePath100k);
+        File.Delete(_tempFilePath1m);
+    }
+
+    private static void WriteElements(string path, int count)
+    {
+        using var writer = new StreamWriter(path);
+        writer.Write('[');
+        for (var i = 0; i < count; i++)
+        {
+            if (i > 0)
+            {
+                writer.Write(',');
+            }
+
+            writer.Write($"{{\"id\":{i}}}");
+        }
+
+        writer.Write(']');
     }
 }

--- a/tests/DataMorph.Tests/Engine/IO/JsonArray/RowIndexerBenchmarks.cs
+++ b/tests/DataMorph.Tests/Engine/IO/JsonArray/RowIndexerBenchmarks.cs
@@ -1,0 +1,64 @@
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Jobs;
+
+namespace DataMorph.Tests.Engine.IO.JsonArray;
+
+[SimpleJob(RuntimeMoniker.NativeAot80)]
+[MemoryDiagnoser]
+public class RowIndexerBenchmarks
+{
+    private readonly string _tempFilePath;
+
+    public RowIndexerBenchmarks()
+    {
+        _tempFilePath = Path.Combine(Path.GetTempPath(), $"jsonarray_benchmark_{Guid.NewGuid()}.json");
+    }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        throw new NotImplementedException();
+    }
+
+    [GlobalCleanup]
+    public void Cleanup()
+    {
+        throw new NotImplementedException();
+    }
+
+    [Benchmark]
+    public void BuildIndex_1kElements()
+    {
+        throw new NotImplementedException();
+    }
+
+    [Benchmark]
+    public void BuildIndex_100kElements()
+    {
+        throw new NotImplementedException();
+    }
+
+    [Benchmark]
+    public void BuildIndex_1mElements()
+    {
+        throw new NotImplementedException();
+    }
+
+    [Benchmark]
+    public void GetCheckPoint_First()
+    {
+        throw new NotImplementedException();
+    }
+
+    [Benchmark]
+    public void GetCheckPoint_Middle()
+    {
+        throw new NotImplementedException();
+    }
+
+    [Benchmark]
+    public void GetCheckPoint_Last()
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/tests/DataMorph.Tests/Engine/IO/JsonArray/RowIndexerTests.BuildIndex.cs
+++ b/tests/DataMorph.Tests/Engine/IO/JsonArray/RowIndexerTests.BuildIndex.cs
@@ -1,0 +1,314 @@
+using AwesomeAssertions;
+using DataMorph.Engine.IO.JsonArray;
+
+namespace DataMorph.Tests.Engine.IO.JsonArray;
+
+public sealed partial class RowIndexerTests
+{
+    [Fact]
+    public void BuildIndex_WithEmptyArray_ReturnsZeroTotalRows()
+    {
+        // Arrange
+        File.WriteAllText(_testFilePath, "[]");
+        var indexer = new RowIndexer(_testFilePath);
+
+        // Act
+        indexer.BuildIndex();
+
+        // Assert
+        indexer.TotalRows.Should().Be(0);
+    }
+
+    [Fact]
+    public void BuildIndex_WithEmptyArray_FiresBuildIndexCompleted()
+    {
+        // Arrange
+        File.WriteAllText(_testFilePath, "[]");
+        var indexer = new RowIndexer(_testFilePath);
+        var buildIndexCompletedFired = false;
+        indexer.BuildIndexCompleted += () => buildIndexCompletedFired = true;
+
+        // Act
+        indexer.BuildIndex();
+
+        // Assert
+        buildIndexCompletedFired.Should().BeTrue();
+    }
+
+    [Fact]
+    public void BuildIndex_WithSinglePrimitive_ReturnsOneElement()
+    {
+        // Arrange
+        File.WriteAllText(_testFilePath, "[42]");
+        var indexer = new RowIndexer(_testFilePath);
+
+        // Act
+        indexer.BuildIndex();
+
+        // Assert
+        indexer.TotalRows.Should().Be(1);
+    }
+
+    [Fact]
+    public void BuildIndex_WithSingleObject_ReturnsOneElement()
+    {
+        // Arrange
+        File.WriteAllText(_testFilePath, "[{\"a\":1}]");
+        var indexer = new RowIndexer(_testFilePath);
+
+        // Act
+        indexer.BuildIndex();
+
+        // Assert
+        indexer.TotalRows.Should().Be(1);
+    }
+
+    [Fact]
+    public void BuildIndex_WithLeadingWhitespace_ReturnsCorrectTotalRows()
+    {
+        // Arrange — 2-byte leading whitespace before '['
+        File.WriteAllText(_testFilePath, "  [{\"a\":1}]");
+        var indexer = new RowIndexer(_testFilePath);
+
+        // Act
+        indexer.BuildIndex();
+
+        // Assert
+        indexer.TotalRows.Should().Be(1);
+    }
+
+    [Fact]
+    public void BuildIndex_WithMixedTypes_IndexesAllElements()
+    {
+        // Arrange
+        File.WriteAllText(_testFilePath, "[{}, [], 1, \"s\", null, true]");
+        var indexer = new RowIndexer(_testFilePath);
+
+        // Act
+        indexer.BuildIndex();
+
+        // Assert
+        indexer.TotalRows.Should().Be(6);
+    }
+
+    [Fact]
+    public void BuildIndex_WithDeeplyNestedObject_IndexesCorrectly()
+    {
+        // Arrange
+        File.WriteAllText(_testFilePath, "[{\"a\":{\"b\":{\"c\":1}}}]");
+        var indexer = new RowIndexer(_testFilePath);
+
+        // Act
+        indexer.BuildIndex();
+
+        // Assert
+        indexer.TotalRows.Should().Be(1);
+    }
+
+    [Fact]
+    public void BuildIndex_With1001Elements_IndexesAllElements()
+    {
+        // Arrange
+        var elements = Enumerable.Range(0, 1001).Select(i => $"{{\"id\":{i}}}");
+        File.WriteAllText(_testFilePath, $"[{string.Join(",", elements)}]");
+        var indexer = new RowIndexer(_testFilePath);
+
+        // Act
+        indexer.BuildIndex();
+
+        // Assert
+        indexer.TotalRows.Should().Be(1001);
+    }
+
+    [Fact]
+    public void BuildIndex_With1001Elements_FirstCheckpointReachedFiresOnce()
+    {
+        // Arrange
+        var elements = Enumerable.Range(0, 1001).Select(i => $"{{\"id\":{i}}}");
+        File.WriteAllText(_testFilePath, $"[{string.Join(",", elements)}]");
+        var indexer = new RowIndexer(_testFilePath);
+        var fireCount = 0;
+        indexer.FirstCheckpointReached += () => Interlocked.Increment(ref fireCount);
+
+        // Act
+        indexer.BuildIndex();
+
+        // Assert
+        fireCount.Should().Be(1);
+    }
+
+    [Fact]
+    public void BuildIndex_StructuredElementSpansBuffer_IndexesCorrectly()
+    {
+        // Arrange — object with many small fields so the total exceeds 1 MB
+        // without any single JSON string token exceeding the buffer
+        var fields = string.Join(",", Enumerable.Range(0, 90_000).Select(i => $"\"f{i}\":{i}"));
+        File.WriteAllText(_testFilePath, $"[{{{fields}}}]");
+        var indexer = new RowIndexer(_testFilePath);
+
+        // Act
+        indexer.BuildIndex();
+
+        // Assert
+        indexer.TotalRows.Should().Be(1);
+    }
+
+    [Fact]
+    public void BuildIndex_StringValueExceedsBufferSize_ThrowsNotSupportedException()
+    {
+        // Arrange — string value larger than 1 MB buffer
+        var oversizedString = new string('a', 1024 * 1024 + 1);
+        File.WriteAllText(_testFilePath, $"[\"{oversizedString}\"]");
+        var indexer = new RowIndexer(_testFilePath);
+
+        // Act
+        var act = () => indexer.BuildIndex();
+
+        // Assert
+        act.Should().Throw<NotSupportedException>();
+    }
+
+    [Fact]
+    public async Task BuildIndex_WhenCancelled_ThrowsOperationCanceledException()
+    {
+        // Arrange
+        using var cts = new CancellationTokenSource();
+        var elements = Enumerable.Range(0, 2000).Select(i => $"{{\"id\":{i}}}");
+        File.WriteAllText(_testFilePath, $"[{string.Join(",", elements)}]");
+        var indexer = new RowIndexer(_testFilePath);
+        indexer.ProgressChanged += (_, _) => cts.Cancel();
+
+        // Act
+        var task = Task.Run(() => indexer.BuildIndex(cts.Token));
+
+        // Assert
+        Func<Task> act = () => task;
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+
+    [Fact]
+    public async Task BuildIndex_WhenCancelled_BuildIndexCompletedStillFires()
+    {
+        // Arrange
+        using var cts = new CancellationTokenSource();
+        var elements = Enumerable.Range(0, 2000).Select(i => $"{{\"id\":{i}}}");
+        File.WriteAllText(_testFilePath, $"[{string.Join(",", elements)}]");
+        var indexer = new RowIndexer(_testFilePath);
+        var buildIndexCompletedFired = false;
+        indexer.BuildIndexCompleted += () => buildIndexCompletedFired = true;
+        indexer.ProgressChanged += (_, _) => cts.Cancel();
+
+        // Act
+        var task = Task.Run(() => indexer.BuildIndex(cts.Token));
+
+        // Assert
+        Func<Task> act = () => task;
+        await act.Should().ThrowAsync<OperationCanceledException>();
+        buildIndexCompletedFired.Should().BeTrue();
+    }
+
+    [Fact]
+    public void BuildIndex_RaisesFirstCheckpointReached_WithEmptyArray()
+    {
+        // Arrange
+        File.WriteAllText(_testFilePath, "[]");
+        var indexer = new RowIndexer(_testFilePath);
+        var firstCheckpointFired = false;
+        indexer.FirstCheckpointReached += () => firstCheckpointFired = true;
+
+        // Act
+        indexer.BuildIndex();
+
+        // Assert
+        firstCheckpointFired.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task BuildIndex_RaisesFirstCheckpointReached_WhenCancelledBeforeCheckpoint()
+    {
+        // Arrange
+        using var cts = new CancellationTokenSource();
+        var elements = Enumerable.Range(0, 10).Select(i => $"{{\"id\":{i}}}");
+        File.WriteAllText(_testFilePath, $"[{string.Join(",", elements)}]");
+        var indexer = new RowIndexer(_testFilePath);
+        var firstCheckpointFired = false;
+        indexer.FirstCheckpointReached += () => firstCheckpointFired = true;
+        cts.Cancel();
+
+        // Act
+        var task = Task.Run(() => indexer.BuildIndex(cts.Token));
+
+        // Assert
+        Func<Task> act = () => task;
+        await act.Should().ThrowAsync<OperationCanceledException>();
+        firstCheckpointFired.Should().BeTrue();
+    }
+
+    [Fact]
+    public void BuildIndex_RaisesProgressChanged_OnEachCheckpoint()
+    {
+        // Arrange
+        var elements = Enumerable.Range(0, 2500).Select(i => $"{{\"id\":{i}}}");
+        File.WriteAllText(_testFilePath, $"[{string.Join(",", elements)}]");
+        var indexer = new RowIndexer(_testFilePath);
+        var progressCount = 0;
+        indexer.ProgressChanged += (_, _) => Interlocked.Increment(ref progressCount);
+
+        // Act
+        indexer.BuildIndex();
+
+        // Assert
+        progressCount.Should().Be(2);
+    }
+
+    [Fact]
+    public void BuildIndex_RaisesBuildIndexCompleted_AfterCompletion()
+    {
+        // Arrange
+        File.WriteAllText(_testFilePath, "[{\"id\":1},{\"id\":2}]");
+        var indexer = new RowIndexer(_testFilePath);
+        var buildIndexCompletedFired = false;
+        indexer.BuildIndexCompleted += () => buildIndexCompletedFired = true;
+
+        // Act
+        indexer.BuildIndex();
+
+        // Assert
+        buildIndexCompletedFired.Should().BeTrue();
+    }
+
+    [Fact]
+    public void BuildIndex_BytesRead_IncreasesMonotonically()
+    {
+        // Arrange
+        var elements = Enumerable.Range(0, 2501).Select(i => $"{{\"id\":{i}}}");
+        File.WriteAllText(_testFilePath, $"[{string.Join(",", elements)}]");
+        var indexer = new RowIndexer(_testFilePath);
+        List<long> progressEvents = [];
+        indexer.ProgressChanged += (bytesRead, _) => progressEvents.Add(bytesRead);
+
+        // Act
+        indexer.BuildIndex();
+
+        // Assert
+        progressEvents.Should().HaveCount(2);
+        progressEvents[1].Should().BeGreaterThanOrEqualTo(progressEvents[0]);
+        indexer.BytesRead.Should().BeGreaterThan(0);
+    }
+
+    [Fact]
+    public void BuildIndex_FileSize_MatchesActualFileLength()
+    {
+        // Arrange
+        var content = "[{\"id\":1},{\"id\":2},{\"id\":3}]";
+        File.WriteAllText(_testFilePath, content);
+        var expectedFileSize = new FileInfo(_testFilePath).Length;
+        var indexer = new RowIndexer(_testFilePath);
+
+        // Act
+        indexer.BuildIndex();
+
+        // Assert
+        indexer.FileSize.Should().Be(expectedFileSize);
+    }
+}

--- a/tests/DataMorph.Tests/Engine/IO/JsonArray/RowIndexerTests.BuildIndex.cs
+++ b/tests/DataMorph.Tests/Engine/IO/JsonArray/RowIndexerTests.BuildIndex.cs
@@ -173,7 +173,8 @@ public sealed partial class RowIndexerTests
     {
         // Arrange
         using var cts = new CancellationTokenSource();
-        var elements = Enumerable.Range(0, 2000).Select(i => $"{{\"id\":{i}}}");
+        // Use enough elements to exceed 1 MB buffer to ensure multiple outer loop iterations
+        var elements = Enumerable.Range(0, 100_000).Select(i => $"{{\"id\":{i}}}");
         File.WriteAllText(_testFilePath, $"[{string.Join(",", elements)}]");
         var indexer = new RowIndexer(_testFilePath);
         indexer.ProgressChanged += (_, _) => cts.Cancel();
@@ -191,7 +192,7 @@ public sealed partial class RowIndexerTests
     {
         // Arrange
         using var cts = new CancellationTokenSource();
-        var elements = Enumerable.Range(0, 2000).Select(i => $"{{\"id\":{i}}}");
+        var elements = Enumerable.Range(0, 100_000).Select(i => $"{{\"id\":{i}}}");
         File.WriteAllText(_testFilePath, $"[{string.Join(",", elements)}]");
         var indexer = new RowIndexer(_testFilePath);
         var buildIndexCompletedFired = false;
@@ -205,6 +206,22 @@ public sealed partial class RowIndexerTests
         Func<Task> act = () => task;
         await act.Should().ThrowAsync<OperationCanceledException>();
         buildIndexCompletedFired.Should().BeTrue();
+    }
+
+    [Fact]
+    public void BuildIndex_LessThanCheckpointInterval_FiresFirstCheckpointReached()
+    {
+        // Arrange
+        File.WriteAllText(_testFilePath, "[{\"a\":1},{\"b\":2},{\"c\":3}]");
+        var indexer = new RowIndexer(_testFilePath);
+        var firstCheckpointFired = false;
+        indexer.FirstCheckpointReached += () => firstCheckpointFired = true;
+
+        // Act
+        indexer.BuildIndex();
+
+        // Assert
+        firstCheckpointFired.Should().BeTrue();
     }
 
     [Fact]

--- a/tests/DataMorph.Tests/Engine/IO/JsonArray/RowIndexerTests.GetCheckPoint.cs
+++ b/tests/DataMorph.Tests/Engine/IO/JsonArray/RowIndexerTests.GetCheckPoint.cs
@@ -110,4 +110,36 @@ public sealed partial class RowIndexerTests
         byteOffset.Should().Be(1); // clamped to checkpoint 0
         rowOffset.Should().Be(5000);
     }
+
+    [Fact]
+    public void GetCheckPoint_WithLeadingWhitespace_ReturnsCorrectByteOffset()
+    {
+        // Arrange — 2-byte leading whitespace before '['
+        File.WriteAllText(_testFilePath, "  [{\"a\":1}]");
+        var indexer = new RowIndexer(_testFilePath);
+        indexer.BuildIndex();
+
+        // Act
+        var (byteOffset, rowOffset) = indexer.GetCheckPoint(0);
+
+        // Assert — offset of '{' is 3 (2 whitespace + '[' = byte 3)
+        byteOffset.Should().Be(3);
+        rowOffset.Should().Be(0);
+    }
+
+    [Fact]
+    public void GetCheckPoint_WithNegativeTargetRow_ThrowsArgumentOutOfRangeException()
+    {
+        // Arrange
+        File.WriteAllText(_testFilePath, "[{\"id\":1},{\"id\":2},{\"id\":3}]");
+        var indexer = new RowIndexer(_testFilePath);
+        indexer.BuildIndex();
+
+        // Act
+        var act = () => indexer.GetCheckPoint(-1);
+
+        // Assert
+        act.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
 }

--- a/tests/DataMorph.Tests/Engine/IO/JsonArray/RowIndexerTests.GetCheckPoint.cs
+++ b/tests/DataMorph.Tests/Engine/IO/JsonArray/RowIndexerTests.GetCheckPoint.cs
@@ -1,0 +1,113 @@
+using AwesomeAssertions;
+using DataMorph.Engine.IO.JsonArray;
+
+namespace DataMorph.Tests.Engine.IO.JsonArray;
+
+public sealed partial class RowIndexerTests
+{
+    [Fact]
+    public void GetCheckPoint_BeforeBuildIndex_ReturnsNegativeOne()
+    {
+        // Arrange
+        File.WriteAllText(_testFilePath, "[{\"a\":1}]");
+        var indexer = new RowIndexer(_testFilePath);
+
+        // Act
+        var (byteOffset, rowOffset) = indexer.GetCheckPoint(0);
+
+        // Assert
+        byteOffset.Should().Be(-1);
+        rowOffset.Should().Be(0);
+    }
+
+    [Fact]
+    public void GetCheckPoint_Element0_ReturnsCorrectOffset()
+    {
+        // Arrange
+        File.WriteAllText(_testFilePath, "[{\"a\":1}]");
+        var indexer = new RowIndexer(_testFilePath);
+        indexer.BuildIndex();
+
+        // Act
+        var (byteOffset, rowOffset) = indexer.GetCheckPoint(0);
+
+        // Assert
+        byteOffset.Should().Be(1); // offset of '{', after '['
+        rowOffset.Should().Be(0);
+    }
+
+    [Fact]
+    public void GetCheckPoint_Element500_ReturnsCheckpoint0WithRowOffset500()
+    {
+        // Arrange
+        var elements = Enumerable.Range(0, 800).Select(i => $"{{\"id\":{i}}}");
+        File.WriteAllText(_testFilePath, $"[{string.Join(",", elements)}]");
+        var indexer = new RowIndexer(_testFilePath);
+        indexer.BuildIndex();
+
+        // Act
+        var (byteOffset, rowOffset) = indexer.GetCheckPoint(500);
+
+        // Assert
+        byteOffset.Should().Be(1); // checkpoint 0 = offset of first element
+        rowOffset.Should().Be(500);
+    }
+
+    [Fact]
+    public void GetCheckPoint_Element1000_ReturnsCheckpoint1WithZeroRowOffset()
+    {
+        // Arrange
+        var elements = Enumerable.Range(0, 1500).Select(i => $"{{\"id\":{i}}}");
+        var content = $"[{string.Join(",", elements)}]";
+        File.WriteAllText(_testFilePath, content);
+        var indexer = new RowIndexer(_testFilePath);
+        indexer.BuildIndex();
+        var marker = "{\"id\":1000}";
+        var expectedOffset = (long)content.IndexOf(marker, StringComparison.Ordinal);
+
+        // Act
+        var (byteOffset, rowOffset) = indexer.GetCheckPoint(1000);
+
+        // Assert
+        rowOffset.Should().Be(0);
+        byteOffset.Should().Be(expectedOffset);
+    }
+
+    [Fact]
+    public async Task GetCheckPoint_WhileIndexingInBackground_IsThreadSafe()
+    {
+        // Arrange
+        var elements = Enumerable.Range(0, 2500).Select(i => $"{{\"id\":{i}}}");
+        File.WriteAllText(_testFilePath, $"[{string.Join(",", elements)}]");
+        var indexer = new RowIndexer(_testFilePath);
+        var overlap = false;
+        indexer.FirstCheckpointReached += () =>
+        {
+            _ = indexer.GetCheckPoint(0);
+            overlap = true;
+        };
+
+        // Act: start indexing in background and call GetCheckPoint from the event callback
+        var buildTask = Task.Run(() => indexer.BuildIndex());
+
+        // Assert: no exception thrown during concurrent access
+        await buildTask;
+        overlap.Should().BeTrue();
+    }
+
+    [Fact]
+    public void GetCheckPoint_BeyondTotalRows_ClampsToLastCheckpoint()
+    {
+        // Arrange
+        File.WriteAllText(_testFilePath, "[{\"id\":1},{\"id\":2},{\"id\":3}]");
+        var indexer = new RowIndexer(_testFilePath);
+        indexer.BuildIndex();
+
+        // Act — targetRow 5000 / 1000 = idealIndex 5, but only 1 checkpoint exists → clamped to 0
+        var (byteOffset, rowOffset) = indexer.GetCheckPoint(5000);
+
+        // Assert
+        byteOffset.Should().Be(1); // clamped to checkpoint 0
+        rowOffset.Should().Be(5000);
+    }
+}

--- a/tests/DataMorph.Tests/Engine/IO/JsonArray/RowIndexerTests.cs
+++ b/tests/DataMorph.Tests/Engine/IO/JsonArray/RowIndexerTests.cs
@@ -1,0 +1,76 @@
+using AwesomeAssertions;
+using DataMorph.Engine.IO.JsonArray;
+
+namespace DataMorph.Tests.Engine.IO.JsonArray;
+
+public sealed partial class RowIndexerTests : IDisposable
+{
+    private readonly string _testFilePath;
+
+    public RowIndexerTests()
+    {
+        _testFilePath = Path.Combine(
+            Path.GetTempPath(),
+            $"jsonarrayRowIndexer_{Guid.NewGuid()}.json"
+        );
+    }
+
+    public void Dispose()
+    {
+        if (File.Exists(_testFilePath))
+        {
+            File.Delete(_testFilePath);
+        }
+    }
+
+    [Fact]
+    public void Constructor_WithNullFilePath_ThrowsArgumentException()
+    {
+        // Arrange — no setup required
+
+        // Act
+        var act = () => new RowIndexer(null!);
+
+        // Assert
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void Constructor_WithWhiteSpaceFilePath_ThrowsArgumentException()
+    {
+        // Arrange — no setup required
+
+        // Act
+        var act = () => new RowIndexer("   ");
+
+        // Assert
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void Constructor_WithValidFilePath_SetsFilePathProperty()
+    {
+        // Arrange
+        var expectedPath = "/path/to/file.json";
+
+        // Act
+        var indexer = new RowIndexer(expectedPath);
+
+        // Assert
+        indexer.FilePath.Should().Be(expectedPath);
+    }
+
+    [Fact]
+    public void TotalRows_BeforeBuildIndex_ReturnsZero()
+    {
+        // Arrange
+        File.WriteAllText(_testFilePath, "[]");
+        var indexer = new RowIndexer(_testFilePath);
+
+        // Act
+        var totalRows = indexer.TotalRows;
+
+        // Assert
+        totalRows.Should().Be(0);
+    }
+}


### PR DESCRIPTION
## Summary

- Implement `BuildIndex` in `JsonArray.RowIndexer` to scan a JSON array file and record byte offsets at every 1,000-element boundary.
- Implement `GetCheckPoint` to return the nearest indexed byte offset for a given target row, enabling efficient seek-based access.
- Register `JsonArray.RowIndexer` in `RowIndexerFactory` so it is wired into the existing pipeline.
- Add comprehensive unit tests covering edge cases: empty files, single-element arrays, negative target rows, large arrays, leading whitespace, and first-checkpoint boundary conditions.
- Add benchmarks in `RowIndexerBenchmarks`.

## Test plan

- [ ] All existing tests pass (`dotnet test`)
- [ ] `BuildIndex` tests: empty file, single element, multiple elements, elements ≥ 1000, leading whitespace with valid byte offset
- [ ] `GetCheckPoint` tests: negative target row (clamp via `Math.Clamp`), exact boundary, beyond last checkpoint, first checkpoint reached
- [ ] Zero build warnings (`dotnet build`)

Closes #61