### PR TITLE
fix: throw ArgumentOutOfRangeException for negative targetRow in CSV and JsonLines GetCheckPoint

### DIFF
--- a/src/Engine/IO/Csv/DataRowIndexer.cs
+++ b/src/Engine/IO/Csv/DataRowIndexer.cs
@@ -125,10 +125,13 @@ public sealed class DataRowIndexer : RowIndexerBase
     /// Returns the file byte offset and row offset from that checkpoint.
     /// This method is thread-safe.
     /// </summary>
-    /// <param name="targetRow">The zero-based row index to seek to.</param>
+    /// <param name="targetRow">The zero-based row index to seek to. Must be non-negative.</param>
     /// <returns>A tuple of (byteOffset, rowOffset) where byteOffset is the file position in bytes and rowOffset is rows to advance from the checkpoint.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="targetRow"/> is negative.</exception>
     public override (long byteOffset, int rowOffset) GetCheckPoint(long targetRow)
     {
+        ArgumentOutOfRangeException.ThrowIfNegative(targetRow);
+
         lock (_lock)
         {
             if (_checkpoints.Count == 0)
@@ -139,7 +142,7 @@ public sealed class DataRowIndexer : RowIndexerBase
 
             var idealCheckPointIndex = (int)(targetRow / CheckPointInterval);
             // Clamp to the last available checkpoint (handles partial indexing or beyond-EOF requests)
-            var actualCheckPointIndex = Math.Min(idealCheckPointIndex, _checkpoints.Count - 1);
+            var actualCheckPointIndex = Math.Clamp(idealCheckPointIndex, 0, _checkpoints.Count - 1);
             var byteOffset = _checkpoints[actualCheckPointIndex];
             // Calculate the row number that the actual checkpoint represents
             var actualCheckPointRow = (long)actualCheckPointIndex * CheckPointInterval;

--- a/src/Engine/IO/JsonLines/RowIndexer.cs
+++ b/src/Engine/IO/JsonLines/RowIndexer.cs
@@ -122,18 +122,21 @@ public sealed class RowIndexer : RowIndexerBase
     /// Returns the file byte offset and row offset from that checkpoint.
     /// This method is thread-safe.
     /// </summary>
-    /// <param name="targetRow">The zero-based row index to seek to.</param>
+    /// <param name="targetRow">The zero-based row index to seek to. Must be non-negative.</param>
     /// <returns>
     /// A tuple of (byteOffset, rowOffset) where byteOffset is the file position in bytes
     /// and rowOffset is the number of rows to advance from the checkpoint.
     /// </returns>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="targetRow"/> is negative.</exception>
     public override (long byteOffset, int rowOffset) GetCheckPoint(long targetRow)
     {
+        ArgumentOutOfRangeException.ThrowIfNegative(targetRow);
+
         lock (_lock)
         {
             var idealCheckPointIndex = (int)(targetRow / CheckPointInterval);
             // Clamp to the last available checkpoint (handles partial indexing or beyond-EOF requests)
-            var actualCheckPointIndex = Math.Min(idealCheckPointIndex, _checkpoints.Count - 1);
+            var actualCheckPointIndex = Math.Clamp(idealCheckPointIndex, 0, _checkpoints.Count - 1);
             var byteOffset = _checkpoints[actualCheckPointIndex];
             // Calculate the row number that the actual checkpoint represents
             var actualCheckPointRow = (long)actualCheckPointIndex * CheckPointInterval;

--- a/tests/DataMorph.Tests/Engine/IO/Csv/DataRowIndexerTests.GetCheckPoint.cs
+++ b/tests/DataMorph.Tests/Engine/IO/Csv/DataRowIndexerTests.GetCheckPoint.cs
@@ -100,7 +100,7 @@ public sealed partial class DataRowIndexerTests
     }
 
     [Fact]
-    public void GetCheckPoint_WithNegativeRow_ReturnsFirstCheckpoint()
+    public void GetCheckPoint_WithNegativeRow_ThrowsArgumentOutOfRangeException()
     {
         // Arrange
         File.WriteAllText(_testFilePath, "col1,col2\nval1,val2\nval3,val4");
@@ -108,12 +108,10 @@ public sealed partial class DataRowIndexerTests
         indexer.BuildIndex();
 
         // Act
-        var (byteOffset, rowOffset) = indexer.GetCheckPoint(-1);
+        var act = () => indexer.GetCheckPoint(-1);
 
         // Assert
-        // Header length: "col1,col2\n" = 10 bytes
-        byteOffset.Should().Be(10); // First checkpoint after header
-        rowOffset.Should().Be(-1); // Negative offset from checkpoint
+        act.Should().Throw<ArgumentOutOfRangeException>();
     }
 
     [Fact]

--- a/tests/DataMorph.Tests/Engine/IO/JsonLines/RowIndexerTests.GetCheckPoint.cs
+++ b/tests/DataMorph.Tests/Engine/IO/JsonLines/RowIndexerTests.GetCheckPoint.cs
@@ -172,6 +172,21 @@ public sealed partial class RowIndexerTests
     }
 
     [Fact]
+    public void GetCheckPoint_WithNegativeTargetRow_ThrowsArgumentOutOfRangeException()
+    {
+        // Arrange
+        File.WriteAllText(_testFilePath, "{\"id\": 1}\n{\"id\": 2}\n{\"id\": 3}");
+        var indexer = new RowIndexer(_testFilePath);
+        indexer.BuildIndex();
+
+        // Act
+        var act = () => indexer.GetCheckPoint(-1);
+
+        // Assert
+        act.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    [Fact]
     public void GetCheckPoint_WithLargeFile_ReturnsValidCheckpoints()
     {
         // Arrange: Create file with 10,000 rows to ensure multiple checkpoints


### PR DESCRIPTION
Align `DataRowIndexer` (CSV) and `RowIndexer` (JsonLines) with the existing `JsonArray.RowIndexer` behavior by throwing `ArgumentOutOfRangeException` when `targetRow` is negative in `GetCheckPoint`. Also replaces `Math.Min` with `Math.Clamp` for consistency, and adds the corresponding XML doc `<exception>` tags.

- Updated the CSV test that previously expected negative values to pass through
- Added a new negative-value test for the JsonLines indexer

Fixes #210