### PR TITLE
refactor: introduce JsonRawBytes alias and fix naming for ReadOnlyMemory<byte>

### DIFF
--- a/GlobalUsings.cs
+++ b/GlobalUsings.cs
@@ -1,2 +1,3 @@
 // Global type aliases for the entire DataMorph solution
 global using CsvDataRow = System.Collections.Generic.IReadOnlyList<System.ReadOnlyMemory<char>>;
+global using JsonRawBytes = System.ReadOnlyMemory<byte>;

--- a/src/App/Cli/FilterEvaluator.cs
+++ b/src/App/Cli/FilterEvaluator.cs
@@ -42,7 +42,7 @@ internal static class FilterEvaluator
     /// <param name="filters">Filter specs to evaluate.</param>
     /// <param name="indexToNameBytes">Pre-built map of source column index to UTF-8-encoded column name bytes.</param>
     internal static bool EvaluateJsonFilters(
-        ReadOnlyMemory<byte> lineBytes,
+        JsonRawBytes lineBytes,
         IReadOnlyList<FilterSpec> filters,
         IReadOnlyDictionary<int, ReadOnlyMemory<byte>> indexToNameBytes
     )

--- a/src/App/Cli/JsonLinesRecordReader.cs
+++ b/src/App/Cli/JsonLinesRecordReader.cs
@@ -15,9 +15,9 @@ internal struct JsonLinesRecordReader : IRecordReader
     private readonly IReadOnlyList<Engine.Filtering.FilterSpec> _filters;
     private RowReader? _rowReader;
     private long _batchStart;
-    private IReadOnlyList<ReadOnlyMemory<byte>> _currentBatch;
+    private IReadOnlyList<JsonRawBytes> _currentBatch;
     private int _batchIndex;
-    private ReadOnlyMemory<byte> _currentLineBytes;
+    private JsonRawBytes _currentLineBytes;
     private bool _disposed;
 
     public JsonLinesRecordReader(RowIndexer rowIndexer, RowReader rowReader, TableSchema inputSchema, BatchOutputSchema outputSchema)

--- a/src/App/Cli/JsonLinesRecordReader.cs
+++ b/src/App/Cli/JsonLinesRecordReader.cs
@@ -72,7 +72,7 @@ internal struct JsonLinesRecordReader : IRecordReader
             var (byteOffset, rowOffset) = _rowIndexer.GetCheckPoint(_batchStart);
             var linesToRead = (int)Math.Min(1000, _rowIndexer.TotalRows - _batchStart);
 
-            _currentBatch = _rowReader.ReadLineBytes(byteOffset, rowOffset, linesToRead);
+            _currentBatch = _rowReader.ReadLines(byteOffset, rowOffset, linesToRead);
             _batchStart += linesToRead;
             _batchIndex = -1;
         }

--- a/src/App/Cli/JsonLinesRecordWriter.PooledBufferWriter.cs
+++ b/src/App/Cli/JsonLinesRecordWriter.PooledBufferWriter.cs
@@ -14,7 +14,7 @@ internal partial struct JsonLinesRecordWriter
             _buffer = ArrayPool<byte>.Shared.Rent(initialSize);
         }
 
