### PR TITLE
chore: add blank line rules to .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -42,6 +42,12 @@ dotnet_diagnostic.CA1303.severity = none
 # IDE0005: Using directive is unnecessary.
 dotnet_diagnostic.IDE0005.severity = warning
 
+# IDE2000: Disallow multiple blank lines.
+dotnet_diagnostic.IDE2000.severity = warning
+
+# IDE2003: Require blank line after a block statement.
+dotnet_diagnostic.IDE2003.severity = warning
+
 #### Core EditorConfig Options ####
 
 # Indentation and spacing
@@ -186,6 +192,9 @@ csharp_style_prefer_primary_constructors = true:suggestion
 #### C# Formatting Rules ####
 
 # New line preferences
+dotnet_style_allow_multiple_blank_lines_experimental = false
+dotnet_style_allow_statement_immediately_after_block_experimental = false
+csharp_style_allow_blank_lines_between_consecutive_declarations = true
 csharp_new_line_before_open_brace = all
 csharp_new_line_before_else = true
 csharp_new_line_before_catch = true

--- a/src/App/AppKeyHandler.cs
+++ b/src/App/AppKeyHandler.cs
@@ -233,6 +233,7 @@ internal sealed class AppKeyHandler : IDisposable
             {
                 return;
             }
+
             current = current.SuperView;
         }
 

--- a/src/App/Cli/CsvRecordReader.cs
+++ b/src/App/Cli/CsvRecordReader.cs
@@ -40,6 +40,7 @@ internal struct CsvRecordReader : IRecordReader
         {
             return new ValueTask<bool>(false);
         }
+
         return _reader.MoveNextAsync(ct);
     }
 
@@ -55,6 +56,7 @@ internal struct CsvRecordReader : IRecordReader
         {
             return false;
         }
+
         return FilterEvaluator.EvaluateCsvFilters(_reader.Current, _filters);
     }
 
@@ -71,6 +73,7 @@ internal struct CsvRecordReader : IRecordReader
         {
             return _reader.Current[sourceIndex].Span;
         }
+
         return [];
     }
 

--- a/src/App/Cli/CsvRecordWriter.cs
+++ b/src/App/Cli/CsvRecordWriter.cs
@@ -84,6 +84,7 @@ internal struct CsvRecordWriter : IRecordWriter
         {
             return;
         }
+
         await _writer.FlushAsync(ct).ConfigureAwait(false);
     }
 

--- a/src/App/Cli/JsonLinesRecordReader.cs
+++ b/src/App/Cli/JsonLinesRecordReader.cs
@@ -57,6 +57,7 @@ internal struct JsonLinesRecordReader : IRecordReader
                 {
                     continue;
                 }
+
                 return new ValueTask<bool>(true);
             }
 

--- a/src/App/Cli/JsonLinesRecordWriter.cs
+++ b/src/App/Cli/JsonLinesRecordWriter.cs
@@ -29,6 +29,7 @@ internal partial struct JsonLinesRecordWriter : IRecordWriter
             _bufferWriter.Dispose();
             throw;
         }
+
         _disposed = false;
     }
 
@@ -99,6 +100,7 @@ internal partial struct JsonLinesRecordWriter : IRecordWriter
         {
             return;
         }
+
         await _stream.FlushAsync(ct).ConfigureAwait(false);
     }
 
@@ -176,6 +178,7 @@ internal partial struct JsonLinesRecordWriter : IRecordWriter
             await _jsonWriter.DisposeAsync().ConfigureAwait(false);
             _jsonWriter = null;
         }
+
         _bufferWriter?.Dispose();
         _bufferWriter = null;
         if (_stream is not null)
@@ -183,6 +186,7 @@ internal partial struct JsonLinesRecordWriter : IRecordWriter
             await _stream.DisposeAsync().ConfigureAwait(false);
             _stream = null;
         }
+
         _disposed = true;
     }
 }

--- a/src/App/Cli/RecordProcessor.cs
+++ b/src/App/Cli/RecordProcessor.cs
@@ -35,6 +35,7 @@ internal static class RecordProcessor
                     writer.WriteCellSpan(i, reader.GetCellSpan(i));
                     continue;
                 }
+
                 var span = transform switch
                 {
                     FillSpec fill => fill.Value.AsSpan(),

--- a/src/App/Cli/Runner.cs
+++ b/src/App/Cli/Runner.cs
@@ -50,6 +50,7 @@ internal static class Runner
                 await logger.WriteErrorAsync($"Error building output schema: {outputSchemaResult.Error}");
                 return ExitCode.Failure;
             }
+
             var outputSchema = outputSchemaResult.Value;
 
             // Dispatch to generated static monomorphization logic

--- a/src/App/MainWindow.cs
+++ b/src/App/MainWindow.cs
@@ -124,6 +124,7 @@ internal sealed class MainWindow : Window
             _state.Dispose();
             _viewManager.Dispose();
         }
+
         base.Dispose(disposing);
     }
 

