### PR TITLE
feat: implement JSON Object top-level key scanner

### DIFF
--- a/docs/design_json_object_top_level_scanner.md
+++ b/docs/design_json_object_top_level_scanner.md
@@ -1,0 +1,305 @@
+# JSON Object Top-Level Key Scanner — Design Document
+
+## Scope
+
+Implement `TopLevelScanner`, the Engine-layer class that scans all top-level keys and their
+raw byte values from a JSON Object file
+(`{"key1": ..., "key2": ..., ...}`).
+
+The App-layer integration (tree view, file dialog wiring) is out of scope and will be
+addressed in the follow-up issue (Explorer Mode).
+
+---
+
+## 1. Requirements
+
+### Functional Requirements
+
+- Scan all top-level keys and their values from a JSON Object file
+- Return results as `IReadOnlyList<(string key, ReadOnlyMemory<byte> value)>` preserving
+  insertion order
+- Correctly handle nested objects/arrays as values without parsing deep structures
+- Duplicate keys: last value wins (consistent with `JSON.parse`); key order reflects first occurrence
+
+### Non-Functional Requirements
+
+- **One-shot**: scan once at call time; no persistent random-access indexer required
+- **Streaming**: `RandomAccess.Read` + `Utf8JsonReader`; file is never fully loaded into memory
+- **AOT-compatible**: `Utf8JsonReader` is AOT-safe; no reflection
+- **Adaptive buffer**: starts at 1 MB, doubles on demand up to 16 MB; throws
+  `NotSupportedException` beyond that
+
+---
+
+## 2. Why `IRowIndexer` is Not Needed
+
+| Aspect | JSON Lines / JSON Array | JSON Object |
+|--------|------------------------|-------------|
+| Access pattern | Random access for scroll / lazy load | Sequential scan once at file open |
+| Persistent resource | `IRowIndexer` kept alive for the session | Scanner is discarded after scan |
+| Key count | Millions of rows | Tens to hundreds of top-level keys |
+| Interface fit | `GetCheckPoint(long targetRow)` — row-based | No row concept; key-based, one-time |
+
+JSON Object top-level keys are the primary navigation structure. After the scan, all
+top-level values are held in memory by the caller; further access is in-memory only.
+
+### Value Memory Strategy
+
+All top-level values are copied into `byte[]` during the scan. The caller's child nodes can
+use `ReadOnlyMemory<byte>.Slice` into the parent's buffer, so no additional allocations occur
+when expanding nested structures.
+
+The alternative of storing `(fileOffset, length)` and loading lazily was rejected: JSON
+Object files have few top-level keys (not millions), so the memory savings are negligible
+while the design complexity (new lazy-loading node types) is significant.
+
+---
+
+## 3. Design
+
+### 3.1 Class: `JsonObject.TopLevelScanner`
+
+```csharp
+namespace DataMorph.Engine.IO.JsonObject;
+
+internal sealed class TopLevelScanner
+{
+    private const int InitialBufferSize = 1024 * 1024;      // 1 MB
+    private const int MaxBufferSize     = 16 * 1024 * 1024; // 16 MB
+
+    internal static IReadOnlyList<(string key, ReadOnlyMemory<byte> value)> Scan(
+        string filePath,
+        CancellationToken ct = default);
+}
+```
+
+- Uses `RandomAccess.Read` + `Utf8JsonReader` with `JsonReaderState` carried across chunks
+  (same rolling-buffer pattern as `JsonArray.RowIndexer`)
+- Reads tokens until depth-1 `PropertyName` to capture a key
+- Reads the following value token(s) and copies their bytes into a `byte[]`
+- Returns when the root `EndObject` token is consumed
+
+### 3.2 Scanning Algorithm
+
+```
+fileSize = new FileInfo(filePath).Length
+buffer = ArrayPool.Rent(InitialBufferSize)
+try:
+  using handle = File.OpenHandle(filePath, Open, Read, Read)
+  state = default(JsonReaderState)
+  bufferOriginFileOffset = 0L
+  fileReadOffset = 0L
+  remainingLen = 0
+  result = new List<(string, ReadOnlyMemory<byte>)>()
+  keyIndex = new Dictionary<string, int>()   // key → index in result (for last-wins dedup)
+  currentKey = null
+  valueStart = -1L
+
+loop:
+  ct.ThrowIfCancellationRequested()
+
+  // Detect stuck: buffer is full and nothing was consumed last pass
+  if remainingLen == buffer.Length:
+    if buffer.Length >= MaxBufferSize:
+      throw NotSupportedException("JSON string value exceeds maximum supported size (16 MB).")
+    buffer = GrowBuffer(buffer)   // double size; copy remaining bytes; return old buffer to pool
+
+  bytesRead = RandomAccess.Read(handle, buffer[remainingLen..], fileReadOffset)
+  if bytesRead == 0: break
+  fileReadOffset += bytesRead
+  dataEnd = remainingLen + bytesRead
+  isFinalBlock = (fileReadOffset >= fileSize)
+
+  reader = new Utf8JsonReader(buffer[0..dataEnd], isFinalBlock, state)
+
+  innerLoop:
+    if not reader.Read(): break innerLoop
+
+    depth = reader.CurrentDepth
+
+    if depth == 0 && reader.TokenType == EndObject: goto done  // root object closed
+    if depth != 1: continue innerLoop                          // skip nested tokens
+
+    // depth 1: PropertyName or value tokens
+
+    if reader.TokenType == PropertyName:
+      currentKey = reader.GetString()
+      valueStart = -1L
+      continue innerLoop
+
+    // Value token for currentKey
+    if currentKey is null: continue innerLoop   // malformed JSON; skip
+
+    if reader.TokenType in {StartObject, StartArray}:
+      if valueStart < 0:
+        valueStart = bufferOriginFileOffset + reader.TokenStartIndex
+      continue innerLoop   // wait for matching End* to return to depth 1
+
+    if reader.TokenType in {EndObject, EndArray}:
+      // reader.BytesConsumed is the position immediately after the closing `}`/`]`
+      valueEnd = bufferOriginFileOffset + (long)reader.BytesConsumed
+      RecordEntry(currentKey, buffer, valueStart, valueEnd)
+      currentKey = null
+      valueStart = -1L
+      continue innerLoop
+
+    // Primitive value at depth 1 (String, Number, True, False, Null)
+    // TopLevelScanner always constructs Utf8JsonReader from ReadOnlySpan<byte>,
+    // so HasValueSequence is always false — use ValueSpan exclusively.
+    primitiveStart = bufferOriginFileOffset + reader.TokenStartIndex
+    primitiveEnd   = bufferOriginFileOffset + (long)reader.BytesConsumed
+    RecordEntry(currentKey, buffer, primitiveStart, primitiveEnd)
+    currentKey = null
+    valueStart = -1L
+
+  state = reader.CurrentState
+
+  // Do not advance bufferOriginFileOffset past valueStart when tracking a value
+  // that spans multiple buffer fills — the opening bytes must remain in the buffer.
+  safeConsumed = valueStart >= 0
+    ? (int)Math.Min(reader.BytesConsumed, valueStart - bufferOriginFileOffset)
+    : (int)reader.BytesConsumed
+
+  bufferOriginFileOffset += safeConsumed
+  remainingLen = dataEnd - safeConsumed
+  Buffer.BlockCopy(buffer, safeConsumed, buffer, 0, remainingLen)
+
+done:
+  return result.AsReadOnly()
+
+finally:
+  ArrayPool.Return(buffer)
+
+RecordEntry(key, buffer, start, end):
+  length = (int)(end - start)
+  copy = new byte[length]
+  Buffer.BlockCopy(buffer, (int)(start - bufferOriginFileOffset), copy, 0, length)
+  mem = new ReadOnlyMemory<byte>(copy)
+  if keyIndex.TryGetValue(key, out idx):
+    result[idx] = (key, mem)   // last-wins: overwrite value, preserve first-occurrence order
+  else:
+    keyIndex[key] = result.Count
+    result.Add((key, mem))
+```
+
+### 3.3 Buffer Growth
+
+| Condition | Action |
+|-----------|--------|
+| `remainingLen < buffer.Length` | Normal: refill spare space |
+| `remainingLen == buffer.Length && buffer.Length < MaxBufferSize` | Double buffer size |
+| `remainingLen == buffer.Length && buffer.Length == MaxBufferSize` | `NotSupportedException` |
+
+16 MB accommodates approximately 5.5 million UTF-8 characters — more than 30 novels in
+Japanese — which is sufficient for all practical single-value strings.
+
+---
+
+## 4. Edge Cases
+
+| Case | Handling |
+|------|----------|
+| Empty object `{}` | Returns empty list |
+| Object with a single key | Normal flow; one entry in result |
+| Nested objects / arrays as values | Depth tracking captures full byte range; tokens read one by one until depth returns to 1 |
+| Value spans buffer boundary | `Read()` returns `false`; `JsonReaderState` + `valueStart` persist; `safeConsumed` keeps value bytes in buffer; buffer grows as needed |
+| String value > 16 MB | `NotSupportedException` thrown |
+| Duplicate keys | Last value wins (consistent with `JSON.parse`); key order reflects first occurrence; implemented via `Dictionary<string, int>` index map |
+| Cancellation | `OperationCanceledException` propagates; `ArrayPool.Return` in `finally` |
+| Root token is not `{` (e.g., `[…]`, `42`) | All depth-1 tokens skipped (`currentKey` is always `null`); returns empty list without throwing |
+
+---
+
+## 5. Files to Create / Modify
+
+| File | Action | Purpose |
+|------|--------|---------|
+| `src/Engine/IO/JsonObject/TopLevelScanner.cs` | Create | Streaming scanner; returns key-value list |
+| `tests/DataMorph.Tests/Engine/IO/JsonObject/TopLevelScannerTests.cs` | Create | Unit tests (shared fixtures) |
+| `tests/DataMorph.Tests/Engine/IO/JsonObject/TopLevelScannerTests.Scan.cs` | Create | `Scan` correctness tests |
+| `tests/DataMorph.Tests/Engine/IO/JsonObject/TopLevelScannerBenchmarks.cs` | Create | BenchmarkDotNet perf tests |
+
+---
+
+## 6. Testing Strategy
+
+### 6.1 Unit Tests (`TopLevelScanner.Scan`)
+
+| Test | Input | Expected |
+|------|-------|----------|
+| Empty object | `{}` | Empty list returned |
+| Single primitive string | `{"k":"v"}` | `[("k", bytes of `"v"`)]` |
+| Single primitive number | `{"n":42}` | `[("n", bytes of `42`)]` |
+| Single nested object | `{"o":{"a":1}}` | `[("o", bytes of `{"a":1}`)]` |
+| Single nested array | `{"a":[1,2]}` | `[("a", bytes of `[1,2]`)]` |
+| Multiple keys — order preserved | `{"b":2,"a":1}` | `[("b",…),("a",…)]` in that order |
+| Duplicate keys — last wins | `{"k":1,"k":2}` | `[("k", bytes of `2`)]` — last value; key order from first occurrence |
+| Duplicate keys — triple occurrence | `{"k":1,"k":2,"k":3}` | `[("k", bytes of `3`)]` |
+| Duplicate key — position stable with other keys | `{"a":1,"k":1,"b":2,"k":2}` | `[("a",…),("k", bytes of `2`),("b",…)]` — `k` stays at index 1 |
+| Deeply nested value | `{"x":{"y":{"z":1}}}` | Correct byte range captured |
+| Value spans buffer boundary | Object with value tokens crossing 1 MB boundary | Correct bytes captured; no exception |
+| String value > 16 MB | Single string value exceeding MaxBufferSize | `NotSupportedException` thrown |
+| Boolean true value | `{"k":true}` | `[("k", bytes of `true`)]` |
+| Boolean false value | `{"k":false}` | `[("k", bytes of `false`)]` |
+| Null value | `{"k":null}` | `[("k", bytes of `null`)]` |
+| Cancellation | Any object | `OperationCanceledException` thrown; pool buffer returned |
+| Leading/trailing whitespace | `  { "k" : 1 }  ` | Same result as compact form |
+
+### 6.2 Benchmarks
+
+```csharp
+[MemoryDiagnoser]
+class TopLevelScannerBenchmarks
+```
+
+| Benchmark | Description |
+|-----------|-------------|
+| `Scan_10Keys_SmallValues` | 10 keys with small primitive values |
+| `Scan_100Keys_SmallValues` | 100 keys with small primitive values |
+| `Scan_100Keys_LargeNestedValues` | 100 keys each holding a ~10 KB nested object |
+
+Target: minimal heap allocations beyond the result `byte[]` copies.
+
+---
+
+## 7. Decision Record
+
+### Why No `IRowIndexer`
+
+`IRowIndexer` provides `GetCheckPoint(long targetRow)` for checkpoint-based random access used
+by `SlidingWindowLruCache`. JSON Object files have no row concept and are opened once: after
+the scan, all top-level values are in memory. A persistent indexer would add complexity with
+no benefit.
+
+### Why `IReadOnlyList` Over `IReadOnlyDictionary`
+
+`IReadOnlyDictionary` was considered but rejected because it does not guarantee key insertion
+order — display order would diverge from file order. `IReadOnlyList<(string key,
+ReadOnlyMemory<byte> value)>` preserves first-occurrence order while the last-wins dedup
+logic is handled internally by `keyIndex`.
+
+### Why Eager Copy Over Lazy `(offset, length)`
+
+Storing `(fileOffset, length)` and reading lazily on node expansion was considered but rejected:
+- JSON Object files have few top-level keys; the memory savings are negligible
+- Child-level expansion uses `ReadOnlyMemory<byte>.Slice` into already-copied bytes — no
+  additional allocations
+
+### Why Last-Wins for Duplicate Keys
+
+RFC 8259 says keys within an object "SHOULD be unique" but does not forbid duplicates.
+Last-wins (consistent with `JSON.parse`) was chosen because:
+- Future table mode requires unique keys to identify actions unambiguously
+- Preserving all duplicates would require callers to handle disambiguation
+- Real-world JSON files with duplicate keys are vanishingly rare
+
+Key order reflects first occurrence so that display order is stable and predictable.
+Full duplicate-key support can be added later if a concrete use case arises.
+
+### Why No `yield return` / Streaming
+
+A streaming `IEnumerable<T>` approach was considered but rejected:
+- Allocations (`string` keys, `byte[]` values) are identical regardless of enumeration style
+- File open is a one-time, non-hot-path operation
+- `Scan()` is a synchronous method; lazy enumeration would still complete the full scan
+  before returning anything useful