-        public ReadOnlyMemory<byte> WrittenMemory
+        public JsonRawBytes WrittenMemory
         {
             get
             {

--- a/src/App/DrillDownRequest.cs
+++ b/src/App/DrillDownRequest.cs
@@ -14,6 +14,6 @@ namespace DataMorph.App;
 /// </param>
 internal sealed record DrillDownRequest(
     DataFormat Format,
-    ReadOnlyMemory<byte> NodeBytes,
+    JsonRawBytes NodeBytes,
     string? KeyName = null,
     long? RecordPosition = null);

--- a/src/App/DrillDownState.cs
+++ b/src/App/DrillDownState.cs
@@ -7,7 +7,7 @@ namespace DataMorph.App;
 /// Holds the in-memory state produced by the DrillDown command.
 /// </summary>
 internal sealed record DrillDownState(
-    IReadOnlyList<JsonRawBytes> ChildValueBytes,
+    IReadOnlyList<JsonRawBytes> ChildRawValues,
     TableSchema Schema,
     DataFormat Format,
     long? RecordPosition);

--- a/src/App/DrillDownState.cs
+++ b/src/App/DrillDownState.cs
@@ -7,7 +7,7 @@ namespace DataMorph.App;
 /// Holds the in-memory state produced by the DrillDown command.
 /// </summary>
 internal sealed record DrillDownState(
-    IReadOnlyList<ReadOnlyMemory<byte>> ChildValueBytes,
+    IReadOnlyList<JsonRawBytes> ChildValueBytes,
     TableSchema Schema,
     DataFormat Format,
     long? RecordPosition);

--- a/src/App/ModeController.cs
+++ b/src/App/ModeController.cs
@@ -106,7 +106,7 @@ internal sealed class ModeController
         }
 
         _state.DrillDown = new DrillDownState(
-            result.Value.childValueBytes,
+            result.Value.childRawValues,
             result.Value.schema,
             request.Format,
             request.RecordPosition);

--- a/src/App/Schema/JsonLines/IncrementalSchemaScanner.cs
+++ b/src/App/Schema/JsonLines/IncrementalSchemaScanner.cs
@@ -27,7 +27,7 @@ internal sealed class IncrementalSchemaScanner : IncrementalSchemaScannerBase
     protected override TableSchema ExecuteInitialScan()
     {
         using var reader = new RowReader(_filePath);
-        var lines = reader.ReadLineBytes(
+        var lines = reader.ReadLines(
             byteOffset: 0,
             linesToSkip: 0,
             linesToRead: InitialScanCount
@@ -53,7 +53,7 @@ internal sealed class IncrementalSchemaScanner : IncrementalSchemaScannerBase
         while (!cancellationToken.IsCancellationRequested)
         {
             using var reader = new RowReader(_filePath);
-            var lines = reader.ReadLineBytes(
+            var lines = reader.ReadLines(
                 byteOffset: 0,
                 linesToSkip: lineIndex,
                 linesToRead: BackgroundBatchSize

--- a/src/App/ViewManager.cs
+++ b/src/App/ViewManager.cs
@@ -279,7 +279,7 @@ internal sealed class ViewManager : IDisposable
         Justification = "Child views are owned by the container and disposed via SwapView."
     )]
     internal void SwitchToJsonObjectTree(
-        IReadOnlyList<(string key, ReadOnlyMemory<byte> value)> entries)
+        IReadOnlyList<(string key, JsonRawBytes value)> entries)
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
         ArgumentNullException.ThrowIfNull(entries);

--- a/src/App/Views/FocusedTableSource.cs
+++ b/src/App/Views/FocusedTableSource.cs
@@ -11,7 +11,7 @@ namespace DataMorph.App.Views;
 /// </summary>
 internal sealed class FocusedTableSource : ITableSource
 {
-    private readonly IReadOnlyList<ReadOnlyMemory<byte>> _childValueBytes;
+    private readonly IReadOnlyList<JsonRawBytes> _childValueBytes;
     private readonly TableSchema _schema;
     private readonly long? _recordPosition;
     private readonly string[] _columnNames;

--- a/src/App/Views/FocusedTableSource.cs
+++ b/src/App/Views/FocusedTableSource.cs
@@ -11,7 +11,7 @@ namespace DataMorph.App.Views;
 /// </summary>
 internal sealed class FocusedTableSource : ITableSource
 {
-    private readonly IReadOnlyList<JsonRawBytes> _childValueBytes;
+    private readonly IReadOnlyList<JsonRawBytes> _childRawValues;
     private readonly TableSchema _schema;
     private readonly long? _recordPosition;
     private readonly string[] _columnNames;
@@ -20,7 +20,7 @@ internal sealed class FocusedTableSource : ITableSource
     internal FocusedTableSource(DrillDownState drillDown)
     {
         ArgumentNullException.ThrowIfNull(drillDown);
-        _childValueBytes = drillDown.ChildValueBytes;
+        _childRawValues = drillDown.ChildRawValues;
         _schema = drillDown.Schema;
         _recordPosition = drillDown.RecordPosition;
         _columnNames = ["#", .. drillDown.Schema.Columns.Select(c => c.Name)];
@@ -28,7 +28,7 @@ internal sealed class FocusedTableSource : ITableSource
     }
 
     /// <inheritdoc/>
-    public int Rows => _childValueBytes.Count;
+    public int Rows => _childRawValues.Count;
 
     /// <inheritdoc/>
     public int Columns => _schema.ColumnCount + 1;
@@ -56,7 +56,7 @@ internal sealed class FocusedTableSource : ITableSource
                 return FormatHashColumn(row);
             }
 
-            return JsonObjectCellExtractor.ExtractCell(_childValueBytes[row].Span, _columnNamesUtf8[col - 1]);
+            return JsonObjectCellExtractor.ExtractCell(_childRawValues[row].Span, _columnNamesUtf8[col - 1]);
         }
     }
 

--- a/src/App/Views/JsonArrayTreeView.cs
+++ b/src/App/Views/JsonArrayTreeView.cs
@@ -63,7 +63,7 @@ internal sealed class JsonArrayTreeView : RangeTreeViewBase
     protected override void AddSmallFileNodes(long totalRows)
     {
         var (byteOffset, rowOffset) = Indexer.GetCheckPoint(0);
-        var elements = _reader.ReadElementBytes(byteOffset, rowOffset, (int)totalRows);
+        var elements = _reader.ReadElements(byteOffset, rowOffset, (int)totalRows);
 
         for (var i = 0; i < elements.Count; i++)
         {

--- a/src/App/Views/JsonLinesTreeView.cs
+++ b/src/App/Views/JsonLinesTreeView.cs
@@ -63,7 +63,7 @@ internal sealed class JsonLinesTreeView : RangeTreeViewBase
     protected override void AddSmallFileNodes(long totalRows)
     {
         var (byteOffset, rowOffset) = Indexer.GetCheckPoint(0);
-        var lines = _reader.ReadLineBytes(byteOffset, rowOffset, (int)totalRows);
+        var lines = _reader.ReadLines(byteOffset, rowOffset, (int)totalRows);
 
         for (var i = 0; i < lines.Count; i++)
         {

--- a/src/App/Views/JsonObjectTreeView.cs
+++ b/src/App/Views/JsonObjectTreeView.cs
@@ -25,7 +25,7 @@ internal sealed class JsonObjectTreeView : MorphTreeView
     /// </param>
     /// <returns>A populated <see cref="JsonObjectTreeView"/>.</returns>
     internal static JsonObjectTreeView Create(
-        IReadOnlyList<(string key, ReadOnlyMemory<byte> value)> entries,
+        IReadOnlyList<(string key, JsonRawBytes value)> entries,
         Action onTableModeToggle)
     {
         ArgumentNullException.ThrowIfNull(entries);
@@ -50,7 +50,7 @@ internal sealed class JsonObjectTreeView : MorphTreeView
     /// <param name="key">The top-level property key.</param>
     /// <param name="valueBytes">The raw JSON bytes of the property value.</param>
     /// <returns>A tree node representing the key-value pair.</returns>
-    internal static ITreeNode CreateKeyNode(string key, ReadOnlyMemory<byte> valueBytes)
+    internal static ITreeNode CreateKeyNode(string key, JsonRawBytes valueBytes)
     {
         var prefix = $"{key}: ";
         ITreeNode invalidNode() =>

--- a/src/App/Views/JsonRangeTreeNodes/JsonArrayRangeTreeNode.cs
+++ b/src/App/Views/JsonRangeTreeNodes/JsonArrayRangeTreeNode.cs
@@ -32,7 +32,7 @@ internal sealed class JsonArrayRangeTreeNode : RangeTreeNodeBase
     /// <summary>
     /// Creates an element node for display from raw JSON bytes.
     /// </summary>
-    internal static ITreeNode CreateElementNode(ReadOnlyMemory<byte> bytes, long index)
+    internal static ITreeNode CreateElementNode(JsonRawBytes bytes, long index)
     {
         var prefix = FormattableString.Invariant($"[{index:N0}]: ");
         ITreeNode invalidNode() =>

--- a/src/App/Views/JsonRangeTreeNodes/JsonArrayRangeTreeNode.cs
+++ b/src/App/Views/JsonRangeTreeNodes/JsonArrayRangeTreeNode.cs
@@ -84,7 +84,7 @@ internal sealed class JsonArrayRangeTreeNode : RangeTreeNodeBase
     protected override void AddDirectChildren()
     {
         var (byteOffset, rowOffset) = _indexer.GetCheckPoint(StartIndex);
-        var elements = _reader.ReadElementBytes(byteOffset, rowOffset, (int)Count);
+        var elements = _reader.ReadElements(byteOffset, rowOffset, (int)Count);
         List<ITreeNode> children = [];
 
         for (var i = 0; i < elements.Count; i++)

--- a/src/App/Views/JsonRangeTreeNodes/JsonLinesRangeTreeNode.cs
+++ b/src/App/Views/JsonRangeTreeNodes/JsonLinesRangeTreeNode.cs
@@ -85,7 +85,7 @@ internal sealed class JsonLinesRangeTreeNode : RangeTreeNodeBase
     protected override void AddDirectChildren()
     {
         var (byteOffset, rowOffset) = _indexer.GetCheckPoint(StartIndex);
-        var lines = _reader.ReadLineBytes(byteOffset, rowOffset, (int)Count);
+        var lines = _reader.ReadLines(byteOffset, rowOffset, (int)Count);
         List<ITreeNode> children = [];
 
         for (var i = 0; i < lines.Count; i++)

--- a/src/App/Views/JsonRangeTreeNodes/JsonLinesRangeTreeNode.cs
+++ b/src/App/Views/JsonRangeTreeNodes/JsonLinesRangeTreeNode.cs
@@ -33,7 +33,7 @@ internal sealed class JsonLinesRangeTreeNode : RangeTreeNodeBase
     /// Creates a line node for display from raw JSON bytes.
     /// <paramref name="lineIndex"/> is 0-based; the display label uses <c>lineNumber = lineIndex + 1</c> (1-based).
     /// </summary>
-    internal static ITreeNode CreateLineNode(ReadOnlyMemory<byte> lineBytes, long lineIndex)
+    internal static ITreeNode CreateLineNode(JsonRawBytes lineBytes, long lineIndex)
     {
         var prefix = FormattableString.Invariant($"Line {lineIndex + 1:N0}: ");
         ITreeNode invalidNode() =>

--- a/src/App/Views/JsonTreeNodes/JsonArrayTreeNode.cs
+++ b/src/App/Views/JsonTreeNodes/JsonArrayTreeNode.cs
@@ -9,7 +9,7 @@ namespace DataMorph.App.Views.JsonTreeNodes;
 /// </summary>
 internal sealed class JsonArrayTreeNode : TreeNode
 {
-    private readonly ReadOnlyMemory<byte> _rawJson;
+    private readonly JsonRawBytes _rawJson;
     private bool _childrenLoaded;
 
     /// <summary>Property name or index-label this node represents (e.g. "tags", "[0]"). Null for root-level array nodes.</summary>
@@ -19,14 +19,14 @@ internal sealed class JsonArrayTreeNode : TreeNode
     public long? RecordPosition { get; init; }
 
     /// <summary>Raw JSON bytes of this node.</summary>
-    internal ReadOnlyMemory<byte> RawJson => _rawJson;
+    internal JsonRawBytes RawJson => _rawJson;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="JsonArrayTreeNode"/> class.
     /// </summary>
     /// <param name="rawJson">The raw JSON bytes representing this array.</param>
     /// <param name="prefix">Optional prefix prepended to the display text (e.g. "Line N: ").</param>
-    public JsonArrayTreeNode(ReadOnlyMemory<byte> rawJson, string prefix = "")
+    public JsonArrayTreeNode(JsonRawBytes rawJson, string prefix = "")
     {
         _rawJson = rawJson;
         Text = $"{prefix}{FormatDisplayText()}";

--- a/src/App/Views/JsonTreeNodes/JsonObjectTreeNode.cs
+++ b/src/App/Views/JsonTreeNodes/JsonObjectTreeNode.cs
@@ -9,7 +9,7 @@ namespace DataMorph.App.Views.JsonTreeNodes;
 /// </summary>
 internal sealed class JsonObjectTreeNode : TreeNode
 {
-    private readonly ReadOnlyMemory<byte> _rawJson;
+    private readonly JsonRawBytes _rawJson;
     private bool _childrenLoaded;
 
     /// <summary>Property name this node represents. Null for root-level nodes.</summary>
@@ -26,7 +26,7 @@ internal sealed class JsonObjectTreeNode : TreeNode
     /// </summary>
     /// <param name="rawJson">The raw JSON bytes representing this object.</param>
     /// <param name="prefix">Optional prefix prepended to the display text (e.g. "Line N: ").</param>
-    public JsonObjectTreeNode(ReadOnlyMemory<byte> rawJson, string prefix = "")
+    public JsonObjectTreeNode(JsonRawBytes rawJson, string prefix = "")
     {
         _rawJson = rawJson;
         Text = $"{prefix}{FormatDisplayText()}";

--- a/src/App/Views/JsonTreeNodes/JsonTreeNodeHelper.cs
+++ b/src/App/Views/JsonTreeNodes/JsonTreeNodeHelper.cs
@@ -20,7 +20,7 @@ internal static class JsonTreeNodeHelper
     internal static ITreeNode? CreateChildNode(
         ref Utf8JsonReader reader,
         string label,
-        ReadOnlyMemory<byte> rawJson,
+        JsonRawBytes rawJson,
         long? recordPosition = null
     )
     {
@@ -69,7 +69,7 @@ internal static class JsonTreeNodeHelper
     private static JsonObjectTreeNode CreateNestedObjectNode(
         ref Utf8JsonReader reader,
         string label,
-        ReadOnlyMemory<byte> rawJson,
+        JsonRawBytes rawJson,
         long? recordPosition
     )
     {
@@ -84,7 +84,7 @@ internal static class JsonTreeNodeHelper
     private static JsonArrayTreeNode CreateNestedArrayNode(
         ref Utf8JsonReader reader,
         string label,
-        ReadOnlyMemory<byte> rawJson,
+        JsonRawBytes rawJson,
         long? recordPosition
     )
     {

--- a/src/Engine/IO/DrillDown/DrillDownSchemaExtractor.cs
+++ b/src/Engine/IO/DrillDown/DrillDownSchemaExtractor.cs
@@ -19,26 +19,26 @@ public static class DrillDownSchemaExtractor
     /// Returns <c>Failure</c> when children include non-Objects, the array is empty, or the
     /// JSON is malformed.
     /// </summary>
-    public static Result<(TableSchema schema, IReadOnlyList<ReadOnlyMemory<byte>> childValueBytes)>
-        ExtractFromNode(ReadOnlyMemory<byte> nodeBytes, DataFormat format)
+    public static Result<(TableSchema schema, IReadOnlyList<JsonRawBytes> childValueBytes)>
+        ExtractFromNode(JsonRawBytes nodeBytes, DataFormat format)
     {
         var childBytesResult = ExtractChildBytes(nodeBytes);
         if (childBytesResult.IsFailure)
         {
-            return Results.Failure<(TableSchema, IReadOnlyList<ReadOnlyMemory<byte>>)>(childBytesResult.Error);
+            return Results.Failure<(TableSchema, IReadOnlyList<JsonRawBytes>)>(childBytesResult.Error);
         }
 
         var schemaResult = BuildSchema(childBytesResult.Value, format);
         if (schemaResult.IsFailure)
         {
-            return Results.Failure<(TableSchema, IReadOnlyList<ReadOnlyMemory<byte>>)>(schemaResult.Error);
+            return Results.Failure<(TableSchema, IReadOnlyList<JsonRawBytes>)>(schemaResult.Error);
         }
 
-        return Results.Success<(TableSchema, IReadOnlyList<ReadOnlyMemory<byte>>)>(
+        return Results.Success<(TableSchema, IReadOnlyList<JsonRawBytes>)>(
             (schemaResult.Value, childBytesResult.Value));
     }
 
-    private static Result<List<ReadOnlyMemory<byte>>> ExtractChildBytes(ReadOnlyMemory<byte> nodeBytes)
+    private static Result<List<JsonRawBytes>> ExtractChildBytes(JsonRawBytes nodeBytes)
     {
         try
         {
@@ -46,18 +46,18 @@ public static class DrillDownSchemaExtractor
         }
         catch (JsonException)
         {
-            return Results.Failure<List<ReadOnlyMemory<byte>>>("Malformed JSON.");
+            return Results.Failure<List<JsonRawBytes>>("Malformed JSON.");
         }
     }
 
-    private static Result<List<ReadOnlyMemory<byte>>> ParseArrayElements(ReadOnlyMemory<byte> nodeBytes)
+    private static Result<List<JsonRawBytes>> ParseArrayElements(JsonRawBytes nodeBytes)
     {
-        List<ReadOnlyMemory<byte>> children = [];
+        List<JsonRawBytes> children = [];
         var reader = new Utf8JsonReader(nodeBytes.Span);
 
         if (!reader.Read() || reader.TokenType != JsonTokenType.StartArray)
         {
-            return Results.Failure<List<ReadOnlyMemory<byte>>>("Node is not a JSON Array.");
+            return Results.Failure<List<JsonRawBytes>>("Node is not a JSON Array.");
         }
 
         while (reader.Read())
@@ -69,7 +69,7 @@ public static class DrillDownSchemaExtractor
 
             if (reader.TokenType != JsonTokenType.StartObject)
             {
-                return Results.Failure<List<ReadOnlyMemory<byte>>>("Array contains non-Object elements.");
+                return Results.Failure<List<JsonRawBytes>>("Array contains non-Object elements.");
             }
 
             // ExtractNestedBytes reads through the object and stops at EndObject.
@@ -80,13 +80,13 @@ public static class DrillDownSchemaExtractor
 
         if (children.Count == 0)
         {
-            return Results.Failure<List<ReadOnlyMemory<byte>>>("Array is empty.");
+            return Results.Failure<List<JsonRawBytes>>("Array is empty.");
         }
 
         return Results.Success(children);
     }
 
-    private static Result<TableSchema> BuildSchema(List<ReadOnlyMemory<byte>> childValueBytes, DataFormat format)
+    private static Result<TableSchema> BuildSchema(List<JsonRawBytes> childValueBytes, DataFormat format)
     {
         List<string> keyOrder = [];
         var keySet = new HashSet<string>(StringComparer.Ordinal);

--- a/src/Engine/IO/DrillDown/DrillDownSchemaExtractor.cs
+++ b/src/Engine/IO/DrillDown/DrillDownSchemaExtractor.cs
@@ -19,7 +19,7 @@ public static class DrillDownSchemaExtractor
     /// Returns <c>Failure</c> when children include non-Objects, the array is empty, or the
     /// JSON is malformed.
     /// </summary>
-    public static Result<(TableSchema schema, IReadOnlyList<JsonRawBytes> childValueBytes)>
+    public static Result<(TableSchema schema, IReadOnlyList<JsonRawBytes> childRawValues)>
         ExtractFromNode(JsonRawBytes nodeBytes, DataFormat format)
     {
         var childBytesResult = ExtractChildBytes(nodeBytes);
@@ -86,14 +86,14 @@ public static class DrillDownSchemaExtractor
         return Results.Success(children);
     }
 
-    private static Result<TableSchema> BuildSchema(List<JsonRawBytes> childValueBytes, DataFormat format)
+    private static Result<TableSchema> BuildSchema(List<JsonRawBytes> childRawValues, DataFormat format)
     {
         List<string> keyOrder = [];
         var keySet = new HashSet<string>(StringComparer.Ordinal);
         var columnTypes = new Dictionary<string, ColumnType>(StringComparer.Ordinal);
         var keyObservedCount = new Dictionary<string, int>(StringComparer.Ordinal);
 
-        foreach (var childBytes in childValueBytes)
+        foreach (var childBytes in childRawValues)
         {
             var observedKeys = new HashSet<string>(StringComparer.Ordinal);
             ScanObject(childBytes.Span, keyOrder, keySet, columnTypes, observedKeys);
@@ -114,7 +114,7 @@ public static class DrillDownSchemaExtractor
             {
                 Name = key,
                 Type = columnTypes.GetValueOrDefault(key, ColumnType.Text),
-                IsNullable = observedCount < childValueBytes.Count,
+                IsNullable = observedCount < childRawValues.Count,
                 ColumnIndex = i,
             });
         }

--- a/src/Engine/IO/DrillDown/DrillDownSchemaExtractor.cs
+++ b/src/Engine/IO/DrillDown/DrillDownSchemaExtractor.cs
@@ -22,23 +22,23 @@ public static class DrillDownSchemaExtractor
     public static Result<(TableSchema schema, IReadOnlyList<JsonRawBytes> childRawValues)>
         ExtractFromNode(JsonRawBytes nodeBytes, DataFormat format)
     {
-        var childBytesResult = ExtractChildBytes(nodeBytes);
-        if (childBytesResult.IsFailure)
+        var childrenResult = ExtractChildren(nodeBytes);
+        if (childrenResult.IsFailure)
         {
-            return Results.Failure<(TableSchema, IReadOnlyList<JsonRawBytes>)>(childBytesResult.Error);
+            return Results.Failure<(TableSchema, IReadOnlyList<JsonRawBytes>)>(childrenResult.Error);
         }
 
-        var schemaResult = BuildSchema(childBytesResult.Value, format);
+        var schemaResult = BuildSchema(childrenResult.Value, format);
         if (schemaResult.IsFailure)
         {
             return Results.Failure<(TableSchema, IReadOnlyList<JsonRawBytes>)>(schemaResult.Error);
         }
 
         return Results.Success<(TableSchema, IReadOnlyList<JsonRawBytes>)>(
-            (schemaResult.Value, childBytesResult.Value));
+            (schemaResult.Value, childrenResult.Value));
     }
 
-    private static Result<List<JsonRawBytes>> ExtractChildBytes(JsonRawBytes nodeBytes)
+    private static Result<List<JsonRawBytes>> ExtractChildren(JsonRawBytes nodeBytes)
     {
         try
         {

--- a/src/Engine/IO/Json/JsonByteExtractor.cs
+++ b/src/Engine/IO/Json/JsonByteExtractor.cs
@@ -18,9 +18,9 @@ public static class JsonByteExtractor
     /// <param name="reader">The JSON reader positioned at a StartObject or StartArray token.</param>
     /// <param name="rawJson">The full raw JSON bytes containing the nested structure.</param>
     /// <returns>A slice of the raw bytes covering exactly the nested structure.</returns>
-    public static ReadOnlyMemory<byte> ExtractNestedBytes(
+    public static JsonRawBytes ExtractNestedBytes(
         ref Utf8JsonReader reader,
-        ReadOnlyMemory<byte> rawJson)
+        JsonRawBytes rawJson)
     {
         var startPosition = (int)reader.TokenStartIndex;
         var depth = 1;

--- a/src/Engine/IO/JsonArray/ElementByteCache.cs
+++ b/src/Engine/IO/JsonArray/ElementByteCache.cs
@@ -28,7 +28,7 @@ public sealed class ElementByteCache(
         long byteOffset,
         int rowOffsetToSkip,
         int rowsToFetch) =>
-        _reader.ReadElementBytes(byteOffset, rowOffsetToSkip, rowsToFetch);
+        _reader.ReadElements(byteOffset, rowOffsetToSkip, rowsToFetch);
 
     /// <inheritdoc/>
     public void Dispose()

--- a/src/Engine/IO/JsonArray/ElementByteCache.cs
+++ b/src/Engine/IO/JsonArray/ElementByteCache.cs
@@ -8,23 +8,23 @@ public sealed class ElementByteCache(
     IRowIndexer indexer,
     int capacity = 200,
     int prefetchWindow = 20)
-    : SlidingWindowLruCache<ReadOnlyMemory<byte>>(indexer, capacity, prefetchWindow), IDisposable
+    : SlidingWindowLruCache<JsonRawBytes>(indexer, capacity, prefetchWindow), IDisposable
 {
     private readonly ElementReader _reader = new(indexer.FilePath);
     private bool _disposed;
 
     /// <inheritdoc/>
-    public override ReadOnlyMemory<byte> GetRow(int index)
+    public override JsonRawBytes GetRow(int index)
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
         return base.GetRow(index);
     }
 
     /// <inheritdoc/>
-    protected override ReadOnlyMemory<byte> EmptyValue => ReadOnlyMemory<byte>.Empty;
+    protected override JsonRawBytes EmptyValue => JsonRawBytes.Empty;
 
     /// <inheritdoc/>
-    protected override IEnumerable<ReadOnlyMemory<byte>> LoadRows(
+    protected override IEnumerable<JsonRawBytes> LoadRows(
         long byteOffset,
         int rowOffsetToSkip,
         int rowsToFetch) =>

--- a/src/Engine/IO/JsonArray/ElementReader.cs
+++ b/src/Engine/IO/JsonArray/ElementReader.cs
@@ -45,7 +45,7 @@ public sealed class ElementReader : IDisposable
     /// <returns>Raw JSON bytes per element (NOT TreeNode — no App layer dependency).</returns>
     /// <exception cref="ArgumentOutOfRangeException">Thrown for negative <paramref name="elementsToSkip"/> or <paramref name="elementsToFetch"/>.</exception>
     /// <exception cref="ObjectDisposedException">Thrown after <see cref="Dispose"/> has been called.</exception>
-    public IReadOnlyList<ReadOnlyMemory<byte>> ReadElementBytes(
+    public IReadOnlyList<JsonRawBytes> ReadElementBytes(
         long byteOffset,
         int elementsToSkip,
         int elementsToFetch
@@ -60,7 +60,7 @@ public sealed class ElementReader : IDisposable
             return [];
         }
 
-        List<ReadOnlyMemory<byte>> result = [];
+        List<JsonRawBytes> result = [];
         result.EnsureCapacity(elementsToFetch);
 
         var buffer = ArrayPool<byte>.Shared.Rent(BufferSize);
@@ -81,7 +81,7 @@ public sealed class ElementReader : IDisposable
         long byteOffset,
         int elementsToSkip,
         int elementsToFetch,
-        List<ReadOnlyMemory<byte>> result)
+        List<JsonRawBytes> result)
     {
         var state = default(JsonReaderState);
         // bufferOriginFileOffset maps buffer[0] → virtual file offset (byteOffset - 1 for synthetic '[').
@@ -203,7 +203,7 @@ public sealed class ElementReader : IDisposable
         long endFile,
         int encountered,
         int toSkip,
-        List<ReadOnlyMemory<byte>> result)
+        List<JsonRawBytes> result)
     {
         encountered++;
         if (encountered <= toSkip)

--- a/src/Engine/IO/JsonArray/ElementReader.cs
+++ b/src/Engine/IO/JsonArray/ElementReader.cs
@@ -45,7 +45,7 @@ public sealed class ElementReader : IDisposable
     /// <returns>Raw JSON bytes per element (NOT TreeNode — no App layer dependency).</returns>
     /// <exception cref="ArgumentOutOfRangeException">Thrown for negative <paramref name="elementsToSkip"/> or <paramref name="elementsToFetch"/>.</exception>
     /// <exception cref="ObjectDisposedException">Thrown after <see cref="Dispose"/> has been called.</exception>
-    public IReadOnlyList<JsonRawBytes> ReadElementBytes(
+    public IReadOnlyList<JsonRawBytes> ReadElements(
         long byteOffset,
         int elementsToSkip,
         int elementsToFetch
@@ -66,7 +66,7 @@ public sealed class ElementReader : IDisposable
         var buffer = ArrayPool<byte>.Shared.Rent(BufferSize);
         try
         {
-            ReadElements(buffer, byteOffset, elementsToSkip, elementsToFetch, result);
+            FetchElements(buffer, byteOffset, elementsToSkip, elementsToFetch, result);
         }
         finally
         {
@@ -76,7 +76,7 @@ public sealed class ElementReader : IDisposable
         return result;
     }
 
-    private void ReadElements(
+    private void FetchElements(
         byte[] buffer,
         long byteOffset,
         int elementsToSkip,

--- a/src/Engine/IO/JsonLines/FilterRowIndexer.cs
+++ b/src/Engine/IO/JsonLines/FilterRowIndexer.cs
@@ -91,7 +91,7 @@ public sealed class FilterRowIndexer : IFilterRowIndexer
 
             var rowsToRead = Math.Min(batchSize, totalRows - processed);
             var (byteOffset, rowOffset) = _indexer.GetCheckPoint(sourceRow);
-            var lines = reader.ReadLineBytes(byteOffset, rowOffset, rowsToRead);
+            var lines = reader.ReadLines(byteOffset, rowOffset, rowsToRead);
 
             if (lines.Count == 0)
             {

--- a/src/Engine/IO/JsonLines/RowByteCache.cs
+++ b/src/Engine/IO/JsonLines/RowByteCache.cs
@@ -28,7 +28,7 @@ public sealed class RowByteCache(
         long byteOffset,
         int rowOffsetToSkip,
         int rowsToFetch) =>
-        _reader.ReadLineBytes(byteOffset, rowOffsetToSkip, rowsToFetch);
+        _reader.ReadLines(byteOffset, rowOffsetToSkip, rowsToFetch);
 
     /// <inheritdoc/>
     public void Dispose()

--- a/src/Engine/IO/JsonLines/RowByteCache.cs
+++ b/src/Engine/IO/JsonLines/RowByteCache.cs
@@ -8,23 +8,23 @@ public sealed class RowByteCache(
     IRowIndexer indexer,
     int capacity = 200,
     int prefetchWindow = 20)
-    : SlidingWindowLruCache<ReadOnlyMemory<byte>>(indexer, capacity, prefetchWindow), IDisposable
+    : SlidingWindowLruCache<JsonRawBytes>(indexer, capacity, prefetchWindow), IDisposable
 {
     private readonly RowReader _reader = new(indexer.FilePath);
     private bool _disposed;
 
     /// <inheritdoc/>
-    protected override ReadOnlyMemory<byte> EmptyValue => ReadOnlyMemory<byte>.Empty;
+    protected override JsonRawBytes EmptyValue => JsonRawBytes.Empty;
 
     /// <inheritdoc/>
-    public override ReadOnlyMemory<byte> GetRow(int index)
+    public override JsonRawBytes GetRow(int index)
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
         return base.GetRow(index);
     }
 
     /// <inheritdoc/>
-    protected override IEnumerable<ReadOnlyMemory<byte>> LoadRows(
+    protected override IEnumerable<JsonRawBytes> LoadRows(
         long byteOffset,
         int rowOffsetToSkip,
         int rowsToFetch) =>

--- a/src/Engine/IO/JsonLines/RowReader.cs
+++ b/src/Engine/IO/JsonLines/RowReader.cs
@@ -40,7 +40,7 @@ public sealed class RowReader : IDisposable
     /// <returns>A list of raw JSON line bytes.</returns>
     /// <exception cref="ObjectDisposedException">The reader has been disposed.</exception>
     /// <exception cref="NotSupportedException">The JSON line exceeds the supported size limit.</exception>
-    public IReadOnlyList<JsonRawBytes> ReadLineBytes(
+    public IReadOnlyList<JsonRawBytes> ReadLines(
         long byteOffset,
         int linesToSkip,
         int linesToRead

--- a/src/Engine/IO/JsonLines/RowReader.cs
+++ b/src/Engine/IO/JsonLines/RowReader.cs
@@ -40,7 +40,7 @@ public sealed class RowReader : IDisposable
     /// <returns>A list of raw JSON line bytes.</returns>
     /// <exception cref="ObjectDisposedException">The reader has been disposed.</exception>
     /// <exception cref="NotSupportedException">The JSON line exceeds the supported size limit.</exception>
-    public IReadOnlyList<ReadOnlyMemory<byte>> ReadLineBytes(
+    public IReadOnlyList<JsonRawBytes> ReadLineBytes(
         long byteOffset,
         int linesToSkip,
         int linesToRead
@@ -48,7 +48,7 @@ public sealed class RowReader : IDisposable
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
 
-        List<ReadOnlyMemory<byte>> result = [];
+        List<JsonRawBytes> result = [];
         result.EnsureCapacity(linesToRead);
         var currentOffset = byteOffset;
 
@@ -171,7 +171,7 @@ public sealed class RowReader : IDisposable
         return span;
     }
 
-    private void HandleIncompleteLineAtEof(long offset, long incompleteLineBytes, List<ReadOnlyMemory<byte>> result)
+    private void HandleIncompleteLineAtEof(long offset, long incompleteLineBytes, List<JsonRawBytes> result)
     {
         if (incompleteLineBytes <= 0)
         {

--- a/src/Engine/IO/JsonLines/SchemaScanner.cs
+++ b/src/Engine/IO/JsonLines/SchemaScanner.cs
@@ -18,7 +18,7 @@ public static class SchemaScanner
     /// <param name="initialScanCount">Maximum number of lines to scan (default: 200).</param>
     /// <returns>Result containing the inferred TableSchema, or an error message.</returns>
     public static Result<TableSchema> ScanSchema(
-        IReadOnlyList<ReadOnlyMemory<byte>> lineBytes,
+        IReadOnlyList<JsonRawBytes> lineBytes,
         int initialScanCount = 200
     )
     {

--- a/src/Engine/IO/JsonLines/SchemaScanner.cs
+++ b/src/Engine/IO/JsonLines/SchemaScanner.cs
@@ -14,11 +14,11 @@ public static class SchemaScanner
     /// Scans the first N lines of a JSON Lines file and returns an inferred schema.
     /// Seeds the schema from the first valid line, then refines with remaining lines.
     /// </summary>
-    /// <param name="lineBytes">Raw byte buffers of individual lines.</param>
+    /// <param name="rawLines">Raw byte buffers of individual lines.</param>
     /// <param name="initialScanCount">Maximum number of lines to scan (default: 200).</param>
     /// <returns>Result containing the inferred TableSchema, or an error message.</returns>
     public static Result<TableSchema> ScanSchema(
-        IReadOnlyList<JsonRawBytes> lineBytes,
+        IReadOnlyList<JsonRawBytes> rawLines,
         int initialScanCount = 200
     )
     {
@@ -30,21 +30,21 @@ public static class SchemaScanner
             );
         }
 
-        ArgumentNullException.ThrowIfNull(lineBytes);
+        ArgumentNullException.ThrowIfNull(rawLines);
 
-        if (lineBytes.Count == 0)
+        if (rawLines.Count == 0)
         {
             return Results.Failure<TableSchema>("No lines provided for schema inference.");
         }
 
-        var linesToProcess = System.Math.Min(lineBytes.Count, initialScanCount);
+        var linesToProcess = System.Math.Min(rawLines.Count, initialScanCount);
 
         // Find first valid line to seed the initial schema
         TableSchema? schema = null;
         var startIndex = 0;
         for (var i = 0; i < linesToProcess; i++)
         {
-            var seedResult = TrySeedSchema(lineBytes[i].Span);
+            var seedResult = TrySeedSchema(rawLines[i].Span);
             if (seedResult.IsFailure)
             {
                 continue;
@@ -65,7 +65,7 @@ public static class SchemaScanner
         // Refine schema with remaining lines
         for (var i = startIndex; i < linesToProcess; i++)
         {
-            var refineResult = RefineSchema(schema, lineBytes[i].Span);
+            var refineResult = RefineSchema(schema, rawLines[i].Span);
             if (refineResult.IsFailure)
             {
                 continue;

--- a/src/Engine/IO/JsonObject/TopLevelScanner.cs
+++ b/src/Engine/IO/JsonObject/TopLevelScanner.cs
@@ -18,7 +18,7 @@ public sealed class TopLevelScanner
     /// <param name="filePath">Path to the JSON Object file.</param>
     /// <param name="ct">Cancellation token for cooperative cancellation.</param>
     /// <returns>A read-only list of key-value pairs with raw JSON bytes for each value.</returns>
-    public static IReadOnlyList<(string key, ReadOnlyMemory<byte> value)> Scan(
+    public static IReadOnlyList<(string key, JsonRawBytes value)> Scan(
         string filePath,
         CancellationToken ct = default
     )
@@ -38,7 +38,7 @@ public sealed class TopLevelScanner
             var fileSize = RandomAccess.GetLength(handle);
             var state = new JsonScanState(fileSize);
             var rootCompleted = false;
-            List<(string key, ReadOnlyMemory<byte> value)> result = [];
+            List<(string key, JsonRawBytes value)> result = [];
             var keyIndex = new Dictionary<string, int>();
 
             while (true)
@@ -109,7 +109,7 @@ public sealed class TopLevelScanner
         ref Utf8JsonReader reader,
         ref JsonScanState state,
         byte[] buffer,
-        List<(string key, ReadOnlyMemory<byte> value)> result,
+        List<(string key, JsonRawBytes value)> result,
         Dictionary<string, int> keyIndex
     )
     {
@@ -183,7 +183,7 @@ public sealed class TopLevelScanner
         byte[] buffer,
         int bufferOffset,
         int length,
-        List<(string key, ReadOnlyMemory<byte> value)> result,
+        List<(string key, JsonRawBytes value)> result,
         Dictionary<string, int> keyIndex
     )
     {
@@ -195,7 +195,7 @@ public sealed class TopLevelScanner
             dstOffset: 0,
             count: length
         );
-        var mem = new ReadOnlyMemory<byte>(copy);
+        var mem = new JsonRawBytes(copy);
 
         if (keyIndex.TryGetValue(key, out var idx))
         {

--- a/tests/DataMorph.Tests/App/FileDialogHandlerTests.cs
+++ b/tests/DataMorph.Tests/App/FileDialogHandlerTests.cs
@@ -200,7 +200,7 @@ public sealed class FileDialogHandlerTests : IDisposable
             Columns = [new ColumnSchema { Name = "col1", Type = ColumnType.Text }]
         };
         state.DrillDown = new DrillDownState(
-            [ReadOnlyMemory<byte>.Empty],
+            [JsonRawBytes.Empty],
             schema,
             DataFormat.JsonObject,
             RecordPosition: 1);

--- a/tests/DataMorph.Tests/App/ViewManagerTests.cs
+++ b/tests/DataMorph.Tests/App/ViewManagerTests.cs
@@ -462,7 +462,7 @@ public sealed class ViewManagerTests : IDisposable
         using var window = new Window();
         var modeController = new ModeController(state);
         using var viewManager = new ViewManager(window, state, modeController, action => action());
-        IReadOnlyList<(string key, ReadOnlyMemory<byte> value)> entries =
+        IReadOnlyList<(string key, JsonRawBytes value)> entries =
         [
             ("id", System.Text.Encoding.UTF8.GetBytes("1")),
         ];
@@ -483,7 +483,7 @@ public sealed class ViewManagerTests : IDisposable
         using var window = new Window();
         var modeController = new ModeController(state);
         using var viewManager = new ViewManager(window, state, modeController, action => action());
-        IReadOnlyList<(string key, ReadOnlyMemory<byte> value)>? nullEntries = null;
+        IReadOnlyList<(string key, JsonRawBytes value)>? nullEntries = null;
 
         // Act
         var act = () => viewManager.SwitchToJsonObjectTree(nullEntries!);
@@ -502,7 +502,7 @@ public sealed class ViewManagerTests : IDisposable
         var modeController = new ModeController(state);
         var viewManager = new ViewManager(window, state, modeController, action => action());
         viewManager.Dispose();
-        IReadOnlyList<(string key, ReadOnlyMemory<byte> value)> entries = [];
+        IReadOnlyList<(string key, JsonRawBytes value)> entries = [];
 
         // Act
         var act = () => viewManager.SwitchToJsonObjectTree(entries);
@@ -523,7 +523,7 @@ public sealed class ViewManagerTests : IDisposable
         window.Add(statusBar);
         var modeController = new ModeController(state);
         using var viewManager = new ViewManager(window, state, modeController, action => action());
-        IReadOnlyList<(string key, ReadOnlyMemory<byte> value)> entries =
+        IReadOnlyList<(string key, JsonRawBytes value)> entries =
         [
             ("id", System.Text.Encoding.UTF8.GetBytes("1")),
         ];

--- a/tests/DataMorph.Tests/App/Views/FocusedTableSourceTests.cs
+++ b/tests/DataMorph.Tests/App/Views/FocusedTableSourceTests.cs
@@ -8,7 +8,7 @@ namespace DataMorph.Tests.App.Views;
 
 public sealed class FocusedTableSourceTests
 {
-    private static readonly IReadOnlyList<ReadOnlyMemory<byte>> DefaultChildBytes =
+    private static readonly IReadOnlyList<JsonRawBytes> DefaultChildBytes =
     [
         "{\"name\": \"Alice\", \"age\": 30}"u8.ToArray(),
         "{\"name\": \"Bob\", \"age\": 25}"u8.ToArray(),
@@ -25,7 +25,7 @@ public sealed class FocusedTableSourceTests
     };
 
     private static DrillDownState CreateState(
-        IReadOnlyList<ReadOnlyMemory<byte>>? childValueBytes = null,
+        IReadOnlyList<JsonRawBytes>? childValueBytes = null,
         TableSchema? schema = null,
         DataFormat format = DataFormat.JsonLines,
         long? recordPosition = 22) =>

--- a/tests/DataMorph.Tests/App/Views/FocusedTableSourceTests.cs
+++ b/tests/DataMorph.Tests/App/Views/FocusedTableSourceTests.cs
@@ -8,7 +8,7 @@ namespace DataMorph.Tests.App.Views;
 
 public sealed class FocusedTableSourceTests
 {
-    private static readonly IReadOnlyList<JsonRawBytes> DefaultChildBytes =
+    private static readonly IReadOnlyList<JsonRawBytes> DefaultChildRawValues =
     [
         "{\"name\": \"Alice\", \"age\": 30}"u8.ToArray(),
         "{\"name\": \"Bob\", \"age\": 25}"u8.ToArray(),
@@ -25,11 +25,11 @@ public sealed class FocusedTableSourceTests
     };
 
     private static DrillDownState CreateState(
-        IReadOnlyList<JsonRawBytes>? childValueBytes = null,
+        IReadOnlyList<JsonRawBytes>? childRawValues = null,
         TableSchema? schema = null,
         DataFormat format = DataFormat.JsonLines,
         long? recordPosition = 22) =>
-        new(childValueBytes ?? DefaultChildBytes, schema ?? DefaultSchema, format, recordPosition);
+        new(childRawValues ?? DefaultChildRawValues, schema ?? DefaultSchema, format, recordPosition);
 
     [Fact]
     public void Constructor_NullDrillDownState_ThrowsArgumentNullException()

--- a/tests/DataMorph.Tests/App/Views/JsonArrayTreeViewTests.Create.cs
+++ b/tests/DataMorph.Tests/App/Views/JsonArrayTreeViewTests.Create.cs
@@ -166,7 +166,7 @@ public sealed partial class JsonArrayTreeViewTests
         var filePath = CreateTempFile("[1, 2]");
         var realIndexer = new RowIndexer(filePath);
         realIndexer.BuildIndex();
-        // Stub says TotalRows=3 but file only has 2 elements → ReadElementBytes returns only 2 elements
+        // Stub says TotalRows=3 but file only has 2 elements → ReadElements returns only 2 elements
         var stubIndexer = new StubRowIndexer(realIndexer, 3);
 
         // Act

--- a/tests/DataMorph.Tests/App/Views/JsonObjectTreeViewTests.cs
+++ b/tests/DataMorph.Tests/App/Views/JsonObjectTreeViewTests.cs
@@ -21,7 +21,7 @@ public sealed class JsonObjectTreeViewTests : IDisposable
 
     public void Dispose() => _app.Dispose();
 
-    private static ReadOnlyMemory<byte> ToBytes(string json) =>
+    private static JsonRawBytes ToBytes(string json) =>
         Encoding.UTF8.GetBytes(json);
 
     // --- CreateKeyNode tests ---
@@ -108,7 +108,7 @@ public sealed class JsonObjectTreeViewTests : IDisposable
     public void Create_WithNullEntries_ThrowsArgumentNullException()
     {
         // Arrange
-        IReadOnlyList<(string key, ReadOnlyMemory<byte> value)> nullEntries = null!;
+        IReadOnlyList<(string key, JsonRawBytes value)> nullEntries = null!;
 
         // Act
         var act = () => JsonObjectTreeView.Create(nullEntries, () => { });
@@ -121,7 +121,7 @@ public sealed class JsonObjectTreeViewTests : IDisposable
     public void Create_WithNullToggle_ThrowsArgumentNullException()
     {
         // Arrange
-        IReadOnlyList<(string key, ReadOnlyMemory<byte> value)> entries = [];
+        IReadOnlyList<(string key, JsonRawBytes value)> entries = [];
 
         // Act
         var act = () => JsonObjectTreeView.Create(entries, null!);
@@ -134,7 +134,7 @@ public sealed class JsonObjectTreeViewTests : IDisposable
     public void Create_WithEmptyEntries_AddsNoObjects()
     {
         // Arrange
-        IReadOnlyList<(string key, ReadOnlyMemory<byte> value)> entries = [];
+        IReadOnlyList<(string key, JsonRawBytes value)> entries = [];
 
         // Act
         using var view = JsonObjectTreeView.Create(entries, () => { });
@@ -147,7 +147,7 @@ public sealed class JsonObjectTreeViewTests : IDisposable
     public void Create_WithEntries_AddsOneNodePerKey()
     {
         // Arrange
-        IReadOnlyList<(string key, ReadOnlyMemory<byte> value)> entries =
+        IReadOnlyList<(string key, JsonRawBytes value)> entries =
         [
             ("id", ToBytes("1")),
             ("name", ToBytes("\"Alice\"")),

--- a/tests/DataMorph.Tests/App/Views/JsonRangeTreeNodes/JsonArrayRangeTreeNodeTests.cs
+++ b/tests/DataMorph.Tests/App/Views/JsonRangeTreeNodes/JsonArrayRangeTreeNodeTests.cs
@@ -234,7 +234,7 @@ public sealed class JsonArrayRangeTreeNodeTests : IDisposable
     public void CreateElementNode_WithEmptyBytes_CreatesJsonValueTreeNodeWithErrorText()
     {
         // Arrange
-        var emptyBytes = ReadOnlyMemory<byte>.Empty;
+        var emptyBytes = JsonRawBytes.Empty;
 
         // Act
         var elementNode = JsonArrayRangeTreeNode.CreateElementNode(emptyBytes, 0L);
@@ -248,7 +248,7 @@ public sealed class JsonArrayRangeTreeNodeTests : IDisposable
     public void CreateElementNode_WithMalformedJson_CreatesJsonValueTreeNodeWithErrorText()
     {
         // Arrange
-        var malformed = new ReadOnlyMemory<byte>(System.Text.Encoding.UTF8.GetBytes("{abc"));
+        var malformed = new JsonRawBytes(System.Text.Encoding.UTF8.GetBytes("{abc"));
 
         // Act
         var node = JsonArrayRangeTreeNode.CreateElementNode(malformed, 5L);
@@ -263,7 +263,7 @@ public sealed class JsonArrayRangeTreeNodeTests : IDisposable
     public void CreateElementNode_WithTruncatedObject_CreatesJsonValueTreeNodeWithErrorText()
     {
         // Arrange
-        var truncated = new ReadOnlyMemory<byte>(System.Text.Encoding.UTF8.GetBytes("{"));
+        var truncated = new JsonRawBytes(System.Text.Encoding.UTF8.GetBytes("{"));
 
         // Act
         var node = JsonArrayRangeTreeNode.CreateElementNode(truncated, 3L);
@@ -463,7 +463,7 @@ public sealed class JsonArrayRangeTreeNodeTests : IDisposable
     public void CreateElementNode_ObjectToken_SetsRecordPositionAsZeroBased()
     {
         // Arrange
-        var bytes = new ReadOnlyMemory<byte>(Encoding.UTF8.GetBytes("{\"a\":1}"));
+        var bytes = new JsonRawBytes(Encoding.UTF8.GetBytes("{\"a\":1}"));
 
         // Act
         var node = JsonArrayRangeTreeNode.CreateElementNode(bytes, 3L);
@@ -477,7 +477,7 @@ public sealed class JsonArrayRangeTreeNodeTests : IDisposable
     public void CreateElementNode_ArrayToken_SetsRecordPositionAsZeroBased()
     {
         // Arrange
-        var bytes = new ReadOnlyMemory<byte>(Encoding.UTF8.GetBytes("[1,2]"));
+        var bytes = new JsonRawBytes(Encoding.UTF8.GetBytes("[1,2]"));
 
         // Act
         var node = JsonArrayRangeTreeNode.CreateElementNode(bytes, 3L);

--- a/tests/DataMorph.Tests/App/Views/JsonRangeTreeNodes/JsonArrayRangeTreeNodeTests.cs
+++ b/tests/DataMorph.Tests/App/Views/JsonRangeTreeNodes/JsonArrayRangeTreeNodeTests.cs
@@ -295,7 +295,7 @@ public sealed class JsonArrayRangeTreeNodeTests : IDisposable
     [Fact]
     public void EnsureChildrenLoaded_CountExceedsAvailableElements_ReturnsOnlyAvailableChildren()
     {
-        // Arrange — file has 2 elements, but node requests count=3; ReadElementBytes returns only 2
+        // Arrange — file has 2 elements, but node requests count=3; ReadElements returns only 2
         var indexer = CreateAndBuildIndexer("[1, 2]");
         using var reader = new ElementReader(indexer.FilePath);
         var node = new JsonArrayRangeTreeNode(indexer, reader, 0L, 3L);

--- a/tests/DataMorph.Tests/App/Views/JsonRangeTreeNodes/JsonLinesRangeTreeNodeTests.cs
+++ b/tests/DataMorph.Tests/App/Views/JsonRangeTreeNodes/JsonLinesRangeTreeNodeTests.cs
@@ -178,7 +178,7 @@ public sealed class JsonLinesRangeTreeNodeTests : IDisposable
     public void CreateLineNode_WithEmptyBytes_CreatesInvalidNode()
     {
         // Arrange
-        var emptyBytes = ReadOnlyMemory<byte>.Empty;
+        var emptyBytes = JsonRawBytes.Empty;
 
         // Act
         var node = JsonLinesRangeTreeNode.CreateLineNode(emptyBytes, 0L);
@@ -192,7 +192,7 @@ public sealed class JsonLinesRangeTreeNodeTests : IDisposable
     public void CreateLineNode_WithMalformedJson_CreatesInvalidNode()
     {
         // Arrange
-        var malformed = new ReadOnlyMemory<byte>("{abc"u8.ToArray());
+        var malformed = new JsonRawBytes("{abc"u8.ToArray());
 
         // Act
         var node = JsonLinesRangeTreeNode.CreateLineNode(malformed, 5L);
@@ -211,7 +211,7 @@ public sealed class JsonLinesRangeTreeNodeTests : IDisposable
         string json, Type expectedType, string expectedLabel)
     {
         // Arrange
-        var bytes = new ReadOnlyMemory<byte>(System.Text.Encoding.UTF8.GetBytes(json));
+        var bytes = new JsonRawBytes(System.Text.Encoding.UTF8.GetBytes(json));
 
         // Act
         var node = JsonLinesRangeTreeNode.CreateLineNode(bytes, 0L);
@@ -360,7 +360,7 @@ public sealed class JsonLinesRangeTreeNodeTests : IDisposable
     public void CreateLineNode_WithNewlineOnlyBytes_CreatesInvalidNode()
     {
         // Arrange — a bare newline (blank line content) is not valid JSON
-        var bytes = new ReadOnlyMemory<byte>("\n"u8.ToArray());
+        var bytes = new JsonRawBytes("\n"u8.ToArray());
 
         // Act
         var node = JsonLinesRangeTreeNode.CreateLineNode(bytes, 0L);
@@ -374,7 +374,7 @@ public sealed class JsonLinesRangeTreeNodeTests : IDisposable
     public void CreateLineNode_WithUtf8Bom_CreatesInvalidNode()
     {
         // Arrange — BOM (EF BB BF) prefix is not a valid JSON token
-        var bytes = new ReadOnlyMemory<byte>([0xEF, 0xBB, 0xBF, .. "{\"a\":1}"u8]);
+        var bytes = new JsonRawBytes([0xEF, 0xBB, 0xBF, .. "{\"a\":1}"u8]);
 
         // Act
         var node = JsonLinesRangeTreeNode.CreateLineNode(bytes, 0L);
@@ -389,7 +389,7 @@ public sealed class JsonLinesRangeTreeNodeTests : IDisposable
     public void CreateLineNode_ObjectToken_SetsRecordPositionAsOneBased()
     {
         // Arrange
-        var bytes = new ReadOnlyMemory<byte>(Encoding.UTF8.GetBytes("{\"a\":1}"));
+        var bytes = new JsonRawBytes(Encoding.UTF8.GetBytes("{\"a\":1}"));
 
         // Act
         var node = JsonLinesRangeTreeNode.CreateLineNode(bytes, 3L);
@@ -403,7 +403,7 @@ public sealed class JsonLinesRangeTreeNodeTests : IDisposable
     public void CreateLineNode_ArrayToken_SetsRecordPositionAsOneBased()
     {
         // Arrange
-        var bytes = new ReadOnlyMemory<byte>(Encoding.UTF8.GetBytes("[1,2]"));
+        var bytes = new JsonRawBytes(Encoding.UTF8.GetBytes("[1,2]"));
 
         // Act
         var node = JsonLinesRangeTreeNode.CreateLineNode(bytes, 3L);

--- a/tests/DataMorph.Tests/App/Views/JsonRangeTreeNodes/JsonLinesRangeTreeNodeTests.cs
+++ b/tests/DataMorph.Tests/App/Views/JsonRangeTreeNodes/JsonLinesRangeTreeNodeTests.cs
@@ -161,7 +161,7 @@ public sealed class JsonLinesRangeTreeNodeTests : IDisposable
     [Fact]
     public void EnsureChildrenLoaded_CountExceedsAvailableLines_ReturnsOnlyAvailableChildren()
     {
-        // Arrange — file has 2 lines, but node requests count=3; ReadLineBytes returns only 2
+        // Arrange — file has 2 lines, but node requests count=3; ReadLines returns only 2
         var indexer = CreateAndBuildIndexer("{\"a\":1}\n{\"b\":2}");
         using var reader = new RowReader(indexer.FilePath);
         var node = new JsonLinesRangeTreeNode(indexer, reader, 0L, 3L);

--- a/tests/DataMorph.Tests/Engine/IO/DrillDown/DrillDownSchemaExtractorTests.cs
+++ b/tests/DataMorph.Tests/Engine/IO/DrillDown/DrillDownSchemaExtractorTests.cs
@@ -19,7 +19,7 @@ public sealed class DrillDownSchemaExtractorTests
         // Assert
         result.IsSuccess.Should().BeTrue();
         result.Value.schema.Columns.Select(c => c.Name).Should().Equal("name", "age");
-        result.Value.childValueBytes.Should().HaveCount(2);
+        result.Value.childRawValues.Should().HaveCount(2);
     }
 
     [Fact]
@@ -179,7 +179,7 @@ public sealed class DrillDownSchemaExtractorTests
 
         // Assert
         result.IsSuccess.Should().BeTrue();
-        result.Value.childValueBytes.Should().HaveCount(2);
+        result.Value.childRawValues.Should().HaveCount(2);
         result.Value.schema.Columns.Select(c => c.Name).Should().Equal("name", "meta");
     }
 }

--- a/tests/DataMorph.Tests/Engine/IO/DrillDown/DrillDownSchemaExtractorTests.cs
+++ b/tests/DataMorph.Tests/Engine/IO/DrillDown/DrillDownSchemaExtractorTests.cs
@@ -10,7 +10,7 @@ public sealed class DrillDownSchemaExtractorTests
     public void ExtractFromNode_ArrayOfObjects_ReturnsUnionOfAllTopLevelKeys()
     {
         // Arrange
-        ReadOnlyMemory<byte> nodeBytes =
+        JsonRawBytes nodeBytes =
             "[{\"name\": \"Alice\", \"age\": 30}, {\"name\": \"Bob\", \"age\": 25}]"u8.ToArray();
 
         // Act
@@ -26,7 +26,7 @@ public sealed class DrillDownSchemaExtractorTests
     public void ExtractFromNode_ArrayOfObjectsWithVaryingKeys_ReturnsNullableColumnsForMissingKeys()
     {
         // Arrange
-        ReadOnlyMemory<byte> nodeBytes =
+        JsonRawBytes nodeBytes =
             "[{\"name\": \"Alice\", \"role\": \"admin\"}, {\"name\": \"Bob\"}]"u8.ToArray();
 
         // Act
@@ -42,7 +42,7 @@ public sealed class DrillDownSchemaExtractorTests
     public void ExtractFromNode_ArrayWithNonObjectElement_ReturnsFailure()
     {
         // Arrange
-        ReadOnlyMemory<byte> nodeBytes = "[{\"name\": \"Alice\"}, 42]"u8.ToArray();
+        JsonRawBytes nodeBytes = "[{\"name\": \"Alice\"}, 42]"u8.ToArray();
 
         // Act
         var result = DrillDownSchemaExtractor.ExtractFromNode(nodeBytes, DataFormat.JsonLines);
@@ -55,7 +55,7 @@ public sealed class DrillDownSchemaExtractorTests
     public void ExtractFromNode_EmptyArray_ReturnsFailure()
     {
         // Arrange
-        ReadOnlyMemory<byte> nodeBytes = "[]"u8.ToArray();
+        JsonRawBytes nodeBytes = "[]"u8.ToArray();
 
         // Act
         var result = DrillDownSchemaExtractor.ExtractFromNode(nodeBytes, DataFormat.JsonLines);
@@ -68,7 +68,7 @@ public sealed class DrillDownSchemaExtractorTests
     public void ExtractFromNode_ArrayOfEmptyObjects_ReturnsFailure()
     {
         // Arrange
-        ReadOnlyMemory<byte> nodeBytes = "[{}, {}]"u8.ToArray();
+        JsonRawBytes nodeBytes = "[{}, {}]"u8.ToArray();
 
         // Act
         var result = DrillDownSchemaExtractor.ExtractFromNode(nodeBytes, DataFormat.JsonLines);
@@ -82,7 +82,7 @@ public sealed class DrillDownSchemaExtractorTests
     public void ExtractFromNode_MalformedJson_ReturnsFailure()
     {
         // Arrange
-        ReadOnlyMemory<byte> nodeBytes = "[invalid]"u8.ToArray();
+        JsonRawBytes nodeBytes = "[invalid]"u8.ToArray();
 
         // Act
         var result = DrillDownSchemaExtractor.ExtractFromNode(nodeBytes, DataFormat.JsonLines);
@@ -95,7 +95,7 @@ public sealed class DrillDownSchemaExtractorTests
     public void ExtractFromNode_SourceFormatMatchesParameter_ReturnsCorrectFormat()
     {
         // Arrange
-        ReadOnlyMemory<byte> nodeBytes = "[{\"key\": \"value\"}]"u8.ToArray();
+        JsonRawBytes nodeBytes = "[{\"key\": \"value\"}]"u8.ToArray();
 
         // Act
         var result = DrillDownSchemaExtractor.ExtractFromNode(nodeBytes, DataFormat.JsonArray);
@@ -109,7 +109,7 @@ public sealed class DrillDownSchemaExtractorTests
     public void ExtractFromNode_NullBeforeNonNull_InfersCorrectType()
     {
         // Arrange
-        ReadOnlyMemory<byte> nodeBytes = "[{\"age\": null}, {\"age\": 30}]"u8.ToArray();
+        JsonRawBytes nodeBytes = "[{\"age\": null}, {\"age\": 30}]"u8.ToArray();
 
         // Act
         var result = DrillDownSchemaExtractor.ExtractFromNode(nodeBytes, DataFormat.JsonLines);
@@ -125,7 +125,7 @@ public sealed class DrillDownSchemaExtractorTests
     public void ExtractFromNode_JsonObjectInput_ReturnsFailure()
     {
         // Arrange
-        ReadOnlyMemory<byte> nodeBytes = "{\"key\": \"value\"}"u8.ToArray();
+        JsonRawBytes nodeBytes = "{\"key\": \"value\"}"u8.ToArray();
 
         // Act
         var result = DrillDownSchemaExtractor.ExtractFromNode(nodeBytes, DataFormat.JsonLines);
@@ -138,7 +138,7 @@ public sealed class DrillDownSchemaExtractorTests
     public void ExtractFromNode_KeyWithAllNullValues_IsNullableWithTextType()
     {
         // Arrange
-        ReadOnlyMemory<byte> nodeBytes =
+        JsonRawBytes nodeBytes =
             "[{\"name\": \"Alice\", \"tag\": null}, {\"name\": \"Bob\", \"tag\": null}]"u8.ToArray();
 
         // Act
@@ -155,7 +155,7 @@ public sealed class DrillDownSchemaExtractorTests
     public void ExtractFromNode_KeyWithMixedNullAndNonNull_IsNullable()
     {
         // Arrange
-        ReadOnlyMemory<byte> nodeBytes = "[{\"name\": null}, {\"name\": \"Bob\"}]"u8.ToArray();
+        JsonRawBytes nodeBytes = "[{\"name\": null}, {\"name\": \"Bob\"}]"u8.ToArray();
 
         // Act
         var result = DrillDownSchemaExtractor.ExtractFromNode(nodeBytes, DataFormat.JsonLines);
@@ -171,7 +171,7 @@ public sealed class DrillDownSchemaExtractorTests
     public void ExtractFromNode_ChildWithNestedObject_ReturnsCorrectChildBytesCount()
     {
         // Arrange
-        ReadOnlyMemory<byte> nodeBytes =
+        JsonRawBytes nodeBytes =
             "[{\"name\": \"Alice\", \"meta\": {\"dept\": \"Eng\"}}, {\"name\": \"Bob\", \"meta\": {\"dept\": \"HR\"}}]"u8.ToArray();
 
         // Act

--- a/tests/DataMorph.Tests/Engine/IO/JsonArray/ElementByteCacheBenchmarks.cs
+++ b/tests/DataMorph.Tests/Engine/IO/JsonArray/ElementByteCacheBenchmarks.cs
@@ -42,7 +42,7 @@ public sealed class ElementByteCacheBenchmarks : IDisposable
     {
         // Arrange — create a fresh cache for each benchmark run
         using var cache = new ElementByteCache(_indexer);
-        ReadOnlyMemory<byte> result = default;
+        JsonRawBytes result = default;
 
         // Act — sequential GetRow(0.._elementCount) calls
         for (var i = 0; i < _elementCount; i++)
@@ -59,7 +59,7 @@ public sealed class ElementByteCacheBenchmarks : IDisposable
     {
         // Arrange — create a fresh cache for each benchmark run
         using var cache = new ElementByteCache(_indexer);
-        ReadOnlyMemory<byte> result = default;
+        JsonRawBytes result = default;
 
         // Act — random GetRow calls within 0.._elementCount using a simple LCG pattern
         var index = 0;

--- a/tests/DataMorph.Tests/Engine/IO/JsonArray/ElementReaderTests.cs
+++ b/tests/DataMorph.Tests/Engine/IO/JsonArray/ElementReaderTests.cs
@@ -83,7 +83,7 @@ public sealed class ElementReaderTests : IDisposable
     }
 
     [Fact]
-    public void ReadElementBytes_MixedTypeArray_ReturnsCorrectElements()
+    public void ReadElements_MixedTypeArray_ReturnsCorrectElements()
     {
         // Arrange
         WriteTestContent("[1, \"hello\", null, true, {\"a\":1}, [2]]");
@@ -91,7 +91,7 @@ public sealed class ElementReaderTests : IDisposable
         using var reader = new ElementReader(_testFilePath);
 
         // Act
-        var result = reader.ReadElementBytes(byteOffset, skip, 10);
+        var result = reader.ReadElements(byteOffset, skip, 10);
 
         // Assert
         result.Should().HaveCount(6);
@@ -104,7 +104,7 @@ public sealed class ElementReaderTests : IDisposable
     }
 
     [Fact]
-    public void ReadElementBytes_SkipPastEnd_ReturnsEmptyList()
+    public void ReadElements_SkipPastEnd_ReturnsEmptyList()
     {
         // Arrange
         WriteTestContent("[1, 2, 3]");
@@ -112,14 +112,14 @@ public sealed class ElementReaderTests : IDisposable
         using var reader = new ElementReader(_testFilePath);
 
         // Act
-        var result = reader.ReadElementBytes(byteOffset, skip + 100, 10);
+        var result = reader.ReadElements(byteOffset, skip + 100, 10);
 
         // Assert
         result.Should().BeEmpty();
     }
 
     [Fact]
-    public void ReadElementBytes_SingleObject_ReturnsObjectBytes()
+    public void ReadElements_SingleObject_ReturnsObjectBytes()
     {
         // Arrange
         WriteTestContent("[{\"a\":1}]");
@@ -127,7 +127,7 @@ public sealed class ElementReaderTests : IDisposable
         using var reader = new ElementReader(_testFilePath);
 
         // Act
-        var result = reader.ReadElementBytes(byteOffset, skip, 10);
+        var result = reader.ReadElements(byteOffset, skip, 10);
 
         // Assert
         result.Should().HaveCount(1);
@@ -135,7 +135,7 @@ public sealed class ElementReaderTests : IDisposable
     }
 
     [Fact]
-    public void ReadElementBytes_MultipleElements_ReturnsCorrectCount()
+    public void ReadElements_MultipleElements_ReturnsCorrectCount()
     {
         // Arrange
         WriteTestContent("[1, 2, 3]");
@@ -143,14 +143,14 @@ public sealed class ElementReaderTests : IDisposable
         using var reader = new ElementReader(_testFilePath);
 
         // Act
-        var result = reader.ReadElementBytes(byteOffset, skip, 10);
+        var result = reader.ReadElements(byteOffset, skip, 10);
 
         // Assert
         result.Should().HaveCount(3);
     }
 
     [Fact]
-    public void ReadElementBytes_WithSkip_SkipsCorrectElements()
+    public void ReadElements_WithSkip_SkipsCorrectElements()
     {
         // Arrange
         WriteTestContent("[1, 2, 3]");
@@ -158,7 +158,7 @@ public sealed class ElementReaderTests : IDisposable
         using var reader = new ElementReader(_testFilePath);
 
         // Act
-        var result = reader.ReadElementBytes(byteOffset, skip + 1, 2);
+        var result = reader.ReadElements(byteOffset, skip + 1, 2);
 
         // Assert
         result.Should().HaveCount(2);
@@ -167,7 +167,7 @@ public sealed class ElementReaderTests : IDisposable
     }
 
     [Fact]
-    public void ReadElementBytes_ElementSpansBufferBoundary_ReturnsCompleteBytes()
+    public void ReadElements_ElementSpansBufferBoundary_ReturnsCompleteBytes()
     {
         // Arrange — inner array with 300 000 numbers totals ~1.4 MB, forcing multiple
         // 1 MB buffer fills for a single element. Individual tokens stay small (no > 1 MB strings).
@@ -179,7 +179,7 @@ public sealed class ElementReaderTests : IDisposable
         using var reader = new ElementReader(_testFilePath);
 
         // Act
-        var result = reader.ReadElementBytes(byteOffset: 1, elementsToSkip: 0, elementsToFetch: 1);
+        var result = reader.ReadElements(byteOffset: 1, elementsToSkip: 0, elementsToFetch: 1);
 
         // Assert
         result.Should().HaveCount(1);
@@ -190,7 +190,7 @@ public sealed class ElementReaderTests : IDisposable
     }
 
     [Fact]
-    public void ReadElementBytes_FetchBeyondEnd_ReturnsAvailableElements()
+    public void ReadElements_FetchBeyondEnd_ReturnsAvailableElements()
     {
         // Arrange
         WriteTestContent("[1, 2]");
@@ -198,14 +198,14 @@ public sealed class ElementReaderTests : IDisposable
         using var reader = new ElementReader(_testFilePath);
 
         // Act
-        var result = reader.ReadElementBytes(byteOffset, skip, 10);
+        var result = reader.ReadElements(byteOffset, skip, 10);
 
         // Assert
         result.Should().HaveCount(2);
     }
 
     [Fact]
-    public void ReadElementBytes_WithZeroFetchCount_ReturnsEmptyList()
+    public void ReadElements_WithZeroFetchCount_ReturnsEmptyList()
     {
         // Arrange
         WriteTestContent("[1, 2, 3]");
@@ -213,14 +213,14 @@ public sealed class ElementReaderTests : IDisposable
         using var reader = new ElementReader(_testFilePath);
 
         // Act
-        var result = reader.ReadElementBytes(byteOffset, skip, 0);
+        var result = reader.ReadElements(byteOffset, skip, 0);
 
         // Assert
         result.Should().BeEmpty();
     }
 
     [Fact]
-    public void ReadElementBytes_WithNegativeSkipCount_ThrowsArgumentOutOfRangeException()
+    public void ReadElements_WithNegativeSkipCount_ThrowsArgumentOutOfRangeException()
     {
         // Arrange
         WriteTestContent("[1]");
@@ -228,14 +228,14 @@ public sealed class ElementReaderTests : IDisposable
         using var reader = new ElementReader(_testFilePath);
 
         // Act
-        var act = () => reader.ReadElementBytes(byteOffset, -1, 1);
+        var act = () => reader.ReadElements(byteOffset, -1, 1);
 
         // Assert
         act.Should().Throw<ArgumentOutOfRangeException>();
     }
 
     [Fact]
-    public void ReadElementBytes_WithNegativeFetchCount_ThrowsArgumentOutOfRangeException()
+    public void ReadElements_WithNegativeFetchCount_ThrowsArgumentOutOfRangeException()
     {
         // Arrange
         WriteTestContent("[1]");
@@ -243,28 +243,28 @@ public sealed class ElementReaderTests : IDisposable
         using var reader = new ElementReader(_testFilePath);
 
         // Act
-        var act = () => reader.ReadElementBytes(byteOffset, 0, -1);
+        var act = () => reader.ReadElements(byteOffset, 0, -1);
 
         // Assert
         act.Should().Throw<ArgumentOutOfRangeException>();
     }
 
     [Fact]
-    public void ReadElementBytes_EmptyArray_ReturnsEmptyList()
+    public void ReadElements_EmptyArray_ReturnsEmptyList()
     {
         // Arrange — empty array has no checkpoints; byteOffset = -1 from GetCheckPoint.
         WriteTestContent("[]");
         using var reader = new ElementReader(_testFilePath);
 
         // Act
-        var result = reader.ReadElementBytes(-1, 0, 10);
+        var result = reader.ReadElements(-1, 0, 10);
 
         // Assert
         result.Should().BeEmpty();
     }
 
     [Fact]
-    public void ReadElementBytes_AfterDispose_ThrowsObjectDisposedException()
+    public void ReadElements_AfterDispose_ThrowsObjectDisposedException()
     {
         // Arrange
         WriteTestContent("[1]");
@@ -272,7 +272,7 @@ public sealed class ElementReaderTests : IDisposable
         reader.Dispose();
 
         // Act
-        var act = () => reader.ReadElementBytes(0, 0, 1);
+        var act = () => reader.ReadElements(0, 0, 1);
 
         // Assert
         act.Should().Throw<ObjectDisposedException>();

--- a/tests/DataMorph.Tests/Engine/IO/JsonLines/RowReaderTests.cs
+++ b/tests/DataMorph.Tests/Engine/IO/JsonLines/RowReaderTests.cs
@@ -42,14 +42,14 @@ public sealed class RowReaderTests : IDisposable
     }
 
     [Fact]
-    public void ReadLineBytes_WithSingleJsonLine_ReturnsOneLine()
+    public void ReadLines_WithSingleJsonLine_ReturnsOneLine()
     {
         // Arrange
         WriteTestContent("{\"id\":1}\n");
         using var reader = new RowReader(_testFilePath);
 
         // Act
-        var lines = reader.ReadLineBytes(byteOffset: 0, linesToSkip: 0, linesToRead: 1);
+        var lines = reader.ReadLines(byteOffset: 0, linesToSkip: 0, linesToRead: 1);
 
         // Assert
         lines.Should().ContainSingle();
@@ -58,14 +58,14 @@ public sealed class RowReaderTests : IDisposable
     }
 
     [Fact]
-    public void ReadLineBytes_WithMultipleJsonLines_ReturnsAllLines()
+    public void ReadLines_WithMultipleJsonLines_ReturnsAllLines()
     {
         // Arrange
         WriteTestContent("{\"a\":1}\n{\"b\":2}\n{\"c\":3}\n");
         using var reader = new RowReader(_testFilePath);
 
         // Act
-        var lines = reader.ReadLineBytes(byteOffset: 0, linesToSkip: 0, linesToRead: 3);
+        var lines = reader.ReadLines(byteOffset: 0, linesToSkip: 0, linesToRead: 3);
 
         // Assert
         lines.Should().HaveCount(3);
@@ -75,14 +75,14 @@ public sealed class RowReaderTests : IDisposable
     }
 
     [Fact]
-    public void ReadLineBytes_WithLinesToSkip_SkipsCorrectly()
+    public void ReadLines_WithLinesToSkip_SkipsCorrectly()
     {
         // Arrange
         WriteTestContent("{\"skip\":0}\n{\"read\":1}\n{\"read\":2}\n");
         using var reader = new RowReader(_testFilePath);
 
         // Act
-        var lines = reader.ReadLineBytes(byteOffset: 0, linesToSkip: 1, linesToRead: 2);
+        var lines = reader.ReadLines(byteOffset: 0, linesToSkip: 1, linesToRead: 2);
 
         // Assert
         lines.Should().HaveCount(2);
@@ -91,14 +91,14 @@ public sealed class RowReaderTests : IDisposable
     }
 
     [Fact]
-    public void ReadLineBytes_WithLinesToRead_LimitsCorrectly()
+    public void ReadLines_WithLinesToRead_LimitsCorrectly()
     {
         // Arrange
         WriteTestContent("{\"a\":1}\n{\"b\":2}\n{\"c\":3}\n");
         using var reader = new RowReader(_testFilePath);
 
         // Act
-        var lines = reader.ReadLineBytes(byteOffset: 0, linesToSkip: 0, linesToRead: 2);
+        var lines = reader.ReadLines(byteOffset: 0, linesToSkip: 0, linesToRead: 2);
 
         // Assert
         lines.Should().HaveCount(2);
@@ -120,14 +120,14 @@ public sealed class RowReaderTests : IDisposable
     }
 
     [Fact]
-    public void ReadLineBytes_WithInvalidJsonLine_ReturnsBytesAsIs()
+    public void ReadLines_WithInvalidJsonLine_ReturnsBytesAsIs()
     {
         // Arrange
         WriteTestContent("invalid json\n");
         using var reader = new RowReader(_testFilePath);
 
         // Act
-        var lines = reader.ReadLineBytes(byteOffset: 0, linesToSkip: 0, linesToRead: 1);
+        var lines = reader.ReadLines(byteOffset: 0, linesToSkip: 0, linesToRead: 1);
 
         // Assert
         // Without validation, raw bytes are returned as-is
@@ -137,7 +137,7 @@ public sealed class RowReaderTests : IDisposable
     }
 
     [Fact]
-    public void ReadLineBytes_AfterDispose_ThrowsObjectDisposedException()
+    public void ReadLines_AfterDispose_ThrowsObjectDisposedException()
     {
         // Arrange
         WriteTestContent("{\"test\":1}\n");
@@ -145,14 +145,14 @@ public sealed class RowReaderTests : IDisposable
         reader.Dispose();
 
         // Act
-        var act = () => reader.ReadLineBytes(byteOffset: 0, linesToSkip: 0, linesToRead: 1);
+        var act = () => reader.ReadLines(byteOffset: 0, linesToSkip: 0, linesToRead: 1);
 
         // Assert
         act.Should().Throw<ObjectDisposedException>();
     }
 
     [Fact]
-    public void ReadLineBytes_WithOffsetBeyondEOF_ReturnsEmptyList()
+    public void ReadLines_WithOffsetBeyondEOF_ReturnsEmptyList()
     {
         // Arrange
         WriteTestContent("{\"a\":1}\n");
@@ -160,14 +160,14 @@ public sealed class RowReaderTests : IDisposable
         long largeOffset = 1000; // beyond file size
 
         // Act
-        var lines = reader.ReadLineBytes(byteOffset: largeOffset, linesToSkip: 0, linesToRead: 1);
+        var lines = reader.ReadLines(byteOffset: largeOffset, linesToSkip: 0, linesToRead: 1);
 
         // Assert
         lines.Should().BeEmpty();
     }
 
     [Fact]
-    public void ReadLineBytes_WithIncompleteLineAtEOF_ReturnsBytesAsIs()
+    public void ReadLines_WithIncompleteLineAtEOF_ReturnsBytesAsIs()
     {
         // Arrange
         // Incomplete JSON line without newline at EOF
@@ -175,7 +175,7 @@ public sealed class RowReaderTests : IDisposable
         using var reader = new RowReader(_testFilePath);
 
         // Act
-        var lines = reader.ReadLineBytes(byteOffset: 0, linesToSkip: 0, linesToRead: 1);
+        var lines = reader.ReadLines(byteOffset: 0, linesToSkip: 0, linesToRead: 1);
 
         // Assert
         // Incomplete lines at EOF return raw bytes as-is
@@ -185,28 +185,28 @@ public sealed class RowReaderTests : IDisposable
     }
 
     [Fact]
-    public void ReadLineBytes_WithLinesToSkipExceedingTotalLines_ReturnsEmptyList()
+    public void ReadLines_WithLinesToSkipExceedingTotalLines_ReturnsEmptyList()
     {
         // Arrange
         WriteTestContent("{\"a\":1}\n{\"b\":2}\n");
         using var reader = new RowReader(_testFilePath);
 
         // Act
-        var lines = reader.ReadLineBytes(byteOffset: 0, linesToSkip: 10, linesToRead: 1);
+        var lines = reader.ReadLines(byteOffset: 0, linesToSkip: 10, linesToRead: 1);
 
         // Assert
         lines.Should().BeEmpty();
     }
 
     [Fact]
-    public void ReadLineBytes_WithCrLfLineEndings_TrimsCorrectly()
+    public void ReadLines_WithCrLfLineEndings_TrimsCorrectly()
     {
         // Arrange
         WriteTestContent("{\"a\":1}\r\n{\"b\":2}\r\n");
         using var reader = new RowReader(_testFilePath);
 
         // Act
-        var lines = reader.ReadLineBytes(byteOffset: 0, linesToSkip: 0, linesToRead: 2);
+        var lines = reader.ReadLines(byteOffset: 0, linesToSkip: 0, linesToRead: 2);
 
         // Assert
         lines.Should().HaveCount(2);
@@ -215,21 +215,21 @@ public sealed class RowReaderTests : IDisposable
     }
 
     [Fact]
-    public void ReadLineBytes_WithZeroLinesToRead_ReturnsEmptyList()
+    public void ReadLines_WithZeroLinesToRead_ReturnsEmptyList()
     {
         // Arrange
         WriteTestContent("{\"a\":1}\n{\"b\":2}\n");
         using var reader = new RowReader(_testFilePath);
 
         // Act
-        var lines = reader.ReadLineBytes(byteOffset: 0, linesToSkip: 0, linesToRead: 0);
+        var lines = reader.ReadLines(byteOffset: 0, linesToSkip: 0, linesToRead: 0);
 
         // Assert
         lines.Should().BeEmpty();
     }
 
     [Fact]
-    public void ReadLineBytes_WithValidLineWithoutNewlineAtEOF_ReturnsLine()
+    public void ReadLines_WithValidLineWithoutNewlineAtEOF_ReturnsLine()
     {
         // Arrange
         // Valid JSON line without newline at EOF
@@ -237,7 +237,7 @@ public sealed class RowReaderTests : IDisposable
         using var reader = new RowReader(_testFilePath);
 
         // Act
-        var lines = reader.ReadLineBytes(byteOffset: 0, linesToSkip: 0, linesToRead: 1);
+        var lines = reader.ReadLines(byteOffset: 0, linesToSkip: 0, linesToRead: 1);
 
         // Assert
         lines.Should().ContainSingle();
@@ -246,7 +246,7 @@ public sealed class RowReaderTests : IDisposable
     }
 
     [Fact]
-    public void ReadLineBytes_WhenFileHasBOM_ReturnsCorrectLines()
+    public void ReadLines_WhenFileHasBOM_ReturnsCorrectLines()
     {
         // Arrange
         // Write JSONL with BOM
@@ -255,7 +255,7 @@ public sealed class RowReaderTests : IDisposable
 
         // Act
         using var reader = new RowReader(_testFilePath);
-        var lines = reader.ReadLineBytes(0, 0, 10);
+        var lines = reader.ReadLines(0, 0, 10);
 
         // Assert
         lines.Should().ContainSingle();
@@ -266,7 +266,7 @@ public sealed class RowReaderTests : IDisposable
     // Skip loop tests (data <= 1 MB)
 
     [Fact]
-    public void ReadLineBytes_SkipLoop_SmallData_EscapedNewlineInValue_ReadsNextLineCorrectly()
+    public void ReadLines_SkipLoop_SmallData_EscapedNewlineInValue_ReadsNextLineCorrectly()
     {
         // Arrange
         // First line has escaped \n in value, second line should be read correctly
@@ -276,7 +276,7 @@ public sealed class RowReaderTests : IDisposable
 
         // Act
         // Skip first line, read second line
-        var lines = reader.ReadLineBytes(byteOffset: 0, linesToSkip: 1, linesToRead: 1);
+        var lines = reader.ReadLines(byteOffset: 0, linesToSkip: 1, linesToRead: 1);
 
         // Assert
         lines.Should().ContainSingle();
@@ -285,7 +285,7 @@ public sealed class RowReaderTests : IDisposable
     }
 
     [Fact]
-    public void ReadLineBytes_SkipLoop_SmallData_UnclosedQuoteWithEmbeddedNewline_ReturnsAdjacentLine()
+    public void ReadLines_SkipLoop_SmallData_UnclosedQuoteWithEmbeddedNewline_ReturnsAdjacentLine()
     {
         // Arrange
         // First line has unclosed quote with literal newline — without validation,
@@ -296,7 +296,7 @@ public sealed class RowReaderTests : IDisposable
         using var reader = new RowReader(_testFilePath);
 
         // Act
-        var lines = reader.ReadLineBytes(byteOffset: 0, linesToSkip: 1, linesToRead: 1);
+        var lines = reader.ReadLines(byteOffset: 0, linesToSkip: 1, linesToRead: 1);
 
         // Assert
         lines.Should().ContainSingle();
@@ -305,7 +305,7 @@ public sealed class RowReaderTests : IDisposable
     }
 
     [Fact]
-    public void ReadLineBytes_SkipLoop_SmallData_NormalLineEnding_ReadsNextLineCorrectly()
+    public void ReadLines_SkipLoop_SmallData_NormalLineEnding_ReadsNextLineCorrectly()
     {
         // Arrange
         var content = "{\"id\":1}\n{\"id\":2}\n{\"id\":3}\n";
@@ -314,7 +314,7 @@ public sealed class RowReaderTests : IDisposable
 
         // Act
         // Skip first line, read next two lines
-        var lines = reader.ReadLineBytes(byteOffset: 0, linesToSkip: 1, linesToRead: 2);
+        var lines = reader.ReadLines(byteOffset: 0, linesToSkip: 1, linesToRead: 2);
 
         // Assert
         lines.Should().HaveCount(2);
@@ -326,7 +326,7 @@ public sealed class RowReaderTests : IDisposable
 
     [Fact]
     [Trait("Category", "LargeData")]
-    public void ReadLineBytes_SkipLoop_LargeData_EscapedNewlineInValue_ReadsNextLineCorrectly()
+    public void ReadLines_SkipLoop_LargeData_EscapedNewlineInValue_ReadsNextLineCorrectly()
     {
         // Arrange
         // Line 0: valid >1MB line with escaped \n in value — single line exceeds maxSearch, triggering the multi-call path in skip loop
@@ -337,7 +337,7 @@ public sealed class RowReaderTests : IDisposable
 
         // Act
         // Skip large line (>1MB), read next small line
-        var linesRead = reader.ReadLineBytes(byteOffset: 0, linesToSkip: 1, linesToRead: 1);
+        var linesRead = reader.ReadLines(byteOffset: 0, linesToSkip: 1, linesToRead: 1);
 
         // Assert
         linesRead.Should().ContainSingle();
@@ -346,7 +346,7 @@ public sealed class RowReaderTests : IDisposable
 
     [Fact]
     [Trait("Category", "LargeData")]
-    public void ReadLineBytes_SkipLoop_LargeData_UnclosedQuoteWithEmbeddedNewline_ReturnsAdjacentLine()
+    public void ReadLines_SkipLoop_LargeData_UnclosedQuoteWithEmbeddedNewline_ReturnsAdjacentLine()
     {
         // Arrange
         // Malformed: unclosed quote, value > 1MB so FindNextLineLength is called twice.
@@ -358,7 +358,7 @@ public sealed class RowReaderTests : IDisposable
 
         // Act
         // Skip the first byte-level line (up to embedded newline), read next
-        var lines = reader.ReadLineBytes(byteOffset: 0, linesToSkip: 1, linesToRead: 1);
+        var lines = reader.ReadLines(byteOffset: 0, linesToSkip: 1, linesToRead: 1);
 
         // Assert
         lines.Should().ContainSingle();
@@ -368,7 +368,7 @@ public sealed class RowReaderTests : IDisposable
 
     [Fact]
     [Trait("Category", "LargeData")]
-    public void ReadLineBytes_SkipLoop_LargeData_NormalLineEnding_ReadsNextLineCorrectly()
+    public void ReadLines_SkipLoop_LargeData_NormalLineEnding_ReadsNextLineCorrectly()
     {
         // Arrange
         // Line 0: valid >1MB line — single line exceeds maxSearch, triggering the multi-call path in skip loop
@@ -379,7 +379,7 @@ public sealed class RowReaderTests : IDisposable
 
         // Act
         // Skip large line (>1MB), read next two small lines
-        var linesRead = reader.ReadLineBytes(byteOffset: 0, linesToSkip: 1, linesToRead: 2);
+        var linesRead = reader.ReadLines(byteOffset: 0, linesToSkip: 1, linesToRead: 2);
 
         // Assert
         linesRead.Should().HaveCount(2);
@@ -390,7 +390,7 @@ public sealed class RowReaderTests : IDisposable
     // Read loop tests (data <= 1 MB)
 
     [Fact]
-    public void ReadLineBytes_ReadLoop_SmallData_EscapedNewlineInValue_ReturnsCorrectBytes()
+    public void ReadLines_ReadLoop_SmallData_EscapedNewlineInValue_ReturnsCorrectBytes()
     {
         // Arrange
         var content = "{\"text\":\"line1\\nline2\",\"id\":1}\n{\"text\":\"next\",\"id\":2}\n";
@@ -398,7 +398,7 @@ public sealed class RowReaderTests : IDisposable
         using var reader = new RowReader(_testFilePath);
 
         // Act
-        var lines = reader.ReadLineBytes(byteOffset: 0, linesToSkip: 0, linesToRead: 2);
+        var lines = reader.ReadLines(byteOffset: 0, linesToSkip: 0, linesToRead: 2);
 
         // Assert
         lines.Should().HaveCount(2);
@@ -407,7 +407,7 @@ public sealed class RowReaderTests : IDisposable
     }
 
     [Fact]
-    public void ReadLineBytes_ReadLoop_SmallData_UnclosedQuoteWithEmbeddedNewline_ReturnsBothLinesAsIs()
+    public void ReadLines_ReadLoop_SmallData_UnclosedQuoteWithEmbeddedNewline_ReturnsBothLinesAsIs()
     {
         // Arrange
         // Malformed: unclosed quote with literal newline — without validation,
@@ -417,7 +417,7 @@ public sealed class RowReaderTests : IDisposable
         using var reader = new RowReader(_testFilePath);
 
         // Act
-        var lines = reader.ReadLineBytes(byteOffset: 0, linesToSkip: 0, linesToRead: 2);
+        var lines = reader.ReadLines(byteOffset: 0, linesToSkip: 0, linesToRead: 2);
 
         // Assert
         lines.Should().HaveCount(2);
@@ -426,7 +426,7 @@ public sealed class RowReaderTests : IDisposable
     }
 
     [Fact]
-    public void ReadLineBytes_ReadLoop_SmallData_NormalLineEnding_ReturnsCorrectBytes()
+    public void ReadLines_ReadLoop_SmallData_NormalLineEnding_ReturnsCorrectBytes()
     {
         // Arrange
         var content = "{\"id\":1}\n{\"id\":2}\n{\"id\":3}\n";
@@ -434,7 +434,7 @@ public sealed class RowReaderTests : IDisposable
         using var reader = new RowReader(_testFilePath);
 
         // Act
-        var lines = reader.ReadLineBytes(byteOffset: 0, linesToSkip: 0, linesToRead: 3);
+        var lines = reader.ReadLines(byteOffset: 0, linesToSkip: 0, linesToRead: 3);
 
         // Assert
         lines.Should().HaveCount(3);
@@ -447,7 +447,7 @@ public sealed class RowReaderTests : IDisposable
 
     [Fact]
     [Trait("Category", "LargeData")]
-    public void ReadLineBytes_ReadLoop_LargeData_EscapedNewlineInValue_ReturnsCorrectBytes()
+    public void ReadLines_ReadLoop_LargeData_EscapedNewlineInValue_ReturnsCorrectBytes()
     {
         // Arrange
         // Line 0: valid >1MB line with escaped \n in value — single line exceeds maxSearch, triggering the multi-call path in read loop
@@ -458,7 +458,7 @@ public sealed class RowReaderTests : IDisposable
         using var reader = new RowReader(_testFilePath);
 
         // Act
-        var linesRead = reader.ReadLineBytes(byteOffset: 0, linesToSkip: 0, linesToRead: 2);
+        var linesRead = reader.ReadLines(byteOffset: 0, linesToSkip: 0, linesToRead: 2);
 
         // Assert
         linesRead.Should().HaveCount(2);
@@ -468,7 +468,7 @@ public sealed class RowReaderTests : IDisposable
 
     [Fact]
     [Trait("Category", "LargeData")]
-    public void ReadLineBytes_ReadLoop_LargeData_UnclosedQuoteWithEmbeddedNewline_ReturnsBothLinesAsIs()
+    public void ReadLines_ReadLoop_LargeData_UnclosedQuoteWithEmbeddedNewline_ReturnsBothLinesAsIs()
     {
         // Arrange
         // Malformed: unclosed quote, value > 1MB so FindNextLineLength is called twice.
@@ -479,7 +479,7 @@ public sealed class RowReaderTests : IDisposable
         using var reader = new RowReader(_testFilePath);
 
         // Act
-        var lines = reader.ReadLineBytes(byteOffset: 0, linesToSkip: 0, linesToRead: 2);
+        var lines = reader.ReadLines(byteOffset: 0, linesToSkip: 0, linesToRead: 2);
 
         // Assert
         lines.Should().HaveCount(2);
@@ -490,7 +490,7 @@ public sealed class RowReaderTests : IDisposable
 
     [Fact]
     [Trait("Category", "LargeData")]
-    public void ReadLineBytes_ReadLoop_LargeData_NormalLineEnding_ReturnsCorrectBytes()
+    public void ReadLines_ReadLoop_LargeData_NormalLineEnding_ReturnsCorrectBytes()
     {
         // Arrange
         // Line 0: valid >1MB line — single line exceeds maxSearch, triggering the multi-call path in read loop
@@ -501,7 +501,7 @@ public sealed class RowReaderTests : IDisposable
         using var reader = new RowReader(_testFilePath);
 
         // Act
-        var linesRead = reader.ReadLineBytes(byteOffset: 0, linesToSkip: 0, linesToRead: 2);
+        var linesRead = reader.ReadLines(byteOffset: 0, linesToSkip: 0, linesToRead: 2);
 
         // Assert
         linesRead.Should().HaveCount(2);
@@ -510,7 +510,7 @@ public sealed class RowReaderTests : IDisposable
     }
 
     [Fact]
-    public void ReadLineBytes_WithNonZeroByteOffset_ReturnsCorrectLines()
+    public void ReadLines_WithNonZeroByteOffset_ReturnsCorrectLines()
     {
         // Arrange
         var content = "{\"id\":0}\n{\"id\":1}\n{\"id\":2}\n{\"id\":3}\n{\"id\":4}\n";
@@ -521,7 +521,7 @@ public sealed class RowReaderTests : IDisposable
         var byteOffset = Encoding.UTF8.GetBytes("{\"id\":0}\n{\"id\":1}\n").Length;
 
         // Act
-        var lines = reader.ReadLineBytes(byteOffset: byteOffset, linesToSkip: 0, linesToRead: 2);
+        var lines = reader.ReadLines(byteOffset: byteOffset, linesToSkip: 0, linesToRead: 2);
 
         // Assert
         lines.Should().HaveCount(2);

--- a/tests/DataMorph.Tests/Engine/IO/JsonLines/SchemaScannerTests.RefineSchema.cs
+++ b/tests/DataMorph.Tests/Engine/IO/JsonLines/SchemaScannerTests.RefineSchema.cs
@@ -111,7 +111,7 @@ public sealed partial class SchemaScannerTests
             ],
             SourceFormat = DataFormat.JsonLines,
         };
-        var line = new ReadOnlyMemory<byte>("malformed"u8.ToArray());
+        var line = new JsonRawBytes("malformed"u8.ToArray());
 
         // Act
         var result = SchemaScanner.RefineSchema(initialSchema, line.Span);

--- a/tests/DataMorph.Tests/Engine/IO/JsonLines/SchemaScannerTests.ScanSchema.cs
+++ b/tests/DataMorph.Tests/Engine/IO/JsonLines/SchemaScannerTests.ScanSchema.cs
@@ -21,7 +21,7 @@ public sealed partial class SchemaScannerTests
     {
         // Arrange
         var json = $"{{\"a\": {value}}}";
-        ReadOnlyMemory<byte>[] lines = [Line(json)];
+        JsonRawBytes[] lines = [Line(json)];
 
         // Act
         var result = SchemaScanner.ScanSchema(lines);
@@ -45,7 +45,7 @@ public sealed partial class SchemaScannerTests
         // Arrange
         var json1 = $"{{\"a\": {val1}}}";
         var json2 = $"{{\"a\": {val2}}}";
-        ReadOnlyMemory<byte>[] lines = [Line(json1), Line(json2)];
+        JsonRawBytes[] lines = [Line(json1), Line(json2)];
 
         // Act
         var result = SchemaScanner.ScanSchema(lines);
@@ -59,7 +59,7 @@ public sealed partial class SchemaScannerTests
     public void ScanSchema_MultiLineConsistentTypes_PreservesTypes()
     {
         // Arrange
-        ReadOnlyMemory<byte>[] lines =
+        JsonRawBytes[] lines =
         [
             Line("{\"a\": 1, \"b\": \"text\"}"),
             Line("{\"a\": 2, \"b\": \"text2\"}"),
@@ -78,7 +78,7 @@ public sealed partial class SchemaScannerTests
     public void ScanSchema_MissingKeyInSomeRows_MarksNullable()
     {
         // Arrange
-        ReadOnlyMemory<byte>[] lines =
+        JsonRawBytes[] lines =
         [
             Line("{\"a\": 1}"),
             Line("{\"a\": 2}"),
@@ -97,7 +97,7 @@ public sealed partial class SchemaScannerTests
     public void ScanSchema_NewKeyInLaterRow_AddsNullableColumn()
     {
         // Arrange
-        ReadOnlyMemory<byte>[] lines = [Line("{\"a\": 1}"), Line("{\"a\": 2, \"b\": \"text\"}")];
+        JsonRawBytes[] lines = [Line("{\"a\": 1}"), Line("{\"a\": 2, \"b\": \"text\"}")];
 
         // Act
         var result = SchemaScanner.ScanSchema(lines);
@@ -112,7 +112,7 @@ public sealed partial class SchemaScannerTests
     public void ScanSchema_NullValueInRow_TypeUnchangedAndNullable()
     {
         // Arrange
-        ReadOnlyMemory<byte>[] lines = [Line("{\"a\": 1}"), Line("{\"a\": null}")];
+        JsonRawBytes[] lines = [Line("{\"a\": 1}"), Line("{\"a\": null}")];
 
         // Act
         var result = SchemaScanner.ScanSchema(lines);
@@ -126,7 +126,7 @@ public sealed partial class SchemaScannerTests
     public void ScanSchema_EmptyInput_ReturnsFailure()
     {
         // Arrange
-        var lines = Array.Empty<ReadOnlyMemory<byte>>();
+        var lines = Array.Empty<JsonRawBytes>();
 
         // Act
         var result = SchemaScanner.ScanSchema(lines);
@@ -139,10 +139,10 @@ public sealed partial class SchemaScannerTests
     public void ScanSchema_AllLinesMalformed_ReturnsFailure()
     {
         // Arrange
-        ReadOnlyMemory<byte>[] lines =
+        JsonRawBytes[] lines =
         [
-            new ReadOnlyMemory<byte>("not json"u8.ToArray()),
-            new ReadOnlyMemory<byte>("also not json"u8.ToArray()),
+            new JsonRawBytes("not json"u8.ToArray()),
+            new JsonRawBytes("also not json"u8.ToArray()),
         ];
 
         // Act
@@ -156,7 +156,7 @@ public sealed partial class SchemaScannerTests
     public void ScanSchema_NegativeInitialScanCount_ThrowsArgumentOutOfRangeException()
     {
         // Arrange
-        ReadOnlyMemory<byte>[] lines = [Line("{\"a\": 1}")];
+        JsonRawBytes[] lines = [Line("{\"a\": 1}")];
 
         // Act
         Action act = () => SchemaScanner.ScanSchema(lines, -1);

--- a/tests/DataMorph.Tests/Engine/IO/JsonLines/SchemaScannerTests.cs
+++ b/tests/DataMorph.Tests/Engine/IO/JsonLines/SchemaScannerTests.cs
@@ -7,8 +7,8 @@ namespace DataMorph.Tests.Engine.IO.JsonLines;
 
 public sealed partial class SchemaScannerTests
 {
-    private static ReadOnlyMemory<byte> Line(string json) =>
-        new ReadOnlyMemory<byte>(
+    private static JsonRawBytes Line(string json) =>
+        new JsonRawBytes(
             JsonSerializer.SerializeToUtf8Bytes(JsonDocument.Parse(json).RootElement)
         );
 

--- a/tests/DataMorph.Tests/Engine/IO/JsonObject/TopLevelScannerTests.Scan.cs
+++ b/tests/DataMorph.Tests/Engine/IO/JsonObject/TopLevelScannerTests.Scan.cs
@@ -6,7 +6,7 @@ namespace DataMorph.Tests.Engine.IO.JsonObject;
 
 public sealed partial class TopLevelScannerTests
 {
-    private static ReadOnlyMemory<byte> Utf8(string s) => Encoding.UTF8.GetBytes(s);
+    private static JsonRawBytes Utf8(string s) => Encoding.UTF8.GetBytes(s);
 
     [Fact]
     public void Scan_WithEmptyObject_ReturnsEmptyList()


### PR DESCRIPTION
## Summary

- Introduce `JsonRawBytes` as a global type alias for `ReadOnlyMemory<byte>` to make JSON raw byte semantics explicit across the codebase
- Rename `IReadOnlyList<JsonRawBytes>` variables whose `*Bytes` suffix was ambiguous (`ChildValueBytes` → `ChildRawValues`, `lineBytes` → `rawLines`, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)