### PR TITLE
feat: implement JSON Object Explorer Mode (Tree View)

### DIFF
--- a/docs/design_json_object_explorer_mode.md
+++ b/docs/design_json_object_explorer_mode.md
@@ -1,0 +1,402 @@
+# JSON Object Explorer Mode — Design Document
+
+## Scope
+
+Implement Explorer Mode for JSON Object files (`{...}`), displaying top-level keys as a
+tree structure. `TopLevelScanner.Scan()` provides all key-value pairs in one pass;
+the App layer builds flat root-level tree nodes from those bytes — exactly mirroring the
+`JsonArrayTreeView` / `JsonLinesTreeView` pattern (no wrapping root node).
+
+---
+
+## 1. Requirements
+
+### Functional Requirements
+
+- **Key Nodes at Root Level**: Each top-level key appears as a direct root-level node in the
+  tree (no `{ Object }` wrapper node); matches the `JsonArrayTreeView` / `JsonLinesTreeView`
+  pattern
+- **Value Summary Label**: Each node's text shows `{key}: {value summary}` (e.g.
+  `id: 123`, `data: {Object: 2 properties}`, `tags: [Array: 3 items]`)
+- **Lazy Loading (nested)**: Child nodes of each key node are populated only when expanded;
+  primitive values have no children; object/array values lazy-load their nested structure via
+  existing `JsonObjectTreeNode` / `JsonArrayTreeNode`
+- **Schema Preview**: Value type is inferred from the first token of the stored bytes
+  (`Utf8JsonReader`); display is identical to `JsonArrayRangeTreeNode.CreateElementNode`
+- **Arrow-key Navigation**: Inherited from `MorphTreeView` (Vim h/j/k/l, g/G, Ctrl+d/Ctrl+u)
+- **Format Detection**: `.json` files are distinguished by peeking at the first non-whitespace
+  byte: `{` → `JsonObject`, `[` → `JsonArray`
+
+### Non-Functional Requirements
+
+- **Zero allocations** on the tree-node rendering hot path (no allocations in `Text` after
+  initial construction)
+- **Native AOT compatible**: `Utf8JsonReader`; no reflection
+- **Thread-safe read access**: all tree operations run on the UI thread
+
+---
+
+## 2. Architecture Overview
+
+```
+┌─ App Layer ──────────────────────────────────────────────────────────────┐
+│                                                                          │
+│  ┌─────────────────────────────────────────────────────────────────────┐ │
+│  │              MorphTreeView (abstract, existing)                     │ │
+│  │   Vim-key navigation, 't' toggle, Enter toggle                      │ │
+│  └───────────────────────────────┬─────────────────────────────────────┘ │
+│                                  │                                       │
+│                                  ▼                                       │
+│  ┌─────────────────────────────────────────────────────────────────────┐ │
+│  │              JsonObjectTreeView (new)                               │ │
+│  │  - Factory method: Create(entries, onTableModeToggle)               │ │
+│  │  - For each (key, valueBytes): CreateKeyNode → AddObject            │ │
+│  └───────────────────────────────┬─────────────────────────────────────┘ │
+│                                  │ (root-level nodes, one per key)       │
+│                     ┌────────────┼────────────┐                          │
+│                     ▼            ▼            ▼                          │
+│  ┌──────────────────────┐  ┌──────────────┐  ┌──────────────────────┐    │
+│  │ JsonValueTreeNode    │  │JsonObject    │  │ JsonArrayTreeNode    │    │
+│  │ "id: 123"            │  │TreeNode      │  │ "tags: [Array: 3 …]" │    │
+│  │ "name: \"example\""  │  │"data:        │  │                      │    │
+│  │                      │  │{Object: 2…}" │  │                      │    │
+│  └──────────────────────┘  └──────────────┘  └──────────────────────┘    │
+│                    (all existing, same pattern as JsonArrayRangeTreeNode)│
+│                                                                          │
+├─ Engine Layer ────────────────────────────────────────────────────────── │
+│                                                                          │
+│  ┌─────────────────────────────────────────────────────────────────────┐ │
+│  │              TopLevelScanner (existing)                             │ │
+│  │  Scan(filePath, ct) → IReadOnlyList<(string key,                    │ │
+│  │                                      ReadOnlyMemory<byte> value)>   │ │
+│  └─────────────────────────────────────────────────────────────────────┘ │
+│                                                                          │
+└──────────────────────────────────────────────────────────────────────────┘
+```
+
+### Why No Root Node
+
+`JsonArrayTreeView` and `JsonLinesTreeView` do not use a file-level wrapper node; they add
+root-level nodes directly via `AddObject`. `JsonObjectTreeView` follows the same convention
+to keep the tree hierarchy consistent across all formats. A wrapper root node
+(`JsonObjectFileTreeNode`) was explicitly considered and rejected during design; see Section 5.
+
+### Layer Separation
+
+`TopLevelScanner` (Engine) returns `(string key, ReadOnlyMemory<byte> value)` pairs with no
+Terminal.Gui dependency. The App layer converts those pairs into tree nodes using the same
+`JsonObjectTreeNode` / `JsonArrayTreeNode` / `JsonValueTreeNode` types already used by all
+other tree views. No new Engine types are required.
+
+---
+
+## 3. Class Design
+
+### 3.1 App: `JsonObjectTreeView`
+
+**Namespace**: `DataMorph.App.Views`
+
+**Responsibility**: `MorphTreeView` subclass for JSON Object files. Receives pre-scanned
+key-value pairs and adds one root-level node per key via `AddObject`. Constructor is
+`private`; callers use `JsonObjectTreeView.Create(...)`.
+
+**`CreateKeyNode` pattern**: Mirrors `JsonArrayRangeTreeNode.CreateElementNode` exactly —
+construct `Utf8JsonReader` on `valueBytes.Span`, read first token, create the appropriate
+existing node type, and prepend `{key}: ` to its computed `Text`. This avoids calling
+`JsonTreeNodeHelper.CreateChildNode`, which produces the abbreviated `{...}` / `[...]` form
+used for nested child nodes.
+
+```csharp
+internal sealed class JsonObjectTreeView : MorphTreeView
+{
+    private JsonObjectTreeView(Action onTableModeToggle) : base(onTableModeToggle) { }
+
+    internal static JsonObjectTreeView Create(
+        IReadOnlyList<(string key, ReadOnlyMemory<byte> value)> entries,
+        Action onTableModeToggle)
+    {
+        ArgumentNullException.ThrowIfNull(entries);
+        ArgumentNullException.ThrowIfNull(onTableModeToggle);
+        var view = new JsonObjectTreeView(onTableModeToggle);
+        foreach (var (key, valueBytes) in entries)
+        {
+            var node = CreateKeyNode(key, valueBytes);
+            view.AddObject(node);
+        }
+        return view;
+    }
+
+    internal static ITreeNode CreateKeyNode(string key, ReadOnlyMemory<byte> valueBytes)
+    {
+        // 1. Construct Utf8JsonReader on valueBytes.Span
+        // 2. Read first token (reader.Read())
+        // 3. StartObject → new JsonObjectTreeNode(valueBytes); node.Text = $"{key}: {node.Text}"
+        //    StartArray  → new JsonArrayTreeNode(valueBytes);  node.Text = $"{key}: {node.Text}"
+        //    Primitive   → new JsonValueTreeNode($"{key}: {reader.GetPrimitiveDisplay()}")
+        // 4. On JsonException or read failure → JsonValueTreeNode with "[Invalid JSON]"
+    }
+}
+```
+
+**No `Dispose` override required**: `JsonObjectTreeView` holds no disposable resources.
+`TopLevelScanner` result is a plain list; all bytes are heap-owned `ReadOnlyMemory<byte>`.
+
+### 3.2 App: `FormatDetector` (modified)
+
+**Change**: Replace the `.JSON` extension branch with a content-based peek that returns
+`JsonArray` or `JsonObject` based on the first non-whitespace byte.
+
+```csharp
+".JSON" => DetectJsonFormat(filePath),
+```
+
+```csharp
+private static Result<DataFormat> DetectJsonFormat(string filePath)
+{
+    using var fs = File.OpenRead(filePath);
+    int b;
+    while ((b = fs.ReadByte()) != -1)
+    {
+        if (b is not ((byte)' ' or (byte)'\t' or (byte)'\r' or (byte)'\n'))
+        {
+            break;
+        }
+    }
+    // Explicit EOF guard: whitespace-only file (empty file is already caught upstream)
+    if (b == -1)
+    {
+        return Results.Failure<DataFormat>("File contains no valid JSON root token");
+    }
+    return (char)b switch
+    {
+        '{' => Results.Success(DataFormat.JsonObject),
+        '[' => Results.Success(DataFormat.JsonArray),
+        _ => Results.Failure<DataFormat>($"Unrecognized JSON root token: '{(char)b}'"),
+    };
+}
+```
+
+**`t:Tree/Table` hint**: `ViewManager.RefreshStatusBarHints` shows this hint only for
+`JsonLines` and `JsonArray`. `DataFormat.JsonObject` is intentionally excluded — table mode
+is out of scope. No change to `RefreshStatusBarHints` is needed.
+
+### 3.3 App: `ViewMode` (modified)
+
+Add `JsonObjectTree` enum value.
+
+### 3.4 App: `ViewManager` (modified)
+
+Add `SwitchToJsonObjectTree`. Table mode is not supported for JSON Object, so `static () => { }` is passed inline as the no-op toggle callback — no dedicated method is needed.
+
+```csharp
+internal void SwitchToJsonObjectTree(
+    IReadOnlyList<(string key, ReadOnlyMemory<byte> value)> entries)
+{
+    ObjectDisposedException.ThrowIf(_disposed, this);
+    ArgumentNullException.ThrowIfNull(entries);
+    var view = JsonObjectTreeView.Create(entries, static () => { });
+    view.X = 0;
+    view.Y = 1;
+    view.Width = Dim.Fill();
+    view.Height = Dim.Fill() - 1;
+    SwapView(view);
+    RefreshStatusBarHints();
+}
+```
+
+### 3.5 App: `FileDialogHandler` (modified)
+
+**Restructuring**: Add a `stopIndexing: Action` parameter to the constructor. Add a JSON
+Object branch **before** `RowIndexerFactory.Create` with an early `return`. The existing
+CSV/JsonLines/JsonArray flow is unchanged.
+
+```csharp
+// After existing common reset block (_state.CurrentFilePath, ActionStack, RenewCtsWithCancel):
+
+if (format == DataFormat.JsonObject)
+{
+    _stopCurrentIndexing();              // cancel previous background indexing + unwire events
+    _state.RowIndexer = null;
+    _state.Schema = null;
+    _state.OnSchemaRefined = null;
+
+    var ct = _state.Cts.Token;
+    try
+    {
+        var entries = await Task.Run(() => TopLevelScanner.Scan(path, ct), ct);
+        _app.Invoke(() =>
+        {
+            _state.CurrentMode = ViewMode.JsonObjectTree;
+            _viewManager.SwitchToJsonObjectTree(entries);
+        });
+    }
+    catch (OperationCanceledException) { /* file reloaded before scan completed */ }
+    catch (Exception ex)
+    {
+        _app.Invoke(() => _viewManager.ShowError($"Error loading JSON Object: {ex.Message}"));
+    }
+    return;
+}
+
+// Unchanged: only CSV / JsonLines / JsonArray reach this line
+var indexer = RowIndexerFactory.Create(format, path);
+```
+
+`_stopCurrentIndexing()` is called only in the JSON Object branch. For other formats,
+`StartIndexing(indexer)` → `WireIndexerProgress` already unsubscribes from the previous
+indexer, so no additional cleanup is needed.
+
+### 3.6 App: `IndexTaskManager` (modified)
+
+Add `CancelCurrent()` to cancel the running task without starting a new one:
+
+```csharp
+public void CancelCurrent()
+{
+    lock (_lock)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        _cts?.Cancel();
+        _cts?.Dispose();
+        _cts = null;
+    }
+}
+```
+
+Note: `Dispose()` is also updated to set `_cts = null` after cancellation, for symmetry with `CancelCurrent()`.
+
+### 3.7 App: `MainWindow` (modified)
+
+Add `StopCurrentIndexing()` method and pass it to `FileDialogHandler`:
+
+```csharp
+// Constructor change:
+_fileDialogHandler = new FileDialogHandler(app, state, _viewManager, StartIndexing, StopCurrentIndexing);
+
+// New method:
+// Must be called on the UI thread; DismissIndexingProgress modifies Terminal.Gui views.
+internal void StopCurrentIndexing()
+{
+    if (_activeIndexer is not null)
+    {
+        if (_onProgressChanged is not null)
+            _activeIndexer.ProgressChanged -= _onProgressChanged;
+        if (_onBuildIndexCompleted is not null)
+            _activeIndexer.BuildIndexCompleted -= _onBuildIndexCompleted;
+        _activeIndexer = null;
+    }
+    _indexTaskManager.CancelCurrent();
+    DismissIndexingProgress();
+}
+```
+
+---
+
+## 4. Files to Create / Modify
+
+### Files to Create
+
+| File | Layer | Purpose |
+|------|-------|---------|
+| `src/App/Views/JsonObjectTreeView.cs` | App | `MorphTreeView` subclass; one root-level node per key |
+| `tests/DataMorph.Tests/App/Views/JsonObjectTreeViewTests.cs` | Tests | Unit tests for `JsonObjectTreeView.Create` and `CreateKeyNode` |
+
+### Files to Modify
+
+| File | Change |
+|------|--------|
+| `src/App/FormatDetector.cs` | Content-based `.json` detection; EOF guard for whitespace-only files |
+| `src/App/ViewMode.cs` | Add `JsonObjectTree` |
+| `src/App/ViewManager.cs` | Add `SwitchToJsonObjectTree` |
+| `src/App/FileDialogHandler.cs` | Add `stopIndexing: Action` constructor param; add `JsonObject` early-return branch |
+| `src/App/IndexTaskManager.cs` | Add `CancelCurrent()`; update `Dispose()` to set `_cts = null` |
+| `src/App/MainWindow.cs` | Add `StopCurrentIndexing()`; pass it to `FileDialogHandler` |
+| `tests/DataMorph.Tests/App/FileDialogHandlerTests.cs` | Update constructor call sites for new `stopIndexing` parameter |
+
+**Not modified**: `AppState.cs`, `RowIndexerFactory.cs` — scan results are ephemeral and
+passed directly from `FileDialogHandler` to `ViewManager`; no persistent state storage needed.
+
+---
+
+## 5. Key Design Decisions
+
+| Decision | Rationale |
+|----------|-----------|
+| No wrapper root node | `JsonArrayTreeView` and `JsonLinesTreeView` use flat root-level nodes; a wrapper node (`JsonObjectFileTreeNode`) was explicitly considered and rejected to maintain consistency |
+| `CreateKeyNode` mirrors `JsonArrayRangeTreeNode.CreateElementNode` | Reuses the same node-type dispatch without calling `JsonTreeNodeHelper.CreateChildNode`, which produces abbreviated `{...}` / `[...]` labels |
+| No `IRowIndexer` for JSON Object | JSON Object keys are not rows; `TopLevelScanner` is the correct data access layer — one-shot scan, then all values are in memory |
+| `RowIndexerFactory.Create` not restructured | JSON Object branch returns early; the factory call is unreachable for that format without moving it |
+| `stopIndexing: Action` callback in `FileDialogHandler` | `FileDialogHandler` must not own `IndexTaskManager` directly; callback keeps the dependency clean |
+| `TopLevelScanner.Scan` in `Task.Run` | Synchronous file I/O; must not block the UI thread |
+| `AppState` not extended for scan results | Scan results are ephemeral; JSON Object has no table-mode toggle so no re-use path exists |
+| Content-based `.json` detection | Extension alone cannot distinguish JSON Object from JSON Array |
+| No `ToggleJsonObjectModeAsync` method | Table mode is out of scope with no plan to add it; `static () => { }` passed inline avoids a stub method that never does anything |
+
+---
+
+## 6. Dependencies
+
+| Dependency | Status | Notes |
+|------------|--------|-------|
+| `TopLevelScanner` | Existing | `Scan(filePath, ct)` → all key-value pairs |
+| `DataFormat.JsonObject` | Existing | Already defined in `src/Engine/Types/DataFormat.cs` |
+| `JsonObjectTreeNode`, `JsonArrayTreeNode`, `JsonValueTreeNode` | Existing | Reused via `CreateKeyNode` |
+| `JsonArrayRangeTreeNode.CreateElementNode` | Existing | Reference implementation for `CreateKeyNode` pattern |
+| `MorphTreeView` | Existing | Abstract base; Vim-key navigation |
+| `System.Text.Json.Utf8JsonReader` | BCL | AOT-safe; used in `FormatDetector` and `CreateKeyNode` |
+| Terminal.Gui `TreeView`, `TreeNode`, `ITreeNode` | Existing | Base for all tree classes |
+
+---
+
+## 7. Testing Strategy
+
+### 7.1 Unit Tests — `JsonObjectTreeView.CreateKeyNode`
+
+| Test | Input | Expected |
+|------|-------|----------|
+| `CreateKeyNode_NumberValue_ReturnsValueNodeWithLabel` | `("id", bytes of 123)` | `JsonValueTreeNode` with `Text = "id: 123"` |
+| `CreateKeyNode_StringValue_ReturnsValueNodeWithLabel` | `("name", bytes of "x")` | `JsonValueTreeNode` with `Text = "name: \"x\""` |
+| `CreateKeyNode_TrueValue_ReturnsValueNodeWithLabel` | `("ok", bytes of true)` | `JsonValueTreeNode` with `Text = "ok: true"` |
+| `CreateKeyNode_FalseValue_ReturnsValueNodeWithLabel` | `("ok", bytes of false)` | `JsonValueTreeNode` with `Text = "ok: false"` |
+| `CreateKeyNode_NullValue_ReturnsValueNodeWithLabel` | `("k", bytes of null)` | `JsonValueTreeNode` with `Text = "k: <null>"` |
+| `CreateKeyNode_ObjectValue_ReturnsObjectNodeWithLabel` | `("data", bytes of {"a":1})` | `JsonObjectTreeNode` with `Text = "data: {Object: 1 properties}"` |
+| `CreateKeyNode_ArrayValue_ReturnsArrayNodeWithLabel` | `("tags", bytes of [1,2])` | `JsonArrayTreeNode` with `Text = "tags: [Array: 2 items]"` |
+| `CreateKeyNode_InvalidBytes_ReturnsValueNodeWithErrorText` | `("k", malformed bytes)` | `JsonValueTreeNode` with `Text = "k: [Invalid JSON]"` |
+| `CreateKeyNode_EmptyBytes_ReturnsValueNodeWithErrorText` | `("k", empty)` | `JsonValueTreeNode` with `Text = "k: [Invalid JSON]"` |
+
+### 7.2 Unit Tests — `JsonObjectTreeView.Create`
+
+| Test | Input | Expected |
+|------|-------|----------|
+| `Create_WithNullEntries_ThrowsArgumentNullException` | `null` entries | `ArgumentNullException` |
+| `Create_WithNullToggle_ThrowsArgumentNullException` | `null` toggle | `ArgumentNullException` |
+| `Create_WithEmptyEntries_AddsNoObjects` | `[]` | 0 objects in tree |
+| `Create_WithEntries_AddsOneNodePerKey` | 3 entries | 3 root-level objects |
+
+### 7.3 Unit Tests — `FormatDetector`
+
+| Test | Input | Expected |
+|------|-------|----------|
+| `Detect_JsonObjectFile_ReturnsJsonObject` | File starting with `{` | `DataFormat.JsonObject` |
+| `Detect_JsonArrayFile_ReturnsJsonArray` | File starting with `[` | `DataFormat.JsonArray` |
+| `Detect_JsonObjectWithLeadingWhitespace_ReturnsJsonObject` | `  \n{...}` | `DataFormat.JsonObject` |
+| `Detect_JsonArrayWithLeadingWhitespace_ReturnsJsonArray` | `  \n[...]` | `DataFormat.JsonArray` |
+| `Detect_JsonFileWithUnknownRoot_ReturnsFailure` | File starting with `"` | Failure result |
+| `Detect_WhitespaceOnlyJsonFile_ReturnsFailure` | File with only spaces/newlines | Failure result |
+
+### 7.4 Unit Tests — `ViewManager` (additions)
+
+| Test | Expected |
+|------|----------|
+| `SwitchToJsonObjectTree_WithValidEntries_SetsCurrentView` | Current view is `JsonObjectTreeView` |
+| `SwitchToJsonObjectTree_WithNullEntries_ThrowsArgumentNullException` | `ArgumentNullException` |
+| `SwitchToJsonObjectTree_AfterDisposal_ThrowsObjectDisposedException` | `ObjectDisposedException` |
+
+### 7.5 Unit Tests — `IndexTaskManager` (additions)
+
+| Test | Expected |
+|------|----------|
+| `CancelCurrent_WhenIdle_DoesNotThrow` | No exception |
+| `CancelCurrent_AfterStart_CancelsTask` | Background task receives cancellation |
+| `CancelCurrent_CalledTwice_DoesNotThrow` | Second call with `_cts == null` is a no-op; no exception |
+| `CancelCurrent_AfterDisposal_ThrowsObjectDisposedException` | `ObjectDisposedException` |

