### PR TITLE
perf: remove obsolete Native AOT trimmer workaround for Terminal.Gui

### DIFF
--- a/src/App/DataMorph.App.csproj
+++ b/src/App/DataMorph.App.csproj
@@ -11,10 +11,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <TrimmerRootDescriptor Include="TrimmerRoots.xml" />
-  </ItemGroup>
-
-  <ItemGroup>
     <InternalsVisibleTo Include="DataMorph.Tests" />
   </ItemGroup>
 
@@ -37,9 +33,6 @@
     <InvariantGlobalization>false</InvariantGlobalization>
     <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
     <SuppressTrimAnalysisWarnings>false</SuppressTrimAnalysisWarnings>
-
-    <!-- Suppress Terminal.Gui AOT warnings -->
-    <NoWarn>$(NoWarn);IL2026;IL3050;IL3053</NoWarn>
   </PropertyGroup>
 
 </Project>

--- a/src/App/TrimmerRoots.xml
+++ b/src/App/TrimmerRoots.xml
@@ -1,8 +1,0 @@
-<linker>
-  <!--
-    Terminal.Gui uses System.Reflection in module initializers to discover
-    [ConfigProperty]-annotated members. Preserve the entire assembly to prevent
-    NativeAOT trimming from removing required metadata.
-  -->
-  <assembly fullname="Terminal.Gui" preserve="all" />
-</linker>


### PR DESCRIPTION
## Summary

- Removed `src/App/TrimmerRoots.xml` which preserved the entire Terminal.Gui assembly from trimming
- Removed `IL2026`, `IL3050`, and `IL3053` warning suppressions from `DataMorph.App.csproj`
- Binary size reduced from ~29MB to ~20MB (~31% reduction)

## Background

Prior to Terminal.Gui v2.0.1, a `preserve="all"` trimmer root descriptor was required to prevent Native AOT from stripping reflection-dependent configuration metadata. Terminal.Gui v2.0.1 resolved this by introducing `[DynamicDependency]` attributes, making the workaround obsolete. DataMorph was already on v2.0.1+ but the old workaround remained.

## Verification

- `dotnet build`: 0 warnings, 0 errors
- `dotnet test`: 1218 passed, 0 failed

Closes #22