--- a/src/Engine/IO/JsonObject/BufferState.cs
+++ b/src/Engine/IO/JsonObject/BufferState.cs
@@ -1,0 +1,32 @@
+namespace DataMorph.Engine.IO.JsonObject;
+
+internal ref struct BufferState(long fileSize)
+{
+    private readonly long _fileSize = fileSize;
+
+    private long _readHead;
+    private int _remainingLen;
+
+    public int RemainingLen => _remainingLen;
+    public long ReadHead => _readHead;
+    public long BufferOffset => _readHead - _remainingLen;
+    public bool IsFinalBlock => _readHead >= _fileSize;
+
+    public void RecordBytesRead(int bytesRead)
+    {
+        _readHead += bytesRead;
+        _remainingLen += bytesRead;
+    }
+
+    public void ShiftConsumed(int safeConsumed, byte[] buffer)
+    {
+        _remainingLen -= safeConsumed;
+        Buffer.BlockCopy(
+            src: buffer,
+            srcOffset: safeConsumed,
+            dst: buffer,
+            dstOffset: 0,
+            count: _remainingLen
+        );
+    }
+}

--- a/src/Engine/IO/JsonObject/EntryState.cs
+++ b/src/Engine/IO/JsonObject/EntryState.cs
@@ -1,0 +1,28 @@
+namespace DataMorph.Engine.IO.JsonObject;
+
+internal ref struct EntryState()
+{
+    private string _currentKey = string.Empty;
+    private long _valueStart = -1L;
+
+    public string CurrentKey => _currentKey;
+    public long ValueStart => _valueStart;
+    public bool IsNested => _valueStart >= 0;
+
+    public void StartEntry(string key)
+    {
+        _currentKey = key;
+        _valueStart = -1L;
+    }
+
+    public void ClearEntry()
+    {
+        _currentKey = string.Empty;
+        _valueStart = -1L;
+    }
+
+    public void RecordValueStart(long newValueStart)
+    {
+        _valueStart = newValueStart;
+    }
+}