--- a/src/App/FileDialogHandler.cs
+++ b/src/App/FileDialogHandler.cs
@@ -14,12 +14,14 @@ internal sealed class FileDialogHandler(
     IApplication app,
     AppState state,
     ViewManager viewManager,
-    Action<IRowIndexer> onIndexerStart)
+    Action<IRowIndexer> onIndexerStart,
+    Action stopIndexing)
 {
     private readonly IApplication _app = app;
     private readonly AppState _state = state;
     private readonly ViewManager _viewManager = viewManager;
     private readonly Action<IRowIndexer> _onIndexerStart = onIndexerStart;
+    private readonly Action _stopIndexing = stopIndexing;
 
     [SuppressMessage(
         "Reliability",
@@ -58,6 +60,38 @@ internal sealed class FileDialogHandler(
         _state.CurrentFilePath = path;
         _state.ActionStack = [];
         _state.RenewCtsWithCancel();
+
+        // JSON Object: scan keys via TopLevelScanner, then switch to tree view directly.
+        // No IRowIndexer is needed — keys are not rows.
+        if (format == DataFormat.JsonObject)
+        {
+            _stopIndexing();
+            _state.RowIndexer = null;
+            _state.Schema = null;
+            _state.OnSchemaRefined = null;
+
+            var ct = _state.Cts.Token;
+            try
+            {
+                var entries = await Task.Run(
+                    () => Engine.IO.JsonObject.TopLevelScanner.Scan(path, ct), ct);
+                _app.Invoke(() =>
+                {
+                    _state.CurrentMode = ViewMode.JsonObjectTree;
+                    _viewManager.SwitchToJsonObjectTree(entries);
+                });
+            }
+            catch (OperationCanceledException) { /* file reloaded before scan completed */ }
+#pragma warning disable CA1031 // UI top-level handler
+            catch (Exception ex)
+#pragma warning restore CA1031
+            {
+                _app.Invoke(() =>
+                    _viewManager.ShowError($"Error loading JSON Object: {ex.Message}"));
+            }
+
+            return;
+        }
 
         // Create indexer from factory
         var indexer = RowIndexerFactory.Create(format, path);

--- a/src/App/FormatDetector.cs
+++ b/src/App/FormatDetector.cs
@@ -40,8 +40,23 @@ internal static class FormatDetector
         {
             ".CSV" => Results.Success(DataFormat.Csv),
             ".JSONL" => Results.Success(DataFormat.JsonLines),
-            ".JSON" => Results.Success(DataFormat.JsonArray),
+            ".JSON" => DetectJsonFormat(filePath),
             _ => Results.Failure<DataFormat>($"Unsupported file format: {rawExtension}"),
         };
+    }
+
+    /// <summary>
+    /// Distinguishes JSON Object from JSON Array by peeking at the first non-whitespace byte.
+    /// </summary>
+    /// <param name="filePath">Path to the .json file.</param>
+    /// <returns>
+    /// <see cref="DataFormat.JsonObject"/> if the root token is <c>{</c>,
+    /// <see cref="DataFormat.JsonArray"/> if the root token is <c>[</c>,
+    /// or a failure result for any other root token or whitespace-only content.
+    /// </returns>
+    private static Result<DataFormat> DetectJsonFormat(string filePath)
+    {
+        // TODO: Implement in Step 2 — detect object vs array by reading first token
+        return Results.Success(DataFormat.JsonArray);
     }
 }

--- a/src/App/FormatDetector.cs
+++ b/src/App/FormatDetector.cs
@@ -56,7 +56,53 @@ internal static class FormatDetector
     /// </returns>
     private static Result<DataFormat> DetectJsonFormat(string filePath)
     {
-        // TODO: Implement in Step 2 — detect object vs array by reading first token
-        return Results.Success(DataFormat.JsonArray);
+        try
+        {
+            using var fs = File.OpenRead(filePath);
+            SkipUtf8BomIfPresent(fs);
+
+            var b = fs.ReadByte();
+            while (b != -1 && char.IsWhiteSpace((char)b))
+            {
+                b = fs.ReadByte();
+            }
+
+            if (b == -1)
+            {
+                return Results.Failure<DataFormat>("File contains no valid JSON root token");
+            }
+
+            return (char)b switch
+            {
+                '{' => Results.Success(DataFormat.JsonObject),
+                '[' => Results.Success(DataFormat.JsonArray),
+                _ => Results.Failure<DataFormat>($"Unrecognized JSON root token: '{(char)b}'"),
+            };
+        }
+        catch (IOException ex)
+        {
+            return Results.Failure<DataFormat>($"Failed to read file: {ex.Message}");
+        }
+    }
+
+    private static void SkipUtf8BomIfPresent(FileStream fs)
+    {
+        Span<byte> bom = stackalloc byte[3];
+        try
+        {
+            fs.ReadExactly(bom);
+        }
+        catch (EndOfStreamException)
+        {
+            fs.Seek(0, SeekOrigin.Begin);
+            return;
+        }
+
+        if (bom[0] == 0xEF && bom[1] == 0xBB && bom[2] == 0xBF)
+        {
+            return;
+        }
+
+        fs.Seek(-3, SeekOrigin.Current);
     }
 }

--- a/src/App/IndexTaskManager.cs
+++ b/src/App/IndexTaskManager.cs
@@ -43,7 +43,13 @@ internal sealed class IndexTaskManager : IDisposable
     /// </summary>
     public void CancelCurrent()
     {
-        throw new NotImplementedException();
+        lock (_lock)
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
+            _cts?.Cancel();
+            _cts?.Dispose();
+            _cts = null;
+        }
     }
 
     /// <inheritdoc/>