--- a/src/App/Program.cs
+++ b/src/App/Program.cs
@@ -52,5 +52,6 @@ if (tuiOptions.HasAny)
 {
     mainWindow.ScheduleStartupLoad(tuiOptions);
 }
+
 app.Run(mainWindow);
 return (int)ExitCode.Success;

--- a/src/App/Schema/Csv/IncrementalSchemaScanner.cs
+++ b/src/App/Schema/Csv/IncrementalSchemaScanner.cs
@@ -134,6 +134,7 @@ internal sealed class IncrementalSchemaScanner : IncrementalSchemaScannerBase
             {
                 columnName = $"Column{i + 1}";
             }
+
             processedNames[i] = columnName;
         }
 

--- a/src/App/TuiArgumentParser.cs
+++ b/src/App/TuiArgumentParser.cs
@@ -38,6 +38,7 @@ internal static class TuiArgumentParser
                 {
                     return Results.Failure<TuiStartupOptions>(consumeResult.Error);
                 }
+
                 inputFile = args[argsIndex++];
                 continue;
             }
@@ -50,6 +51,7 @@ internal static class TuiArgumentParser
                 {
                     return Results.Failure<TuiStartupOptions>(consumeResult.Error);
                 }
+
                 recipeFile = args[argsIndex++];
                 continue;
             }

--- a/src/App/ViewManager.cs
+++ b/src/App/ViewManager.cs
@@ -442,6 +442,7 @@ internal sealed class ViewManager : IDisposable
             _container.Remove(_currentView);
             _currentView.Dispose();
         }
+
         _currentView = newView;
         _container.Add(_currentView);
         _container.SetNeedsDraw();

--- a/src/App/Views/Dialogs/OptionSelectorExtensions.cs
+++ b/src/App/Views/Dialogs/OptionSelectorExtensions.cs
@@ -40,6 +40,7 @@ internal static class OptionSelectorExtensions
                     selector.FocusedItem++;
                     key.Handled = true;
                 }
+
                 return;
             }
 
@@ -50,6 +51,7 @@ internal static class OptionSelectorExtensions
                     selector.FocusedItem--;
                     key.Handled = true;
                 }
+
                 return;
             }
         };

--- a/src/App/Views/JsonObjectTreeView.cs
+++ b/src/App/Views/JsonObjectTreeView.cs
@@ -35,6 +35,7 @@ internal sealed class JsonObjectTreeView : MorphTreeView
         {
             view.AddObject(CreateKeyNode(key, valueBytes));
         }
+
         return view;
     }
 

--- a/src/App/Views/JsonTreeNodes/JsonArrayTreeNode.cs
+++ b/src/App/Views/JsonTreeNodes/JsonArrayTreeNode.cs
@@ -84,6 +84,7 @@ internal sealed class JsonArrayTreeNode : TreeNode
             {
                 children.Add(elementNode);
             }
+
             elementIndex++;
         }
 

--- a/src/App/Views/MorphTableView.cs
+++ b/src/App/Views/MorphTableView.cs
@@ -99,6 +99,7 @@ internal abstract class MorphTableView : TableView
             {
                 tableToDispose = d;
             }
+
             Table = null;
 
             // Clear selection state (critical to prevent RenderRow crash)

--- a/src/Engine/IO/JsonLines/RowIndexer.cs
+++ b/src/Engine/IO/JsonLines/RowIndexer.cs
@@ -15,7 +15,6 @@ public sealed class RowIndexer : RowIndexerBase
     private long _totalRows;
     private long _bytesRead;
 
-
     private const int BufferSize = 1024 * 1024; // 1MB
     private const int CheckPointInterval = 1000;
 

--- a/src/Engine/IO/JsonLines/RowReader.cs
+++ b/src/Engine/IO/JsonLines/RowReader.cs
@@ -167,6 +167,7 @@ public sealed class RowReader : IDisposable
                 span = span[..^1];
             }
         }
+
         return span;
     }
 

--- a/src/Engine/IO/SlidingWindowLruCache.cs
+++ b/src/Engine/IO/SlidingWindowLruCache.cs
@@ -87,6 +87,7 @@ public abstract class SlidingWindowLruCache<TRow>
         {
             return;
         }
+
         var rows = LoadRows(byteOffset, rowOffsetToSkip, windowEnd - windowStart + 1);
         var rowsArray = rows.ToArray();
 

--- a/src/Engine/Result.cs
+++ b/src/Engine/Result.cs
@@ -33,6 +33,7 @@ public readonly struct Result : IEquatable<Result>
             {
                 throw new InvalidOperationException("Cannot access Error on a successful result.");
             }
+
             return _error.Value;
         }
     }
@@ -54,6 +55,7 @@ public readonly struct Result : IEquatable<Result>
         {
             action();
         }
+
         return this;
     }
 
@@ -68,6 +70,7 @@ public readonly struct Result : IEquatable<Result>
         {
             action(Error);
         }