--- a/src/Engine/IO/JsonObject/JsonScanState.cs
+++ b/src/Engine/IO/JsonObject/JsonScanState.cs
@@ -1,0 +1,12 @@
+using System.Text.Json;
+
+namespace DataMorph.Engine.IO.JsonObject;
+
+internal ref struct JsonScanState(long fileSize)
+{
+    public EntryState Entry = new();
+    public BufferState Buffer = new(fileSize);
+    public JsonReaderState Checkpoint = new();
+    public JsonReaderState RollbackCheckpoint = new();
+    public JsonReaderState PrevCheckpoint = new();
+}

--- a/src/Engine/IO/JsonObject/TopLevelScanner.cs
+++ b/src/Engine/IO/JsonObject/TopLevelScanner.cs
@@ -1,16 +1,241 @@
+using System.Buffers;
+using System.Diagnostics;
+using System.Text.Json;
+
 namespace DataMorph.Engine.IO.JsonObject;
 
 internal sealed class TopLevelScanner
 {
-#pragma warning disable CA1823
-    private const int InitialBufferSize = 1024 * 1024;      // 1 MB
+    private const int InitialBufferSize = 1024 * 1024; // 1 MB
     private const int MaxBufferSize = 16 * 1024 * 1024; // 16 MB
-#pragma warning restore CA1823
 
     internal static IReadOnlyList<(string key, ReadOnlyMemory<byte> value)> Scan(
         string filePath,
-        CancellationToken ct = default)
+        CancellationToken ct = default
+    )
     {
-        throw new NotImplementedException();
+        ArgumentException.ThrowIfNullOrWhiteSpace(filePath);
+
+        var buffer = ArrayPool<byte>.Shared.Rent(InitialBufferSize);
+
+        try
+        {
+            using var handle = File.OpenHandle(
+                filePath,
+                FileMode.Open,
+                FileAccess.Read,
+                FileShare.Read
+            );
+            var fileSize = RandomAccess.GetLength(handle);
+            var state = new JsonScanState(fileSize);
+            var rootCompleted = false;
+            List<(string key, ReadOnlyMemory<byte> value)> result = [];
+            var keyIndex = new Dictionary<string, int>();
+
+            while (true)
+            {
+                ct.ThrowIfCancellationRequested();
+
+                EnsureBufferCapacity(ref buffer, state.Buffer.RemainingLen);
+
+                var bytesRead = RandomAccess.Read(
+                    handle,
+                    buffer.AsSpan(
+                        state.Buffer.RemainingLen,
+                        buffer.Length - state.Buffer.RemainingLen
+                    ),
+                    state.Buffer.ReadHead
+                );
+
+                if (bytesRead == 0)
+                {
+                    break;
+                }
+
+                state.Buffer.RecordBytesRead(bytesRead);
+
+                var reader = new Utf8JsonReader(
+                    buffer.AsSpan(0, state.Buffer.RemainingLen),
+                    state.Buffer.IsFinalBlock,
+                    state.Checkpoint
+                );
+
+                state.PrevCheckpoint = state.Checkpoint;
+
+                while (reader.Read() && !rootCompleted)
+                {
+                    rootCompleted = ProcessToken(ref reader, ref state, buffer, result, keyIndex);
+                    state.PrevCheckpoint = reader.CurrentState;
+                }
+
+                if (rootCompleted)
+                {
+                    break;
+                }
+
+                ct.ThrowIfCancellationRequested();
+
+                // When tracking a nested value, rewind the reader state to the point just before
+                // the opening token so the next iteration re-parses from that token with correct
+                // depth context. Otherwise, use the state at the end of this iteration.
+                state.Checkpoint = state.Entry.IsNested
+                    ? state.RollbackCheckpoint
+                    : reader.CurrentState;
+
+                var safeConsumed = state.Entry.IsNested
+                    ? (int)(state.Entry.ValueStart - state.Buffer.BufferOffset)
+                    : (int)reader.BytesConsumed;
+                state.Buffer.ShiftConsumed(safeConsumed, buffer);
+            }
+
+            return result.AsReadOnly();
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(buffer);
+        }
+    }
+
+    private static bool ProcessToken(
+        ref Utf8JsonReader reader,
+        ref JsonScanState state,
+        byte[] buffer,
+        List<(string key, ReadOnlyMemory<byte> value)> result,
+        Dictionary<string, int> keyIndex
+    )
+    {
+        var depth = reader.CurrentDepth;
+
+        if (depth == 0 && reader.TokenType == JsonTokenType.EndObject)
+        {
+            return true;
+        }
+
+        if (depth != 1)
+        {
+            return false;
+        }
+
+        if (reader.TokenType == JsonTokenType.PropertyName)
+        {
+            var key =
+                reader.GetString()
+                ?? throw new UnreachableException(
+                    "PropertyName token returned a null key; this is unreachable for well-formed JSON."
+                );
+            state.Entry.StartEntry(key);
+            return false;
+        }
+
+        // Defensive check: unreachable with well-formed JSON.
+        if (state.Entry.CurrentKey.Length == 0)
+        {
+            return false;
+        }
+
+        if (reader.TokenType is JsonTokenType.StartObject or JsonTokenType.StartArray)
+        {
+            state.Entry.RecordValueStart(
+                newValueStart: state.Buffer.BufferOffset + (long)reader.TokenStartIndex
+            );
+            state.RollbackCheckpoint = state.PrevCheckpoint;
+            return false;
+        }
+
+        if (reader.TokenType is JsonTokenType.EndObject or JsonTokenType.EndArray)
+        {
+            var valueBufferOffset = (int)(state.Entry.ValueStart - state.Buffer.BufferOffset);
+            RecordEntry(
+                key: state.Entry.CurrentKey,
+                buffer: buffer,
+                bufferOffset: valueBufferOffset,
+                length: (int)(reader.BytesConsumed - valueBufferOffset),
+                result: result,
+                keyIndex: keyIndex
+            );
+            state.Entry.ClearEntry();
+            return false;
+        }
+
+        RecordEntry(
+            key: state.Entry.CurrentKey,
+            buffer: buffer,
+            bufferOffset: (int)reader.TokenStartIndex,
+            length: (int)(reader.BytesConsumed - (long)reader.TokenStartIndex),
+            result: result,
+            keyIndex: keyIndex
+        );
+        state.Entry.ClearEntry();
+        return false;
+    }
+
+    private static void RecordEntry(
+        string key,
+        byte[] buffer,
+        int bufferOffset,
+        int length,
+        List<(string key, ReadOnlyMemory<byte> value)> result,
+        Dictionary<string, int> keyIndex
+    )
+    {
+        var copy = new byte[length];
+        Buffer.BlockCopy(
+            src: buffer,
+            srcOffset: bufferOffset,
+            dst: copy,
+            dstOffset: 0,
+            count: length
+        );
+        var mem = new ReadOnlyMemory<byte>(copy);
+
+        if (keyIndex.TryGetValue(key, out var idx))
+        {
+            result[idx] = (key, mem);
+            return;
+        }
+
+        keyIndex[key] = result.Count;
+        result.Add((key, mem));
+    }
+
+    private static void EnsureBufferCapacity(ref byte[] buffer, int remainingLen)
+    {
+        if (remainingLen < buffer.Length)
+        {
+            return;
+        }
+
+        if (buffer.Length >= MaxBufferSize)
+        {
+            throw new NotSupportedException(
+                "A single top-level value exceeds the maximum supported size (16 MB)."
+            );
+        }
+
+        GrowBuffer(ref buffer, remainingLen);
+    }
+
+    private static void GrowBuffer(ref byte[] buffer, int remainingLen)
+    {
+        var newBuffer = ArrayPool<byte>.Shared.Rent(buffer.Length * 2);
+        try
+        {
+            Buffer.BlockCopy(
+                src: buffer,
+                srcOffset: 0,
+                dst: newBuffer,
+                dstOffset: 0,
+                count: remainingLen
+            );
+        }
+        catch
+        {
+            ArrayPool<byte>.Shared.Return(newBuffer);
+            throw;
+        }
+
+        var oldBuffer = buffer;
+        buffer = newBuffer;
+        ArrayPool<byte>.Shared.Return(oldBuffer);
     }
 }