--- a/src/App/IndexTaskManager.cs
+++ b/src/App/IndexTaskManager.cs
@@ -38,6 +38,14 @@ internal sealed class IndexTaskManager : IDisposable
         }
     }
 
+    /// <summary>
+    /// Cancels the currently running indexing task without starting a new one.
+    /// </summary>
+    public void CancelCurrent()
+    {
+        throw new NotImplementedException();
+    }
+
     /// <inheritdoc/>
     public void Dispose()
     {
@@ -52,6 +60,7 @@ internal sealed class IndexTaskManager : IDisposable
             // periodically and exit cooperatively.
             _cts?.Cancel();
             _cts?.Dispose();
+            _cts = null;
             _disposed = true;
         }
     }

--- a/src/App/MainWindow.cs
+++ b/src/App/MainWindow.cs
@@ -181,7 +181,25 @@ internal sealed class MainWindow : Window
     /// </summary>
     internal void StopCurrentIndexing()
     {
-        throw new NotImplementedException();
+        if (_activeIndexer is not null)
+        {
+            if (_onProgressChanged is not null)
+            {
+                _activeIndexer.ProgressChanged -= _onProgressChanged;
+            }
+
+            if (_onBuildIndexCompleted is not null)
+            {
+                _activeIndexer.BuildIndexCompleted -= _onBuildIndexCompleted;
+            }
+
+            _activeIndexer = null;
+            _onProgressChanged = null;
+            _onBuildIndexCompleted = null;
+        }
+
+        _indexTaskManager.CancelCurrent();
+        DismissIndexingProgress();
     }
 
     [SuppressMessage(

--- a/src/App/MainWindow.cs
+++ b/src/App/MainWindow.cs
@@ -60,7 +60,7 @@ internal sealed class MainWindow : Window
 
         _viewManager = new ViewManager(this, state, _modeController, app.Invoke);
 
-        _fileDialogHandler = new FileDialogHandler(app, state, _viewManager, StartIndexing);
+        _fileDialogHandler = new FileDialogHandler(app, state, _viewManager, StartIndexing, StopCurrentIndexing);
         _recipeCommandHandler = new RecipeCommandHandler(app, state, _viewManager);
 
         InitializeMenu();
@@ -173,6 +173,15 @@ internal sealed class MainWindow : Window
     {
         WireIndexerProgress(indexer);
         _indexTaskManager.Start(indexer);
+    }
+
+    /// <summary>
+    /// Stops the currently running indexing task and unwires progress events.
+    /// Must be called on the UI thread; <see cref="DismissIndexingProgress"/> modifies Terminal.Gui views.
+    /// </summary>
+    internal void StopCurrentIndexing()
+    {
+        throw new NotImplementedException();
     }
 
     [SuppressMessage(

--- a/src/App/ViewManager.cs
+++ b/src/App/ViewManager.cs
@@ -279,7 +279,15 @@ internal sealed class ViewManager : IDisposable
     internal void SwitchToJsonObjectTree(
         IReadOnlyList<(string key, ReadOnlyMemory<byte> value)> entries)
     {
-        throw new NotImplementedException();
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        ArgumentNullException.ThrowIfNull(entries);
+        var view = Views.JsonObjectTreeView.Create(entries, static () => { });
+        view.X = 0;
+        view.Y = 1;
+        view.Width = Dim.Fill();
+        view.Height = Dim.Fill() - 1;
+        SwapView(view);
+        RefreshStatusBarHints();
     }
 
     /// <summary>

--- a/src/App/ViewManager.cs
+++ b/src/App/ViewManager.cs
@@ -265,6 +265,24 @@ internal sealed class ViewManager : IDisposable
     }
 
     /// <summary>
+    /// Switches the content area to the JSON Object hierarchical tree view.
+    /// Table mode is not supported for JSON Object; a no-op callback is passed inline.
+    /// </summary>
+    /// <param name="entries">
+    /// The key-value pairs returned by <see cref="Engine.IO.JsonObject.TopLevelScanner.Scan"/>.
+    /// </param>
+    [SuppressMessage(
+        "Reliability",
+        "CA2000:Dispose objects before losing scope",
+        Justification = "Child views are owned by the container and disposed via SwapView."
+    )]
+    internal void SwitchToJsonObjectTree(
+        IReadOnlyList<(string key, ReadOnlyMemory<byte> value)> entries)
+    {
+        throw new NotImplementedException();
+    }
+
+    /// <summary>
     /// Switches the content area to the JSON Lines table view.
     /// Wraps the source with <see cref="Views.LazyTransformer"/> when the Action Stack is non-empty.
     /// Registers <see cref="AppState.OnSchemaRefined"/> for background schema updates.

--- a/src/App/ViewMode.cs
+++ b/src/App/ViewMode.cs
@@ -36,6 +36,11 @@ internal enum ViewMode
     JsonArrayTable,
 
     /// <summary>
+    /// JSON Object tree view with hierarchical key-value display.
+    /// </summary>
+    JsonObjectTree,
+
+    /// <summary>
     /// Placeholder view displaying loaded file information.
     /// Will be replaced by CsvTable, JsonTable views in future issues.
     /// </summary>

--- a/src/App/Views/JsonObjectTreeView.cs
+++ b/src/App/Views/JsonObjectTreeView.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using DataMorph.App.Views.JsonTreeNodes;
 using Terminal.Gui.Views;
 
@@ -27,7 +28,14 @@ internal sealed class JsonObjectTreeView : MorphTreeView
         IReadOnlyList<(string key, ReadOnlyMemory<byte> value)> entries,
         Action onTableModeToggle)
     {
-        throw new NotImplementedException();
+        ArgumentNullException.ThrowIfNull(entries);
+        ArgumentNullException.ThrowIfNull(onTableModeToggle);
+        var view = new JsonObjectTreeView(onTableModeToggle);
+        foreach (var (key, valueBytes) in entries)
+        {
+            view.AddObject(CreateKeyNode(key, valueBytes));
+        }
+        return view;
     }
 
     /// <summary>
@@ -43,6 +51,46 @@ internal sealed class JsonObjectTreeView : MorphTreeView
     /// <returns>A tree node representing the key-value pair.</returns>
     internal static ITreeNode CreateKeyNode(string key, ReadOnlyMemory<byte> valueBytes)
     {
-        throw new NotImplementedException();
+        string withKey(string text) => $"{key}: {text}";
+        ITreeNode invalidNode() =>
+            new JsonValueTreeNode(withKey("[Invalid JSON]")) { ValueKind = JsonValueKind.Undefined };
+
+        if (valueBytes.IsEmpty)
+        {
+            return invalidNode();
+        }
+
+        var reader = new Utf8JsonReader(valueBytes.Span);
+
+        try
+        {
+            if (!reader.Read())
+            {
+                return invalidNode();
+            }
+
+            if (reader.TokenType == JsonTokenType.StartObject)
+            {
+                var node = new JsonObjectTreeNode(valueBytes);
+                node.Text = withKey(node.Text);
+                return node;
+            }
+
+            if (reader.TokenType == JsonTokenType.StartArray)
+            {
+                var node = new JsonArrayTreeNode(valueBytes);
+                node.Text = withKey(node.Text);
+                return node;
+            }
+
+            return new JsonValueTreeNode(withKey(reader.GetPrimitiveDisplay()))
+            {
+                ValueKind = reader.TokenType.ToJsonValueKind(),
+            };
+        }
+        catch (JsonException)
+        {
+            return invalidNode();
+        }
     }
 }

--- a/src/App/Views/JsonObjectTreeView.cs
+++ b/src/App/Views/JsonObjectTreeView.cs
@@ -1,0 +1,48 @@
+using DataMorph.App.Views.JsonTreeNodes;
+using Terminal.Gui.Views;
+
+namespace DataMorph.App.Views;
+
+/// <summary>
+/// <see cref="MorphTreeView"/> subclass for JSON Object files.
+/// Creates one root-level tree node per top-level key from <see cref="Engine.IO.JsonObject.TopLevelScanner"/> results.
+/// </summary>
+internal sealed class JsonObjectTreeView : MorphTreeView
+{
+    private JsonObjectTreeView(Action onTableModeToggle)
+        : base(onTableModeToggle) { }
+
+    /// <summary>
+    /// Creates a new <see cref="JsonObjectTreeView"/> populated with root-level key nodes.
+    /// </summary>
+    /// <param name="entries">
+    /// The key-value pairs returned by <see cref="Engine.IO.JsonObject.TopLevelScanner.Scan"/>.
+    /// </param>
+    /// <param name="onTableModeToggle">
+    /// Callback invoked when the user presses 't' to toggle between tree and table mode.
+    /// JSON Object does not support table mode, so callers pass a no-op.
+    /// </param>
+    /// <returns>A populated <see cref="JsonObjectTreeView"/>.</returns>
+    internal static JsonObjectTreeView Create(
+        IReadOnlyList<(string key, ReadOnlyMemory<byte> value)> entries,
+        Action onTableModeToggle)
+    {
+        throw new NotImplementedException();
+    }
+
+    /// <summary>
+    /// Creates a single tree node for a top-level key-value pair.
+    /// Mirrors <see cref="JsonArrayRangeTreeNode.CreateElementNode"/>:
+    /// reads the first token from <paramref name="valueBytes"/> and dispatches to the
+    /// appropriate node type (<see cref="JsonObjectTreeNode"/>,
+    /// <see cref="JsonArrayTreeNode"/>, or <see cref="JsonValueTreeNode"/>),
+    /// then prepends <c>"{key}: "</c> to the node's display text.
+    /// </summary>
+    /// <param name="key">The top-level property key.</param>
+    /// <param name="valueBytes">The raw JSON bytes of the property value.</param>
+    /// <returns>A tree node representing the key-value pair.</returns>
+    internal static ITreeNode CreateKeyNode(string key, ReadOnlyMemory<byte> valueBytes)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/src/Engine/IO/JsonObject/TopLevelScanner.cs
+++ b/src/Engine/IO/JsonObject/TopLevelScanner.cs
@@ -4,12 +4,21 @@ using System.Text.Json;
 
 namespace DataMorph.Engine.IO.JsonObject;
 
-internal sealed class TopLevelScanner
+/// <summary>
+/// Scans a JSON Object file and extracts all top-level key-value pairs in a single pass.
+/// </summary>
+public sealed class TopLevelScanner
 {
     private const int InitialBufferSize = 1024 * 1024; // 1 MB
     private const int MaxBufferSize = 16 * 1024 * 1024; // 16 MB
 
-    internal static IReadOnlyList<(string key, ReadOnlyMemory<byte> value)> Scan(
+    /// <summary>
+    /// Scans the specified JSON Object file and returns all top-level key-value pairs.
+    /// </summary>
+    /// <param name="filePath">Path to the JSON Object file.</param>
+    /// <param name="ct">Cancellation token for cooperative cancellation.</param>
+    /// <returns>A read-only list of key-value pairs with raw JSON bytes for each value.</returns>
+    public static IReadOnlyList<(string key, ReadOnlyMemory<byte> value)> Scan(
         string filePath,
         CancellationToken ct = default
     )

--- a/tests/DataMorph.Tests/App/AppKeyHandlerTests.cs
+++ b/tests/DataMorph.Tests/App/AppKeyHandlerTests.cs
@@ -70,7 +70,7 @@ public sealed class AppKeyHandlerTests
         using var window = new Window();
         var modeController = new ModeController(state);
         using var viewManager = new ViewManager(window, state, modeController, action => action());
-        var fileDialogHandler = new FileDialogHandler(app, state, viewManager, _ => { });
+        var fileDialogHandler = new FileDialogHandler(app, state, viewManager, _ => { }, () => { });
         var recipeCommandHandler = new RecipeCommandHandler(app, state, viewManager);
         using var handler = new AppKeyHandler(app, state, viewManager, fileDialogHandler, recipeCommandHandler, null);
 
@@ -92,7 +92,7 @@ public sealed class AppKeyHandlerTests
         using var viewManager = new ViewManager(window, state, modeController, action => action());
         using var view = new TestTableView { Table = null };
         window.Add(view);
-        var fileDialogHandler = new FileDialogHandler(app, state, viewManager, _ => { });
+        var fileDialogHandler = new FileDialogHandler(app, state, viewManager, _ => { }, () => { });
         var recipeCommandHandler = new RecipeCommandHandler(app, state, viewManager);
         using var handler = new AppKeyHandler(app, state, viewManager, fileDialogHandler, recipeCommandHandler, null);
 
@@ -114,7 +114,7 @@ public sealed class AppKeyHandlerTests
         using var viewManager = new ViewManager(window, state, modeController, action => action());
         using var view = new TestTableView { Table = new TestTableSource() };
         window.Add(view);
-        var fileDialogHandler = new FileDialogHandler(app, state, viewManager, _ => { });
+        var fileDialogHandler = new FileDialogHandler(app, state, viewManager, _ => { }, () => { });
         var recipeCommandHandler = new RecipeCommandHandler(app, state, viewManager);
         using var handler = new AppKeyHandler(app, state, viewManager, fileDialogHandler, recipeCommandHandler, null);
 
@@ -140,7 +140,7 @@ public sealed class AppKeyHandlerTests
             GetRawColumnName = _ => "test"
         };
         window.Add(view);
-        var fileDialogHandler = new FileDialogHandler(app, state, viewManager, _ => { });
+        var fileDialogHandler = new FileDialogHandler(app, state, viewManager, _ => { }, () => { });
         var recipeCommandHandler = new RecipeCommandHandler(app, state, viewManager);
         using var handler = new AppKeyHandler(app, state, viewManager, fileDialogHandler, recipeCommandHandler, null);
 
@@ -168,7 +168,7 @@ public sealed class AppKeyHandlerTests
         };
         view.Value = null;
         window.Add(view);
-        var fileDialogHandler = new FileDialogHandler(app, state, viewManager, _ => { });
+        var fileDialogHandler = new FileDialogHandler(app, state, viewManager, _ => { }, () => { });
         var recipeCommandHandler = new RecipeCommandHandler(app, state, viewManager);
         using var handler = new AppKeyHandler(app, state, viewManager, fileDialogHandler, recipeCommandHandler, null);
 
@@ -188,7 +188,7 @@ public sealed class AppKeyHandlerTests
         using var window = new Window();
         var modeController = new ModeController(state);
         using var viewManager = new ViewManager(window, state, modeController, action => action());
-        var fileDialogHandler = new FileDialogHandler(app, state, viewManager, _ => { });
+        var fileDialogHandler = new FileDialogHandler(app, state, viewManager, _ => { }, () => { });
         var recipeCommandHandler = new RecipeCommandHandler(app, state, viewManager);
         using var handler = new AppKeyHandler(app, state, viewManager, fileDialogHandler, recipeCommandHandler, null);
 

--- a/tests/DataMorph.Tests/App/FileDialogHandlerTests.cs
+++ b/tests/DataMorph.Tests/App/FileDialogHandlerTests.cs
@@ -47,7 +47,7 @@ public sealed class FileDialogHandlerTests : IDisposable
         // Act
         Action act = () =>
         {
-            _ = new FileDialogHandler(app, state, viewManager, _ => { });
+            _ = new FileDialogHandler(app, state, viewManager, _ => { }, () => { });
         };
 
         // Assert
@@ -70,7 +70,7 @@ public sealed class FileDialogHandlerTests : IDisposable
             capturedIndexer = indexer;
             // Simulate indexing start
             Task.Run(() => indexer.BuildIndex());
-        });
+        }, () => { });
 
         // Act
         app.Begin(window);