+
         return this;
     }
 
@@ -146,6 +149,7 @@ public readonly struct Result<T> : IEquatable<Result<T>>
             {
                 throw new InvalidOperationException("Cannot access Value on a failed result.");
             }
+
             return _value ?? throw new UnreachableException();
         }
     }
@@ -162,6 +166,7 @@ public readonly struct Result<T> : IEquatable<Result<T>>
             {
                 throw new InvalidOperationException("Cannot access Error on a successful result.");
             }
+
             return _error.Value;
         }
     }
@@ -215,6 +220,7 @@ public readonly struct Result<T> : IEquatable<Result<T>>
         {
             action(Value);
         }
+
         return this;
     }
 
@@ -229,6 +235,7 @@ public readonly struct Result<T> : IEquatable<Result<T>>
         {
             action(Error);
         }
+
         return this;
     }
 

--- a/src/Generators/FormatDispatcherGenerator.cs
+++ b/src/Generators/FormatDispatcherGenerator.cs
@@ -39,8 +39,10 @@ public class FormatDispatcherGenerator : IIncrementalGenerator
             {
                 continue;
             }
+
             result.Add(item);
         }
+
         return result;
     }
 
@@ -50,10 +52,12 @@ public class FormatDispatcherGenerator : IIncrementalGenerator
         {
             return true;
         }
+
         if (node is ClassDeclarationSyntax classDecl && classDecl.AttributeLists.Count > 0)
         {
             return true;
         }
+
         return false;
     }
 
@@ -68,6 +72,7 @@ public class FormatDispatcherGenerator : IIncrementalGenerator
                 return formatInfo;
             }
         }
+
         return null;
     }
 
@@ -108,6 +113,7 @@ public class FormatDispatcherGenerator : IIncrementalGenerator
                 return true;
             }
         }
+
         return false;
     }
 

--- a/tests/DataMorph.Tests/App/IndexTaskManagerTests.cs
+++ b/tests/DataMorph.Tests/App/IndexTaskManagerTests.cs
@@ -258,6 +258,7 @@ public sealed class IndexTaskManagerTests : IDisposable
             {
                 Thread.Sleep(1);
             }
+
             WasCancelled = true;
             IsIndexingCompleted = true;
             BuildIndexCompleted?.Invoke();

--- a/tests/DataMorph.Tests/App/ViewManagerTests.cs
+++ b/tests/DataMorph.Tests/App/ViewManagerTests.cs
@@ -27,6 +27,7 @@ public sealed class ViewManagerTests : IDisposable
                     File.Delete(file);
                 }
             }
+
             _disposed = true;
         }
     }

--- a/tests/DataMorph.Tests/Engine/IO/JsonArray/ElementByteCacheTests.cs
+++ b/tests/DataMorph.Tests/Engine/IO/JsonArray/ElementByteCacheTests.cs
@@ -48,6 +48,7 @@ public sealed class ElementByteCacheTests : IDisposable
         {
             File.Delete(_testFilePath);
         }
+
         _disposed = true;
     }
 

--- a/tests/DataMorph.Tests/Engine/IO/JsonArray/ElementReaderTests.cs
+++ b/tests/DataMorph.Tests/Engine/IO/JsonArray/ElementReaderTests.cs
@@ -25,6 +25,7 @@ public sealed class ElementReaderTests : IDisposable
             {
                 File.Delete(_testFilePath);
             }
+
             _disposed = true;
         }
     }

--- a/tests/DataMorph.Tests/Engine/IO/MmapServiceBenchmarks.cs
+++ b/tests/DataMorph.Tests/Engine/IO/MmapServiceBenchmarks.cs
@@ -31,6 +31,7 @@ public class MmapServiceBenchmarks : IDisposable
         {
             sum += b;
         }
+
         return sum;
     }
 
@@ -44,6 +45,7 @@ public class MmapServiceBenchmarks : IDisposable
         {
             sum += b;
         }
+
         return sum;
     }
 
@@ -57,6 +59,7 @@ public class MmapServiceBenchmarks : IDisposable
         {
             sum += b;
         }
+
         return sum;
     }
 
@@ -72,8 +75,10 @@ public class MmapServiceBenchmarks : IDisposable
             {
                 sum += b;
             }
+
             return sum;
         }
+
         return 0;
     }
 


### PR DESCRIPTION
## Summary

- Add `IDE2000` (disallow multiple consecutive blank lines) and `IDE2003` (require blank line after block statement) with `warning` severity
- Add corresponding experimental options to activate the rules (`dotnet_style_allow_multiple_blank_lines_experimental = false`, `dotnet_style_allow_statement_immediately_after_block_experimental = false`)
- Add `csharp_style_allow_blank_lines_between_consecutive_declarations = true` to allow single blank lines between declarations
- Apply `dotnet format` across the codebase to fix existing violations

## Test plan

- [ ] Verify `dotnet build` passes with no warnings
- [ ] Verify `dotnet format` produces no further changes