--- a/src/Engine/IO/JsonObject/TopLevelScanner.cs
+++ b/src/Engine/IO/JsonObject/TopLevelScanner.cs
@@ -1,0 +1,16 @@
+namespace DataMorph.Engine.IO.JsonObject;
+
+internal sealed class TopLevelScanner
+{
+#pragma warning disable CA1823
+    private const int InitialBufferSize = 1024 * 1024;      // 1 MB
+    private const int MaxBufferSize = 16 * 1024 * 1024; // 16 MB
+#pragma warning restore CA1823
+
+    internal static IReadOnlyList<(string key, ReadOnlyMemory<byte> value)> Scan(
+        string filePath,
+        CancellationToken ct = default)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/tests/DataMorph.Tests/Engine/IO/JsonObject/TopLevelScannerBenchmarks.cs
+++ b/tests/DataMorph.Tests/Engine/IO/JsonObject/TopLevelScannerBenchmarks.cs
@@ -1,0 +1,98 @@
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Jobs;
+
+namespace DataMorph.Tests.Engine.IO.JsonObject;
+
+[SimpleJob(RuntimeMoniker.NativeAot80)]
+[MemoryDiagnoser]
+public sealed class TopLevelScannerBenchmarks
+{
+    private const int KeyCount10 = 10;
+    private const int KeyCount100 = 100;
+
+    private string? _tempFilePath10Keys;
+    private string? _tempFilePath100KeysSmall;
+    private string? _tempFilePath100KeysLarge;
+
+    [GlobalSetup]
+    public void GlobalSetup()
+    {
+        var id = Guid.NewGuid();
+        _tempFilePath10Keys = Path.Combine(
+            Path.GetTempPath(),
+            $"jsonobject_bench_10_{id}.json"
+        );
+        _tempFilePath100KeysSmall = Path.Combine(
+            Path.GetTempPath(),
+            $"jsonobject_bench_100small_{id}.json"
+        );
+        _tempFilePath100KeysLarge = Path.Combine(
+            Path.GetTempPath(),
+            $"jsonobject_bench_100large_{id}.json"
+        );
+
+        WriteKeyValues(_tempFilePath10Keys, KeyCount10, static i => $"{i}");
+        WriteKeyValues(_tempFilePath100KeysSmall, KeyCount100, static i => $"{i}");
+        WriteKeyValues(_tempFilePath100KeysLarge, KeyCount100, static i => GenerateNestedObject(i));
+    }
+
+    [GlobalCleanup]
+    public void GlobalCleanup()
+    {
+        if (_tempFilePath10Keys is not null)
+        {
+            File.Delete(_tempFilePath10Keys);
+        }
+
+        if (_tempFilePath100KeysSmall is not null)
+        {
+            File.Delete(_tempFilePath100KeysSmall);
+        }
+
+        if (_tempFilePath100KeysLarge is not null)
+        {
+            File.Delete(_tempFilePath100KeysLarge);
+        }
+    }
+
+    [Benchmark]
+    public void Scan_10Keys_SmallValues()
+    {
+        throw new NotImplementedException();
+    }
+
+    [Benchmark]
+    public void Scan_100Keys_SmallValues()
+    {
+        throw new NotImplementedException();
+    }
+
+    [Benchmark]
+    public void Scan_100Keys_LargeNestedValues()
+    {
+        throw new NotImplementedException();
+    }
+
+    private static void WriteKeyValues(string path, int count, Func<int, string> valueFactory)
+    {
+        using var writer = new StreamWriter(path);
+        writer.Write('{');
+        for (var i = 0; i < count; i++)
+        {
+            if (i > 0)
+            {
+                writer.Write(',');
+            }
+
+            writer.Write($"\"key{i}\":{valueFactory(i)}");
+        }
+
+        writer.Write('}');
+    }
+
+    private static string GenerateNestedObject(int seed)
+    {
+        var fields = string.Join(",", Enumerable.Range(0, 1000).Select(j => $"\"f{j}\":{seed + j}"));
+        return $"{{{fields}}}";
+    }
+}

--- a/tests/DataMorph.Tests/Engine/IO/JsonObject/TopLevelScannerBenchmarks.cs
+++ b/tests/DataMorph.Tests/Engine/IO/JsonObject/TopLevelScannerBenchmarks.cs
@@ -1,5 +1,6 @@
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Jobs;
+using DataMorph.Engine.IO.JsonObject;
 
 namespace DataMorph.Tests.Engine.IO.JsonObject;
 
@@ -10,9 +11,9 @@ public sealed class TopLevelScannerBenchmarks
     private const int KeyCount10 = 10;
     private const int KeyCount100 = 100;
 
-    private string? _tempFilePath10Keys;
-    private string? _tempFilePath100KeysSmall;
-    private string? _tempFilePath100KeysLarge;
+    private string _tempFilePath10Keys = string.Empty;
+    private string _tempFilePath100KeysSmall = string.Empty;
+    private string _tempFilePath100KeysLarge = string.Empty;
 
     [GlobalSetup]
     public void GlobalSetup()
@@ -39,17 +40,17 @@ public sealed class TopLevelScannerBenchmarks
     [GlobalCleanup]
     public void GlobalCleanup()
     {
-        if (_tempFilePath10Keys is not null)
+        if (_tempFilePath10Keys.Length > 0)
         {
             File.Delete(_tempFilePath10Keys);
         }
 
-        if (_tempFilePath100KeysSmall is not null)
+        if (_tempFilePath100KeysSmall.Length > 0)
         {
             File.Delete(_tempFilePath100KeysSmall);
         }
 
-        if (_tempFilePath100KeysLarge is not null)
+        if (_tempFilePath100KeysLarge.Length > 0)
         {
             File.Delete(_tempFilePath100KeysLarge);
         }
@@ -58,19 +59,19 @@ public sealed class TopLevelScannerBenchmarks
     [Benchmark]
     public void Scan_10Keys_SmallValues()
     {
-        throw new NotImplementedException();
+        TopLevelScanner.Scan(_tempFilePath10Keys);
     }
 
     [Benchmark]
     public void Scan_100Keys_SmallValues()
     {
-        throw new NotImplementedException();
+        TopLevelScanner.Scan(_tempFilePath100KeysSmall);
     }
 
     [Benchmark]
     public void Scan_100Keys_LargeNestedValues()
     {
-        throw new NotImplementedException();
+        TopLevelScanner.Scan(_tempFilePath100KeysLarge);
     }
 
     private static void WriteKeyValues(string path, int count, Func<int, string> valueFactory)

--- a/tests/DataMorph.Tests/Engine/IO/JsonObject/TopLevelScannerTests.Scan.cs
+++ b/tests/DataMorph.Tests/Engine/IO/JsonObject/TopLevelScannerTests.Scan.cs
@@ -1,7 +1,13 @@
+using System.Text;
+using AwesomeAssertions;
+using DataMorph.Engine.IO.JsonObject;
+
 namespace DataMorph.Tests.Engine.IO.JsonObject;
 
 public sealed partial class TopLevelScannerTests
 {
+    private static ReadOnlyMemory<byte> Utf8(string s) => Encoding.UTF8.GetBytes(s);
+
     [Fact]
     public void Scan_WithEmptyObject_ReturnsEmptyList()
     {
@@ -9,8 +15,36 @@ public sealed partial class TopLevelScannerTests
         File.WriteAllText(_testFilePath, "{}");
 
         // Act
+        var result = TopLevelScanner.Scan(_testFilePath);
 
         // Assert
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Scan_WithEmptyFile_ReturnsEmptyList()
+    {
+        // Arrange
+        File.WriteAllText(_testFilePath, string.Empty);
+
+        // Act
+        var result = TopLevelScanner.Scan(_testFilePath);
+
+        // Assert
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Scan_WithNonExistentFilePath_ThrowsFileNotFoundException()
+    {
+        // Arrange
+        var nonExistentPath = Path.Combine(Path.GetTempPath(), $"does_not_exist_{Guid.NewGuid()}.json");
+
+        // Act
+        var act = () => TopLevelScanner.Scan(nonExistentPath);
+
+        // Assert
+        act.Should().Throw<FileNotFoundException>();
     }
 
     [Fact]
@@ -20,8 +54,12 @@ public sealed partial class TopLevelScannerTests
         File.WriteAllText(_testFilePath, "{\"k\":\"v\"}");
 
         // Act
+        var result = TopLevelScanner.Scan(_testFilePath);
 
         // Assert
+        result.Should().HaveCount(1);
+        result[0].key.Should().Be("k");
+        result[0].value.ToArray().Should().BeEquivalentTo(Utf8("\"v\"").ToArray());
     }
 
     [Fact]
@@ -31,8 +69,57 @@ public sealed partial class TopLevelScannerTests
         File.WriteAllText(_testFilePath, "{\"n\":42}");
 
         // Act
+        var result = TopLevelScanner.Scan(_testFilePath);
 
         // Assert
+        result.Should().HaveCount(1);
+        result[0].key.Should().Be("n");
+        result[0].value.ToArray().Should().BeEquivalentTo(Utf8("42").ToArray());
+    }
+
+    [Fact]
+    public void Scan_WithNegativeNumber_ReturnsCorrectBytes()
+    {
+        // Arrange
+        File.WriteAllText(_testFilePath, "{\"n\":-42}");
+
+        // Act
+        var result = TopLevelScanner.Scan(_testFilePath);
+
+        // Assert
+        result.Should().HaveCount(1);
+        result[0].key.Should().Be("n");
+        result[0].value.ToArray().Should().BeEquivalentTo(Utf8("-42").ToArray());
+    }
+
+    [Fact]
+    public void Scan_WithFloatingPointNumber_ReturnsCorrectBytes()
+    {
+        // Arrange
+        File.WriteAllText(_testFilePath, "{\"n\":3.14}");
+
+        // Act
+        var result = TopLevelScanner.Scan(_testFilePath);
+
+        // Assert
+        result.Should().HaveCount(1);
+        result[0].key.Should().Be("n");
+        result[0].value.ToArray().Should().BeEquivalentTo(Utf8("3.14").ToArray());
+    }
+
+    [Fact]
+    public void Scan_WithEmptyStringValue_ReturnsCorrectBytes()
+    {
+        // Arrange
+        File.WriteAllText(_testFilePath, "{\"k\":\"\"}");
+
+        // Act
+        var result = TopLevelScanner.Scan(_testFilePath);
+
+        // Assert
+        result.Should().HaveCount(1);
+        result[0].key.Should().Be("k");
+        result[0].value.ToArray().Should().BeEquivalentTo(Utf8("\"\"").ToArray());
     }
 
     [Fact]
@@ -42,8 +129,12 @@ public sealed partial class TopLevelScannerTests
         File.WriteAllText(_testFilePath, "{\"o\":{\"a\":1}}");
 
         // Act
+        var result = TopLevelScanner.Scan(_testFilePath);
 
         // Assert
+        result.Should().HaveCount(1);
+        result[0].key.Should().Be("o");
+        result[0].value.ToArray().Should().BeEquivalentTo(Utf8("{\"a\":1}").ToArray());
     }
 
     [Fact]
@@ -53,8 +144,29 @@ public sealed partial class TopLevelScannerTests
         File.WriteAllText(_testFilePath, "{\"a\":[1,2]}");
 
         // Act
+        var result = TopLevelScanner.Scan(_testFilePath);
 
         // Assert
+        result.Should().HaveCount(1);
+        result[0].key.Should().Be("a");
+        result[0].value.ToArray().Should().BeEquivalentTo(Utf8("[1,2]").ToArray());
+    }
+
+    [Theory]
+    [InlineData("{\"k\":{}}", "{}")]
+    [InlineData("{\"k\":[]}", "[]")]
+    public void Scan_WithEmptyContainer_ReturnsCorrectBytes(string json, string expectedValue)
+    {
+        // Arrange
+        File.WriteAllText(_testFilePath, json);
+
+        // Act
+        var result = TopLevelScanner.Scan(_testFilePath);
+
+        // Assert
+        result.Should().HaveCount(1);
+        result[0].key.Should().Be("k");
+        result[0].value.ToArray().Should().BeEquivalentTo(Utf8(expectedValue).ToArray());
     }
 
     [Fact]
@@ -64,8 +176,14 @@ public sealed partial class TopLevelScannerTests
         File.WriteAllText(_testFilePath, "{\"b\":2,\"a\":1}");
 
         // Act
+        var result = TopLevelScanner.Scan(_testFilePath);
 
         // Assert
+        result.Should().HaveCount(2);
+        result[0].key.Should().Be("b");
+        result[0].value.ToArray().Should().BeEquivalentTo(Utf8("2").ToArray());
+        result[1].key.Should().Be("a");
+        result[1].value.ToArray().Should().BeEquivalentTo(Utf8("1").ToArray());
     }
 
     [Fact]