@@ -83,6 +83,26 @@ public sealed class FileDialogHandlerTests : IDisposable
         viewManager.GetCurrentView().Should().BeOfType<JsonLinesTreeView>();
         Assert.NotNull(capturedIndexer);
         capturedIndexer.TotalRows.Should().BeGreaterThan(0);
+    }
+
+    [Fact]
+    public void HandleFileSelectedAsync_JsonObjectFile_SwitchesToJsonObjectTree()
+    {
+        // Arrange
+
+        // Act
+
+        // Assert
+    }
+
+    [Fact]
+    public void HandleFileSelectedAsync_JsonObjectFile_WhenCancelled_DoesNotSwitchView()
+    {
+        // Arrange
+
+        // Act
+
+        // Assert
     }
 
     [Fact]
@@ -101,7 +121,7 @@ public sealed class FileDialogHandlerTests : IDisposable
         {
             // Do NOT start indexing yet, so FirstCheckpointReached won't fire
             tcs.TrySetResult();
-        });
+        }, () => { });
 
         // Act
         app.Begin(window);

--- a/tests/DataMorph.Tests/App/FileDialogHandlerTests.cs
+++ b/tests/DataMorph.Tests/App/FileDialogHandlerTests.cs
@@ -10,20 +10,28 @@ namespace DataMorph.Tests.App;
 
 public sealed class FileDialogHandlerTests : IDisposable
 {
-    private readonly string _testFile;
+    private readonly string _jsonLinesFile;
+    private readonly string _jsonObjectFile;
 
     public FileDialogHandlerTests()
     {
-        _testFile = Path.ChangeExtension(Path.GetTempFileName(), ".jsonl");
-        // Add enough data to ensure we can control the flow
-        File.WriteAllText(_testFile, "{\"id\":1}\n");
+        _jsonLinesFile = Path.ChangeExtension(Path.GetTempFileName(), ".jsonl");
+        File.WriteAllText(_jsonLinesFile, "{\"id\":1}\n");
+
+        _jsonObjectFile = Path.ChangeExtension(Path.GetTempFileName(), ".json");
+        File.WriteAllText(_jsonObjectFile, "{\"name\":\"test\",\"count\":42}");
     }
 
     public void Dispose()
     {
-        if (File.Exists(_testFile))
+        if (File.Exists(_jsonLinesFile))
         {
-            File.Delete(_testFile);
+            File.Delete(_jsonLinesFile);
+        }
+
+        if (File.Exists(_jsonObjectFile))
+        {
+            File.Delete(_jsonObjectFile);
         }
     }
 
@@ -74,7 +82,7 @@ public sealed class FileDialogHandlerTests : IDisposable
 
         // Act
         app.Begin(window);
-        await handler.HandleFileSelectedAsync(_testFile);
+        await handler.HandleFileSelectedAsync(_jsonLinesFile);
         app.StopAfterFirstIteration = true;
         app.Run(window);
 
@@ -86,23 +94,53 @@ public sealed class FileDialogHandlerTests : IDisposable
     }
 
     [Fact]
-    public void HandleFileSelectedAsync_JsonObjectFile_SwitchesToJsonObjectTree()
+    public async Task HandleFileSelectedAsync_JsonObjectFile_SwitchesToJsonObjectTree()
     {
         // Arrange
+        using var app = CreateTestApp();
+        using var state = new AppState();
+        using var window = new Window();
+        var modeController = new ModeController(state);
+        using var viewManager = new ViewManager(window, state, modeController, action => action());
+
+        var handler = new FileDialogHandler(app, state, viewManager, _ => { }, () => { });
 
         // Act
+        app.Begin(window);
+        await handler.HandleFileSelectedAsync(_jsonObjectFile);
+        app.StopAfterFirstIteration = true;
+        app.Run(window);
 
         // Assert
+        state.CurrentMode.Should().Be(ViewMode.JsonObjectTree);
+        viewManager.GetCurrentView().Should().BeOfType<JsonObjectTreeView>();
     }
 
     [Fact]
-    public void HandleFileSelectedAsync_JsonObjectFile_WhenCancelled_DoesNotSwitchView()
+    public async Task HandleFileSelectedAsync_JsonObjectFile_WhenCancelled_DoesNotSwitchView()
     {
         // Arrange
+        using var app = CreateTestApp();
+        using var state = new AppState();
+        using var window = new Window();
+        var modeController = new ModeController(state);
+        using var viewManager = new ViewManager(window, state, modeController, action => action());
+        viewManager.SwitchToFileSelection();
+
+        // _stopIndexing is called after RenewCtsWithCancel(), so cancelling state.Cts
+        // here pre-cancels the token before TopLevelScanner.Scan runs.
+        var handler = new FileDialogHandler(app, state, viewManager, _ => { },
+            () => state.Cts.Cancel());
 
         // Act
+        app.Begin(window);
+        await handler.HandleFileSelectedAsync(_jsonObjectFile);
+        app.StopAfterFirstIteration = true;
+        app.Run(window);
 
         // Assert
+        state.CurrentMode.Should().NotBe(ViewMode.JsonObjectTree);
+        viewManager.GetCurrentView().Should().NotBeOfType<JsonObjectTreeView>();
     }
 
     [Fact]