@@ -75,8 +193,12 @@ public sealed partial class TopLevelScannerTests
         File.WriteAllText(_testFilePath, "{\"k\":1,\"k\":2}");
 
         // Act
+        var result = TopLevelScanner.Scan(_testFilePath);
 
         // Assert
+        result.Should().HaveCount(1);
+        result[0].key.Should().Be("k");
+        result[0].value.ToArray().Should().BeEquivalentTo(Utf8("2").ToArray());
     }
 
     [Fact]
@@ -86,8 +208,12 @@ public sealed partial class TopLevelScannerTests
         File.WriteAllText(_testFilePath, "{\"k\":1,\"k\":2,\"k\":3}");
 
         // Act
+        var result = TopLevelScanner.Scan(_testFilePath);
 
         // Assert
+        result.Should().HaveCount(1);
+        result[0].key.Should().Be("k");
+        result[0].value.ToArray().Should().BeEquivalentTo(Utf8("3").ToArray());
     }
 
     [Fact]
@@ -97,8 +223,14 @@ public sealed partial class TopLevelScannerTests
         File.WriteAllText(_testFilePath, "{\"a\":1,\"k\":1,\"b\":2,\"k\":2}");
 
         // Act
+        var result = TopLevelScanner.Scan(_testFilePath);
 
         // Assert