@@ -125,7 +163,7 @@ public sealed class FileDialogHandlerTests : IDisposable
 
         // Act
         app.Begin(window);
-        var handleTask = handler.HandleFileSelectedAsync(_testFile);
+        var handleTask = handler.HandleFileSelectedAsync(_jsonLinesFile);
         await tcs.Task; // Wait until _onIndexerStart is called
 
         // Process any potential early Invokes

--- a/tests/DataMorph.Tests/App/FormatDetectorTests.cs
+++ b/tests/DataMorph.Tests/App/FormatDetectorTests.cs
@@ -127,4 +127,54 @@ public sealed class FormatDetectorTests : IDisposable
         result.IsFailure.Should().BeTrue();
         result.Error.Should().Contain("is empty");
     }
+
+    [Fact]
+    public void Detect_JsonObjectFile_ReturnsJsonObject()
+    {
+        // Arrange
+
+        // Act
+
+        // Assert
+    }
+
+    [Fact]
+    public void Detect_JsonObjectWithLeadingWhitespace_ReturnsJsonObject()
+    {
+        // Arrange
+
+        // Act
+
+        // Assert
+    }
+
+    [Fact]
+    public void Detect_JsonArrayWithLeadingWhitespace_ReturnsJsonArray()
+    {
+        // Arrange
+
+        // Act
+
+        // Assert
+    }
+
+    [Fact]
+    public void Detect_JsonFileWithUnknownRoot_ReturnsFailure()
+    {
+        // Arrange
+
+        // Act
+
+        // Assert
+    }
+
+    [Fact]
+    public void Detect_WhitespaceOnlyJsonFile_ReturnsFailure()
+    {
+        // Arrange
+
+        // Act
+
+        // Assert
+    }
 }

--- a/tests/DataMorph.Tests/App/FormatDetectorTests.cs
+++ b/tests/DataMorph.Tests/App/FormatDetectorTests.cs
@@ -12,6 +12,12 @@ public sealed class FormatDetectorTests : IDisposable
     private readonly string _unsupportedFilePath;
     private readonly string _emptyFilePath;
     private readonly string _nonExistentFilePath;
+    private readonly string _jsonObjectFilePath;
+    private readonly string _jsonObjectWithWhitespacePath;
+    private readonly string _jsonArrayWithWhitespacePath;
+    private readonly string _jsonUnknownRootPath;
+    private readonly string _whitespaceOnlyJsonPath;
+    private readonly string _jsonObjectWithBomPath;
 
     public FormatDetectorTests()
     {
@@ -21,11 +27,22 @@ public sealed class FormatDetectorTests : IDisposable
         _unsupportedFilePath = Path.ChangeExtension(Path.GetTempFileName(), ".txt");
         _emptyFilePath = Path.ChangeExtension(Path.GetTempFileName(), ".csv");
         _nonExistentFilePath = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.csv");
+        _jsonObjectFilePath = Path.ChangeExtension(Path.GetTempFileName(), ".json");
+        _jsonObjectWithWhitespacePath = Path.ChangeExtension(Path.GetTempFileName(), ".json");
+        _jsonArrayWithWhitespacePath = Path.ChangeExtension(Path.GetTempFileName(), ".json");
+        _jsonUnknownRootPath = Path.ChangeExtension(Path.GetTempFileName(), ".json");
+        _whitespaceOnlyJsonPath = Path.ChangeExtension(Path.GetTempFileName(), ".json");
+        _jsonObjectWithBomPath = Path.ChangeExtension(Path.GetTempFileName(), ".json");
     }
 
     public void Dispose()
     {
-        foreach (var path in new[] { _csvFilePath, _jsonlFilePath, _jsonArrayFilePath, _unsupportedFilePath, _emptyFilePath })
+        foreach (var path in new[]
+        {
+            _csvFilePath, _jsonlFilePath, _jsonArrayFilePath, _unsupportedFilePath, _emptyFilePath,
+            _jsonObjectFilePath, _jsonObjectWithWhitespacePath, _jsonArrayWithWhitespacePath,
+            _jsonUnknownRootPath, _whitespaceOnlyJsonPath, _jsonObjectWithBomPath,
+        })
         {
             if (File.Exists(path))
             {
@@ -129,52 +146,87 @@ public sealed class FormatDetectorTests : IDisposable
     }
 
     [Fact]
-    public void Detect_JsonObjectFile_ReturnsJsonObject()
+    public async Task Detect_WithJsonObjectFile_ReturnsJsonObject()
     {
         // Arrange
+        await File.WriteAllTextAsync(_jsonObjectFilePath, "{\"id\":1}");
 
         // Act
+        var result = FormatDetector.Detect(_jsonObjectFilePath);
 
         // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().Be(DataFormat.JsonObject);
     }
 
     [Fact]
-    public void Detect_JsonObjectWithLeadingWhitespace_ReturnsJsonObject()
+    public async Task Detect_WithJsonObjectFileAndLeadingWhitespace_ReturnsJsonObject()
     {
         // Arrange
+        await File.WriteAllTextAsync(_jsonObjectWithWhitespacePath, "  \n{\"id\":1}");
 
         // Act
+        var result = FormatDetector.Detect(_jsonObjectWithWhitespacePath);
 
         // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().Be(DataFormat.JsonObject);
     }
 
     [Fact]
-    public void Detect_JsonArrayWithLeadingWhitespace_ReturnsJsonArray()
+    public async Task Detect_WithJsonArrayFileAndLeadingWhitespace_ReturnsJsonArray()
     {
         // Arrange
+        await File.WriteAllTextAsync(_jsonArrayWithWhitespacePath, "  \n[1,2,3]");
 
         // Act
+        var result = FormatDetector.Detect(_jsonArrayWithWhitespacePath);
 
         // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().Be(DataFormat.JsonArray);
     }
 
     [Fact]
-    public void Detect_JsonFileWithUnknownRoot_ReturnsFailure()
+    public async Task Detect_WithJsonFileWithUnknownRoot_ReturnsFailure()
     {
         // Arrange
+        await File.WriteAllTextAsync(_jsonUnknownRootPath, "\"hello\"");
 
         // Act
+        var result = FormatDetector.Detect(_jsonUnknownRootPath);
 
         // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Contain("Unrecognized JSON root token");
     }
 
     [Fact]
-    public void Detect_WhitespaceOnlyJsonFile_ReturnsFailure()
+    public async Task Detect_WithWhitespaceOnlyJsonFile_ReturnsFailure()
     {
         // Arrange
+        await File.WriteAllTextAsync(_whitespaceOnlyJsonPath, "   \t\r\n  ");
 
         // Act
+        var result = FormatDetector.Detect(_whitespaceOnlyJsonPath);
 
         // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Contain("no valid JSON root token");
+    }
+
+    [Fact]
+    public async Task Detect_WithJsonObjectFileAndBom_ReturnsJsonObject()
+    {
+        // Arrange — write UTF-8 BOM (0xEF 0xBB 0xBF) followed by a JSON object
+        byte[] content = [0xEF, 0xBB, 0xBF, .. "{\"id\":1}"u8];
+        await File.WriteAllBytesAsync(_jsonObjectWithBomPath, content);
+
+        // Act
+        var result = FormatDetector.Detect(_jsonObjectWithBomPath);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().Be(DataFormat.JsonObject);
     }
 }

--- a/tests/DataMorph.Tests/App/IndexTaskManagerTests.cs
+++ b/tests/DataMorph.Tests/App/IndexTaskManagerTests.cs
@@ -139,40 +139,66 @@ public sealed class IndexTaskManagerTests : IDisposable
     public void CancelCurrent_WhenIdle_DoesNotThrow()
     {
         // Arrange
+        using var manager = new IndexTaskManager();
 
         // Act
+        var act = () => manager.CancelCurrent();
 
         // Assert
+        act.Should().NotThrow();
     }
 
     [Fact]
-    public void CancelCurrent_AfterStart_CancelsTask()
+    public async Task CancelCurrent_AfterStart_CancelsTask()
     {
         // Arrange
+        var indexer = new BlockingIndexer();
+        var firstCheckpoint = new TaskCompletionSource<bool>();
+        var completed = new TaskCompletionSource<bool>();
+        indexer.FirstCheckpointReached += () => firstCheckpoint.TrySetResult(true);
+        indexer.BuildIndexCompleted += () => completed.TrySetResult(true);
+
+        using var manager = new IndexTaskManager();
+        manager.Start(indexer);
+        await firstCheckpoint.Task.WaitAsync(TimeSpan.FromSeconds(5));
 
         // Act
+        manager.CancelCurrent();
 
         // Assert
+        await completed.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        indexer.WasCancelled.Should().BeTrue();
     }
 
     [Fact]
     public void CancelCurrent_CalledTwice_DoesNotThrow()
     {
         // Arrange
+        using var manager = new IndexTaskManager();
+        manager.CancelCurrent();
 
         // Act
+        var act = () => manager.CancelCurrent();
 
         // Assert
+        act.Should().NotThrow();
     }
 
     [Fact]
     public void CancelCurrent_AfterDisposal_ThrowsObjectDisposedException()
     {
         // Arrange
+        // CA2000: manager is disposed via manager.Dispose() below; suppress false positive.
+#pragma warning disable CA2000
+        var manager = new IndexTaskManager();
+#pragma warning restore CA2000
+        manager.Dispose();
 
         // Act
+        var act = () => manager.CancelCurrent();
 
         // Assert
+        act.Should().Throw<ObjectDisposedException>();
     }
 
     [Fact]

--- a/tests/DataMorph.Tests/App/IndexTaskManagerTests.cs
+++ b/tests/DataMorph.Tests/App/IndexTaskManagerTests.cs
@@ -136,6 +136,46 @@ public sealed class IndexTaskManagerTests : IDisposable
     }
 
     [Fact]
+    public void CancelCurrent_WhenIdle_DoesNotThrow()
+    {
+        // Arrange
+
+        // Act
+
+        // Assert
+    }
+
+    [Fact]
+    public void CancelCurrent_AfterStart_CancelsTask()
+    {
+        // Arrange
+
+        // Act
+
+        // Assert
+    }
+
+    [Fact]
+    public void CancelCurrent_CalledTwice_DoesNotThrow()
+    {
+        // Arrange
+
+        // Act
+
+        // Assert
+    }
+
+    [Fact]
+    public void CancelCurrent_AfterDisposal_ThrowsObjectDisposedException()
+    {
+        // Arrange
+
+        // Act
+
+        // Assert
+    }
+
+    [Fact]
     public async Task Dispose_CancelsIndexing()
     {
         // Arrange

--- a/tests/DataMorph.Tests/App/ViewManagerTests.cs
+++ b/tests/DataMorph.Tests/App/ViewManagerTests.cs
@@ -450,6 +450,36 @@ public sealed class ViewManagerTests : IDisposable
         act.Should().Throw<ObjectDisposedException>();
     }
 
+    [Fact]
+    public void SwitchToJsonObjectTree_WithValidEntries_SetsCurrentView()
+    {
+        // Arrange
+
+        // Act
+
+        // Assert
+    }
+
+    [Fact]
+    public void SwitchToJsonObjectTree_WithNullEntries_ThrowsArgumentNullException()
+    {
+        // Arrange
+
+        // Act
+
+        // Assert
+    }
+
+    [Fact]
+    public void SwitchToJsonObjectTree_AfterDisposal_ThrowsObjectDisposedException()
+    {
+        // Arrange
+
+        // Act
+
+        // Assert
+    }
+
     /// <summary>
     /// Mock IRowIndexer for testing.
     /// </summary>

--- a/tests/DataMorph.Tests/App/ViewManagerTests.cs
+++ b/tests/DataMorph.Tests/App/ViewManagerTests.cs
@@ -454,30 +454,88 @@ public sealed class ViewManagerTests : IDisposable
     public void SwitchToJsonObjectTree_WithValidEntries_SetsCurrentView()
     {
         // Arrange
+        using var app = CreateTestApp();
+        using var state = new AppState { CurrentFilePath = "test.json" };
+        using var window = new Window();
+        var modeController = new ModeController(state);
+        using var viewManager = new ViewManager(window, state, modeController, action => action());
+        IReadOnlyList<(string key, ReadOnlyMemory<byte> value)> entries =
+        [
+            ("id", System.Text.Encoding.UTF8.GetBytes("1")),
+        ];
 
         // Act
+        viewManager.SwitchToJsonObjectTree(entries);
 
         // Assert
+        viewManager.GetCurrentView().Should().BeOfType<JsonObjectTreeView>();
     }
 
     [Fact]
     public void SwitchToJsonObjectTree_WithNullEntries_ThrowsArgumentNullException()
     {
         // Arrange
+        using var app = CreateTestApp();
+        using var state = new AppState();
+        using var window = new Window();
+        var modeController = new ModeController(state);
+        using var viewManager = new ViewManager(window, state, modeController, action => action());
+        IReadOnlyList<(string key, ReadOnlyMemory<byte> value)>? nullEntries = null;
 
         // Act
+        var act = () => viewManager.SwitchToJsonObjectTree(nullEntries!);
 
         // Assert
+        act.Should().Throw<ArgumentNullException>();
     }
 
     [Fact]
     public void SwitchToJsonObjectTree_AfterDisposal_ThrowsObjectDisposedException()
     {
         // Arrange
+        using var app = CreateTestApp();
+        using var state = new AppState();
+        using var window = new Window();
+        var modeController = new ModeController(state);
+        var viewManager = new ViewManager(window, state, modeController, action => action());
+        viewManager.Dispose();
+        IReadOnlyList<(string key, ReadOnlyMemory<byte> value)> entries = [];
 
         // Act
+        var act = () => viewManager.SwitchToJsonObjectTree(entries);
 
         // Assert
+        act.Should().Throw<ObjectDisposedException>();
+    }
+
+    [Fact]
+    public void RefreshStatusBarHints_WithJsonObjectFilePath_DoesNotIncludeToggleHint()
+    {
+        // Arrange
+        var filePath = CreateTempFile(".json", "{\"id\":1}");
+        using var app = CreateTestApp();
+        using var state = new AppState { CurrentFilePath = filePath, CurrentMode = ViewMode.JsonObjectTree };
+        using var window = new Window();
+        using var statusBar = new StatusBar();
+        window.Add(statusBar);
+        var modeController = new ModeController(state);
+        using var viewManager = new ViewManager(window, state, modeController, action => action());
+        IReadOnlyList<(string key, ReadOnlyMemory<byte> value)> entries =
+        [
+            ("id", System.Text.Encoding.UTF8.GetBytes("1")),
+        ];
+        viewManager.SwitchToJsonObjectTree(entries);
+
+        // Act
+        viewManager.RefreshStatusBarHints();
+
+        // Assert
+        var currentStatusBar = viewManager.GetCurrentStatusBar();
+        currentStatusBar.Should().NotBeNull();
+        var hints = Enumerable.Select(
+            Enumerable.OfType<Shortcut>(currentStatusBar.SubViews),
+            s => s.HelpText);
+        hints.Should().NotContainMatch("*Tree/Table*");
     }
 
     /// <summary>