+        result.Should().HaveCount(3);
+        result[0].key.Should().Be("a");
+        result[1].key.Should().Be("k");
+        result[2].key.Should().Be("b");
+        result[1].value.ToArray().Should().BeEquivalentTo(Utf8("2").ToArray());
     }
 
     [Fact]
@@ -108,8 +240,60 @@ public sealed partial class TopLevelScannerTests
         File.WriteAllText(_testFilePath, "{\"x\":{\"y\":{\"z\":1}}}");
 
         // Act
+        var result = TopLevelScanner.Scan(_testFilePath);
 
         // Assert
+        result.Should().HaveCount(1);
+        result[0].key.Should().Be("x");
+        result[0].value.ToArray().Should().BeEquivalentTo(Utf8("{\"y\":{\"z\":1}}").ToArray());
+    }
+
+    [Fact]
+    public void Scan_WithUnicodeKey_ReturnsCorrectEntry()
+    {
+        // Arrange
+        File.WriteAllText(_testFilePath, "{\"日本語キー\":1}");
+
+        // Act
+        var result = TopLevelScanner.Scan(_testFilePath);
+
+        // Assert
+        result.Should().HaveCount(1);
+        result[0].key.Should().Be("日本語キー");
+        result[0].value.ToArray().Should().BeEquivalentTo(Utf8("1").ToArray());
+    }
+
+    [Fact]
+    public void Scan_WithEscapedCharacterInKey_ReturnsCorrectEntry()
+    {
+        // Arrange — JSON: {"key\"q\"":1}  →  key is: key"q"
+        File.WriteAllText(_testFilePath, "{\"key\\\"q\\\"\":1}");
+
+        // Act
+        var result = TopLevelScanner.Scan(_testFilePath);
+
+        // Assert
+        result.Should().HaveCount(1);
+        result[0].key.Should().Be("key\"q\"");
+        result[0].value.ToArray().Should().BeEquivalentTo(Utf8("1").ToArray());
+    }
+
+    [Theory]
+    [InlineData("{\"k\":true}", "true")]
+    [InlineData("{\"k\":false}", "false")]
+    [InlineData("{\"k\":null}", "null")]
+    public void Scan_WithScalarKeyword_ReturnsCorrectBytes(string json, string expectedValue)
+    {
+        // Arrange
+        File.WriteAllText(_testFilePath, json);
+
+        // Act
+        var result = TopLevelScanner.Scan(_testFilePath);
+
+        // Assert
+        result.Should().HaveCount(1);
+        result[0].key.Should().Be("k");
+        result[0].value.ToArray().Should().BeEquivalentTo(Utf8(expectedValue).ToArray());
     }
 
     [Fact]
@@ -121,8 +305,32 @@ public sealed partial class TopLevelScannerTests
         File.WriteAllText(_testFilePath, $"{{{fields}}}");
 
         // Act
+        var result = TopLevelScanner.Scan(_testFilePath);
 
         // Assert
+        result.Should().HaveCount(90_000);
+        result[0].key.Should().Be("f0");
+        result[0].value.ToArray().Should().BeEquivalentTo(Utf8("0").ToArray());
+        result[89_999].key.Should().Be("f89999");
+        result[89_999].value.ToArray().Should().BeEquivalentTo(Utf8("89999").ToArray());
+    }
+
+    [Fact]
+    public void Scan_WithLargeNestedValueSpanningBufferBoundary_CapturesCorrectBytes()
+    {
+        // Arrange — single nested object whose value exceeds the 1 MB initial buffer,
+        // exercising the buffer-origin arithmetic when a value straddles buffer refills
+        var innerFields = string.Join(",", Enumerable.Range(0, 100_000).Select(i => $"\"f{i}\":{i}"));
+        var innerObject = $"{{{innerFields}}}";
+        File.WriteAllText(_testFilePath, $"{{\"big\":{innerObject}}}");
+
+        // Act
+        var result = TopLevelScanner.Scan(_testFilePath);
+
+        // Assert
+        result.Should().HaveCount(1);
+        result[0].key.Should().Be("big");
+        result[0].value.ToArray().Should().BeEquivalentTo(Utf8(innerObject).ToArray());
     }
 
     [Fact]
@@ -133,41 +341,23 @@ public sealed partial class TopLevelScannerTests
         File.WriteAllText(_testFilePath, $"{{\"k\":\"{oversizedString}\"}}");
 
         // Act
+        var act = () => TopLevelScanner.Scan(_testFilePath);
 
         // Assert
+        act.Should().Throw<NotSupportedException>();
     }
 
     [Fact]
-    public void Scan_WithBooleanTrue_ReturnsCorrectBytes()
+    public void Scan_WithMalformedJson_ThrowsJsonException()
     {
         // Arrange
-        File.WriteAllText(_testFilePath, "{\"k\":true}");
+        File.WriteAllText(_testFilePath, "{\"k\":}");
 
         // Act
+        var act = () => TopLevelScanner.Scan(_testFilePath);
 
         // Assert
-    }
-
-    [Fact]
-    public void Scan_WithBooleanFalse_ReturnsCorrectBytes()
-    {
-        // Arrange
-        File.WriteAllText(_testFilePath, "{\"k\":false}");
-
-        // Act
-
-        // Assert
-    }
-
-    [Fact]
-    public void Scan_WithNullValue_ReturnsCorrectBytes()
-    {
-        // Arrange
-        File.WriteAllText(_testFilePath, "{\"k\":null}");
-
-        // Act
-
-        // Assert
+        act.Should().Throw<System.Text.Json.JsonException>();
     }
 
     [Fact]
@@ -177,10 +367,30 @@ public sealed partial class TopLevelScannerTests
         using var cts = new CancellationTokenSource();
         var fields = string.Join(",", Enumerable.Range(0, 100_000).Select(i => $"\"f{i}\":{i}"));
         File.WriteAllText(_testFilePath, $"{{{fields}}}");
+        cts.Cancel();
 
         // Act
+        var act = () => TopLevelScanner.Scan(_testFilePath, cts.Token);
 
         // Assert
+        act.Should().Throw<OperationCanceledException>();
+    }
+
+    [Fact]
+    public void Scan_WithPreCancelledToken_ThrowsOperationCanceledException()
+    {
+        // Arrange — file exists and is valid, but the token is already cancelled
+        // before Scan is invoked. The first ThrowIfCancellationRequested in the
+        // loop will throw deterministically, regardless of timing.
+        File.WriteAllText(_testFilePath, "{\"k\":1}");
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        // Act
+        var act = () => TopLevelScanner.Scan(_testFilePath, cts.Token);
+
+        // Assert
+        act.Should().Throw<OperationCanceledException>();
     }
 
     [Fact]
@@ -190,8 +400,12 @@ public sealed partial class TopLevelScannerTests
         File.WriteAllText(_testFilePath, "  { \"k\" : 1 }  ");
 
         // Act
+        var result = TopLevelScanner.Scan(_testFilePath);
 
         // Assert
+        result.Should().HaveCount(1);
+        result[0].key.Should().Be("k");
+        result[0].value.ToArray().Should().BeEquivalentTo(Utf8("1").ToArray());
     }
 
     [Fact]
@@ -201,8 +415,10 @@ public sealed partial class TopLevelScannerTests
         File.WriteAllText(_testFilePath, "[1,2,3]");
 
         // Act
+        var result = TopLevelScanner.Scan(_testFilePath);
 
         // Assert
+        result.Should().BeEmpty();
     }
 
     [Fact]
@@ -212,7 +428,9 @@ public sealed partial class TopLevelScannerTests
         File.WriteAllText(_testFilePath, "42");
 
         // Act
+        var result = TopLevelScanner.Scan(_testFilePath);
 
         // Assert
+        result.Should().BeEmpty();
     }
 }

--- a/tests/DataMorph.Tests/Engine/IO/JsonObject/TopLevelScannerTests.Scan.cs
+++ b/tests/DataMorph.Tests/Engine/IO/JsonObject/TopLevelScannerTests.Scan.cs
@@ -361,22 +361,6 @@ public sealed partial class TopLevelScannerTests
     }
 
     [Fact]