--- a/tests/DataMorph.Tests/App/Views/JsonObjectTreeViewTests.cs
+++ b/tests/DataMorph.Tests/App/Views/JsonObjectTreeViewTests.cs
@@ -1,3 +1,7 @@
+using System.Text;
+using AwesomeAssertions;
+using DataMorph.App.Views;
+using DataMorph.App.Views.JsonTreeNodes;
 using Terminal.Gui.App;
 using Terminal.Gui.Drivers;
 
@@ -15,22 +19,41 @@ public sealed class JsonObjectTreeViewTests : IDisposable
 
     public void Dispose() => _app.Dispose();
 
+    private static ReadOnlyMemory<byte> ToBytes(string json) =>
+        Encoding.UTF8.GetBytes(json);
+
     // --- CreateKeyNode tests ---
 
-#pragma warning disable xUnit1026
     [Theory]
     [InlineData("id", "123")]
     [InlineData("name", "\"x\"")]
     [InlineData("ok", "true")]
     [InlineData("ok", "false")]
-    [InlineData("k", "null")]
     public void CreateKeyNode_PrimitiveValue_ReturnsValueNodeWithLabel(string key, string json)
     {
         // Arrange
+        var valueBytes = ToBytes(json);
 
         // Act
+        var node = JsonObjectTreeView.CreateKeyNode(key, valueBytes);
 
         // Assert
+        node.Should().BeOfType<JsonValueTreeNode>();
+        node.Text.Should().StartWith($"{key}: ");
+    }
+
+    [Fact]
+    public void CreateKeyNode_NullValue_ReturnsValueNodeWithLabel()
+    {
+        // Arrange
+        var valueBytes = ToBytes("null");
+
+        // Act
+        var node = JsonObjectTreeView.CreateKeyNode("k", valueBytes);
+
+        // Assert
+        node.Should().BeOfType<JsonValueTreeNode>();
+        node.Text.Should().Be("k: <null>");
     }
 
     [Theory]
@@ -39,31 +62,42 @@ public sealed class JsonObjectTreeViewTests : IDisposable
     public void CreateKeyNode_InvalidInput_ReturnsValueNodeWithErrorText(string key, string rawValue)
     {
         // Arrange
+        var valueBytes = ToBytes(rawValue);
 
         // Act
+        var node = JsonObjectTreeView.CreateKeyNode(key, valueBytes);
 
         // Assert
+        node.Should().BeOfType<JsonValueTreeNode>();
+        node.Text.Should().Be($"{key}: [Invalid JSON]");
     }
-#pragma warning restore xUnit1026
 
     [Fact]
     public void CreateKeyNode_ObjectValue_ReturnsObjectNodeWithLabel()
     {
         // Arrange
+        var valueBytes = ToBytes("{\"a\":1}");
 
         // Act
+        var node = JsonObjectTreeView.CreateKeyNode("data", valueBytes);
 
         // Assert
+        node.Should().BeOfType<JsonObjectTreeNode>();
+        node.Text.Should().Be("data: {Object: 1 properties}");
     }
 
     [Fact]
     public void CreateKeyNode_ArrayValue_ReturnsArrayNodeWithLabel()
     {
         // Arrange
+        var valueBytes = ToBytes("[1,2]");
 
         // Act
+        var node = JsonObjectTreeView.CreateKeyNode("tags", valueBytes);
 
         // Assert
+        node.Should().BeOfType<JsonArrayTreeNode>();
+        node.Text.Should().Be("tags: [Array: 2 items]");
     }
 
     // --- Create tests ---
@@ -72,39 +106,56 @@ public sealed class JsonObjectTreeViewTests : IDisposable
     public void Create_WithNullEntries_ThrowsArgumentNullException()
     {
         // Arrange
+        IReadOnlyList<(string key, ReadOnlyMemory<byte> value)> nullEntries = null!;
 
         // Act
+        var act = () => JsonObjectTreeView.Create(nullEntries, () => { });
 
         // Assert
+        act.Should().Throw<ArgumentNullException>();
     }
 
     [Fact]
     public void Create_WithNullToggle_ThrowsArgumentNullException()
     {
         // Arrange
+        IReadOnlyList<(string key, ReadOnlyMemory<byte> value)> entries = [];
 
         // Act
+        var act = () => JsonObjectTreeView.Create(entries, null!);
 
         // Assert
+        act.Should().Throw<ArgumentNullException>();
     }
 
     [Fact]
     public void Create_WithEmptyEntries_AddsNoObjects()
     {
         // Arrange
+        IReadOnlyList<(string key, ReadOnlyMemory<byte> value)> entries = [];
 
         // Act
+        using var view = JsonObjectTreeView.Create(entries, () => { });
 
         // Assert
+        view.Objects.Should().BeEmpty();
     }
 
     [Fact]
     public void Create_WithEntries_AddsOneNodePerKey()
     {
         // Arrange
+        IReadOnlyList<(string key, ReadOnlyMemory<byte> value)> entries =
+        [
+            ("id", ToBytes("1")),
+            ("name", ToBytes("\"Alice\"")),
+            ("active", ToBytes("true")),
+        ];
 
         // Act
+        using var view = JsonObjectTreeView.Create(entries, () => { });
 
         // Assert
+        view.Objects.Should().HaveCount(3);
     }
 }

--- a/tests/DataMorph.Tests/App/Views/JsonObjectTreeViewTests.cs
+++ b/tests/DataMorph.Tests/App/Views/JsonObjectTreeViewTests.cs
@@ -1,0 +1,110 @@
+using Terminal.Gui.App;
+using Terminal.Gui.Drivers;
+
+namespace DataMorph.Tests.App.Views;
+
+public sealed class JsonObjectTreeViewTests : IDisposable
+{
+    private readonly IApplication _app;
+
+    public JsonObjectTreeViewTests()
+    {
+        _app = Application.Create();
+        _app.Init(DriverRegistry.Names.ANSI);
+    }
+
+    public void Dispose() => _app.Dispose();
+
+    // --- CreateKeyNode tests ---
+
+#pragma warning disable xUnit1026
+    [Theory]
+    [InlineData("id", "123")]
+    [InlineData("name", "\"x\"")]
+    [InlineData("ok", "true")]
+    [InlineData("ok", "false")]
+    [InlineData("k", "null")]
+    public void CreateKeyNode_PrimitiveValue_ReturnsValueNodeWithLabel(string key, string json)
+    {
+        // Arrange
+
+        // Act
+
+        // Assert
+    }
+
+    [Theory]
+    [InlineData("k", "not-json")]
+    [InlineData("k", "")]
+    public void CreateKeyNode_InvalidInput_ReturnsValueNodeWithErrorText(string key, string rawValue)
+    {
+        // Arrange
+
+        // Act
+
+        // Assert
+    }
+#pragma warning restore xUnit1026
+
+    [Fact]
+    public void CreateKeyNode_ObjectValue_ReturnsObjectNodeWithLabel()
+    {
+        // Arrange
+
+        // Act
+
+        // Assert
+    }
+
+    [Fact]
+    public void CreateKeyNode_ArrayValue_ReturnsArrayNodeWithLabel()
+    {
+        // Arrange
+
+        // Act
+
+        // Assert
+    }
+
+    // --- Create tests ---
+
+    [Fact]
+    public void Create_WithNullEntries_ThrowsArgumentNullException()
+    {
+        // Arrange
+
+        // Act
+
+        // Assert
+    }
+
+    [Fact]
+    public void Create_WithNullToggle_ThrowsArgumentNullException()
+    {
+        // Arrange
+
+        // Act
+
+        // Assert
+    }
+
+    [Fact]
+    public void Create_WithEmptyEntries_AddsNoObjects()
+    {
+        // Arrange
+
+        // Act
+
+        // Assert
+    }
+
+    [Fact]
+    public void Create_WithEntries_AddsOneNodePerKey()
+    {
+        // Arrange
+
+        // Act
+
+        // Assert
+    }
+}


### PR DESCRIPTION
Implement Explorer Mode for JSON Object format, displaying object keys in a tree structure with lazy-loading expansion.

## Summary
- Add `JsonObjectTreeView` with tree-based key navigation and lazy-loading
- Extend `FormatDetector` to detect JSON Object format
- Integrate explorer mode into `ViewManager`, `MainWindow`, and `FileDialogHandler`
- Add unit tests for all new components (161 new test lines)

Closes #65