-    public void Scan_WhenCancelled_ThrowsOperationCanceledException()
-    {
-        // Arrange
-        using var cts = new CancellationTokenSource();
-        var fields = string.Join(",", Enumerable.Range(0, 100_000).Select(i => $"\"f{i}\":{i}"));
-        File.WriteAllText(_testFilePath, $"{{{fields}}}");
-        cts.Cancel();
-
-        // Act
-        var act = () => TopLevelScanner.Scan(_testFilePath, cts.Token);
-
-        // Assert
-        act.Should().Throw<OperationCanceledException>();
-    }
-
-    [Fact]
     public void Scan_WithPreCancelledToken_ThrowsOperationCanceledException()
     {
         // Arrange — file exists and is valid, but the token is already cancelled

--- a/tests/DataMorph.Tests/Engine/IO/JsonObject/TopLevelScannerTests.Scan.cs
+++ b/tests/DataMorph.Tests/Engine/IO/JsonObject/TopLevelScannerTests.Scan.cs
@@ -1,0 +1,218 @@
+namespace DataMorph.Tests.Engine.IO.JsonObject;
+
+public sealed partial class TopLevelScannerTests
+{
+    [Fact]
+    public void Scan_WithEmptyObject_ReturnsEmptyList()
+    {
+        // Arrange
+        File.WriteAllText(_testFilePath, "{}");
+
+        // Act
+
+        // Assert
+    }
+
+    [Fact]
+    public void Scan_WithSinglePrimitiveString_ReturnsOneEntry()
+    {
+        // Arrange
+        File.WriteAllText(_testFilePath, "{\"k\":\"v\"}");
+
+        // Act
+
+        // Assert
+    }
+
+    [Fact]
+    public void Scan_WithSinglePrimitiveNumber_ReturnsOneEntry()
+    {
+        // Arrange
+        File.WriteAllText(_testFilePath, "{\"n\":42}");
+
+        // Act
+
+        // Assert
+    }
+
+    [Fact]
+    public void Scan_WithSingleNestedObject_ReturnsOneEntry()
+    {
+        // Arrange
+        File.WriteAllText(_testFilePath, "{\"o\":{\"a\":1}}");
+
+        // Act
+
+        // Assert
+    }
+
+    [Fact]
+    public void Scan_WithSingleNestedArray_ReturnsOneEntry()
+    {
+        // Arrange
+        File.WriteAllText(_testFilePath, "{\"a\":[1,2]}");
+
+        // Act
+
+        // Assert
+    }
+
+    [Fact]
+    public void Scan_WithMultipleKeys_PreservesInsertionOrder()
+    {
+        // Arrange
+        File.WriteAllText(_testFilePath, "{\"b\":2,\"a\":1}");
+
+        // Act
+
+        // Assert
+    }
+
+    [Fact]
+    public void Scan_WithDuplicateKeys_LastValueWins()
+    {
+        // Arrange
+        File.WriteAllText(_testFilePath, "{\"k\":1,\"k\":2}");
+
+        // Act
+
+        // Assert
+    }
+
+    [Fact]
+    public void Scan_WithTripleDuplicateKey_LastValueWins()
+    {
+        // Arrange
+        File.WriteAllText(_testFilePath, "{\"k\":1,\"k\":2,\"k\":3}");
+
+        // Act
+
+        // Assert
+    }
+
+    [Fact]
+    public void Scan_WithDuplicateKey_PositionStableWithOtherKeys()
+    {
+        // Arrange
+        File.WriteAllText(_testFilePath, "{\"a\":1,\"k\":1,\"b\":2,\"k\":2}");
+
+        // Act
+
+        // Assert
+    }
+
+    [Fact]
+    public void Scan_WithDeeplyNestedValue_CapturesCorrectByteRange()
+    {
+        // Arrange
+        File.WriteAllText(_testFilePath, "{\"x\":{\"y\":{\"z\":1}}}");
+
+        // Act
+
+        // Assert
+    }
+
+    [Fact]
+    public void Scan_WithFileSizeExceedingInitialBufferSize_CapturesCorrectBytes()
+    {
+        // Arrange — object with many small fields so the total exceeds 1 MB
+        // without any single JSON string token exceeding the buffer
+        var fields = string.Join(",", Enumerable.Range(0, 90_000).Select(i => $"\"f{i}\":{i}"));
+        File.WriteAllText(_testFilePath, $"{{{fields}}}");
+
+        // Act
+
+        // Assert
+    }
+
+    [Fact]
+    public void Scan_WithStringValueExceedingMaxBufferSize_ThrowsNotSupportedException()
+    {
+        // Arrange — string value larger than 16 MB
+        var oversizedString = new string('a', 16 * 1024 * 1024 + 1);
+        File.WriteAllText(_testFilePath, $"{{\"k\":\"{oversizedString}\"}}");
+
+        // Act
+
+        // Assert
+    }
+
+    [Fact]
+    public void Scan_WithBooleanTrue_ReturnsCorrectBytes()
+    {
+        // Arrange
+        File.WriteAllText(_testFilePath, "{\"k\":true}");
+
+        // Act
+
+        // Assert
+    }
+
+    [Fact]
+    public void Scan_WithBooleanFalse_ReturnsCorrectBytes()
+    {
+        // Arrange
+        File.WriteAllText(_testFilePath, "{\"k\":false}");
+
+        // Act
+
+        // Assert
+    }
+
+    [Fact]
+    public void Scan_WithNullValue_ReturnsCorrectBytes()
+    {
+        // Arrange
+        File.WriteAllText(_testFilePath, "{\"k\":null}");
+
+        // Act
+
+        // Assert
+    }
+
+    [Fact]
+    public void Scan_WhenCancelled_ThrowsOperationCanceledException()
+    {
+        // Arrange
+        using var cts = new CancellationTokenSource();
+        var fields = string.Join(",", Enumerable.Range(0, 100_000).Select(i => $"\"f{i}\":{i}"));
+        File.WriteAllText(_testFilePath, $"{{{fields}}}");
+
+        // Act
+
+        // Assert
+    }
+
+    [Fact]
+    public void Scan_WithLeadingTrailingWhitespace_SameResultAsCompactForm()
+    {
+        // Arrange
+        File.WriteAllText(_testFilePath, "  { \"k\" : 1 }  ");
+
+        // Act
+
+        // Assert
+    }
+
+    [Fact]
+    public void Scan_WithRootArray_ReturnsEmptyList()
+    {
+        // Arrange
+        File.WriteAllText(_testFilePath, "[1,2,3]");
+
+        // Act
+
+        // Assert
+    }
+
+    [Fact]
+    public void Scan_WithRootPrimitive_ReturnsEmptyList()
+    {
+        // Arrange
+        File.WriteAllText(_testFilePath, "42");
+
+        // Act
+
+        // Assert
+    }
+}

--- a/tests/DataMorph.Tests/Engine/IO/JsonObject/TopLevelScannerTests.cs
+++ b/tests/DataMorph.Tests/Engine/IO/JsonObject/TopLevelScannerTests.cs
@@ -1,3 +1,6 @@
+using AwesomeAssertions;
+using DataMorph.Engine.IO.JsonObject;
+
 namespace DataMorph.Tests.Engine.IO.JsonObject;
 
 public sealed partial class TopLevelScannerTests : IDisposable
@@ -26,8 +29,10 @@ public sealed partial class TopLevelScannerTests : IDisposable
         // Arrange — no setup required
 
         // Act
+        var act = () => TopLevelScanner.Scan(null!);
 
         // Assert
+        act.Should().Throw<ArgumentException>();
     }
 
     [Fact]
@@ -36,7 +41,9 @@ public sealed partial class TopLevelScannerTests : IDisposable
         // Arrange — no setup required
 
         // Act
+        var act = () => TopLevelScanner.Scan("   ");
 
         // Assert
+        act.Should().Throw<ArgumentException>();
     }
 }

--- a/tests/DataMorph.Tests/Engine/IO/JsonObject/TopLevelScannerTests.cs
+++ b/tests/DataMorph.Tests/Engine/IO/JsonObject/TopLevelScannerTests.cs
@@ -1,0 +1,42 @@
+namespace DataMorph.Tests.Engine.IO.JsonObject;
+
+public sealed partial class TopLevelScannerTests : IDisposable
+{
+    private readonly string _testFilePath;
+
+    public TopLevelScannerTests()
+    {
+        _testFilePath = Path.Combine(
+            Path.GetTempPath(),
+            $"jsonobject_toplevelscanner_{Guid.NewGuid()}.json"
+        );
+    }
+
+    public void Dispose()
+    {
+        if (File.Exists(_testFilePath))
+        {
+            File.Delete(_testFilePath);
+        }
+    }
+
+    [Fact]
+    public void Scan_WithNullFilePath_ThrowsArgumentException()
+    {
+        // Arrange — no setup required
+
+        // Act
+
+        // Assert
+    }
+
+    [Fact]
+    public void Scan_WithWhiteSpaceFilePath_ThrowsArgumentException()
+    {
+        // Arrange — no setup required
+
+        // Act
+
+        // Assert
+    }
+}


### PR DESCRIPTION
## Summary

- Add `TopLevelScanner` that reads a JSON Object file and returns all top-level key/value pairs as `(string key, ReadOnlyMemory<byte> value)`
- Introduce `BufferState`, `EntryState`, and `JsonScanState` ref structs to manage streaming buffer and parse state
- Use `ArrayPool<byte>` + `RandomAccess` for allocation-efficient, seekable file I/O
- Add unit tests covering standard cases, duplicate keys, cancellation, and large files

Closes #64