### PR TITLE
feat: implement Full Aggregation DrillDown for JSON Lines/Array

### DIFF
--- a/docs/design_drilldown_command_phase2.md
+++ b/docs/design_drilldown_command_phase2.md
@@ -650,6 +650,14 @@ segment = keyPath[segIdx]
 if segment starts with '[':
     // Index segment → expand all array elements
     if first token of currentBytes != StartArray → return  // wrong type, skip silently
+
+    if segIdx == keyPath.Count - 1:
+        // Trailing index segment: "tags" and "tags[0]" must produce identical output
+        // (including the "value" column for primitive elements), so delegate directly
+        // to the same array-leaf collection used when the array itself is the leaf.
+        CollectArrayLeafRows(currentBytes, posHash, rows, keyOrder, keySet, columnTypes, keyObservedCount)
+        return
+
     elementIdx = 0
     for each element bytes in currentBytes (via Utf8JsonReader):
         TraverseKeyPath(elementBytes, keyPath, segIdx + 1, $"{posHash}:{elementIdx}",

--- a/docs/design_drilldown_command_phase2.md
+++ b/docs/design_drilldown_command_phase2.md
@@ -1,0 +1,1054 @@
+# DrillDown Command — Phase 2 Design Document
+
+## Scope
+
+Implements **DrillDown Phase 2: Full Aggregation** — a file-wide scan that collects all child
+objects at the selected key path across every record in the file and presents them as a single
+flat table.
+
+| Phase | Scope | Description |
+|-------|-------|-------------|
+| **Phase 1** (complete) | Selected node only | Displays children of the selected `JsonArrayTreeNode` using in-memory node bytes. |
+| **Phase 2** (this document) | Full file scan | Scans the entire file for all records containing the selected key path. Aggregates their child objects into one table. |
+
+**Supported formats for Phase 2:** JSON Lines, JSON Array only.
+JSON Object is excluded — a single document has no records to aggregate across.
+
+**Out of scope (deferred):**
+- Back / Undo navigation (Backspace to return to Tree)
+- Breadcrumb path display
+- Progress indication during long file scans
+- Memory-efficient viewport-based row loading: all matched rows are materialized in memory
+  after the scan. For files with millions of records this may consume significant memory.
+  Deferred to a future phase.
+- Incremental schema/row updates during the scan: the table is currently updated only once,
+  after the entire scan completes, which does not scale well for very large files (the UI shows
+  no progress until the scan is fully done). Deferred — to be optimized in a future phase.
+
+---
+
+## 1. Requirements
+
+### 1.1 Enable Conditions
+
+| Format | DrillDown Behavior |
+|--------|--------------------|
+| JSON Lines | `x` key on any tree node → always full file scan (Phase 2) |
+| JSON Array | `x` key on any tree node → always full file scan (Phase 2) |
+| JSON Object | Phase 1 behavior retained: `x` key on `JsonArrayTreeNode` → single-node DrillDown |
+
+Any node type may trigger DrillDown: `JsonObjectTreeNode`, `JsonArrayTreeNode`, or primitive leaf
+nodes. The selected node's type determines the output format (see Section 1.4).
+
+### 1.2 Key Path Construction
+
+When "DrillDown" is triggered, the `ParentNode` chain of the selected node is traversed upward
+to build a `KeyPath`: an ordered list of path segments from root to the selected node.
+
+Segment contribution rules:
+
+| Node type | Segment added |
+|-----------|---------------|
+| `JsonObjectTreeNode` with `KeyName = "orders"` | `"orders"` |
+| `JsonArrayTreeNode` with `KeyName = "tags"` | `"tags"` |
+| Array-index display node (e.g. `[0]`) | `"[0]"` (literal string; index value retained as array marker) |
+| Root sentinel node (no KeyName) | *(no segment)* |
+
+The path is built lazily at trigger time only. Each tree node carries a single
+`ParentNode { get; init; }` reference (8-byte pointer set at construction). No list object is
+allocated per node at construction time.
+
+Example: selected node `orders[0].shipping` → `KeyPath = ["orders", "[0]", "shipping"]`
+
+### 1.3 Path Traversal Rules
+
+The scanner follows `KeyPath` segment by segment for each record in the file:
+
+| Segment type | Identification | Action |
+|---|---|---|
+| Key segment (e.g. `"orders"`, `"shipping"`) | Does **not** start with `[` | Navigate into the JSON object by this key. If key absent or value is wrong type → skip record silently |
+| Index segment (e.g. `"[0]"`) | Starts with `[` | Ignore the numeric index. **Expand all array elements** and continue traversal independently for each |
+
+**Core rule:** `[n]` signals that a JSON array was present at this path position.
+The index value is discarded — all elements are always expanded.
+Therefore `orders` and `orders[0]` always produce identical DrillDown output.
+
+If at any point the expected JSON structure is not found (key absent, wrong token type for the
+next segment), that record is **silently skipped** — no error is raised.
+
+### 1.4 Output Format
+
+After the full `KeyPath` is followed, the leaf value determines the output. Long format is used
+in all cases: each scalar value occupies exactly one row.
+
+| Leaf type | Columns | Output |
+|---|---|---|
+| JSONObject | Each key of the object becomes a column | One row per record (or per parent array element) |
+| JSONArray of JSONObject | Each key of child objects becomes a column | One row per child element; `#` gains one level |
+| JSONArray of Primitive | Single `value` column | One row per element; `#` gains one level |
+| Primitive | Single column named after the key | One row per record (or per parent array element) |
+
+Examples below use JSON Lines. The output structure is the same for JSON Array; only the `#` value differs — see Section 1.5.
+
+#### JSONObject
+
+```json
+// Record pos=1
+{ "user": { "name": "Alice", "age": 30 } }
+// Record pos=2
+{ "user": { "name": "Bob", "age": 25 } }
+```
+
+**`user`** (0 arrays in path):
+```
+#  | name  | age
+1  | Alice | 30
+2  | Bob   | 25
+```
+
+#### JSONArray of JSONObject
+
+```json
+// Record pos=1
+{ "orders": [{ "id": "A1", "qty": 2 }, { "id": "A2", "qty": 5 }] }
+// Record pos=2
+{ "orders": [{ "id": "B1", "qty": 1 }] }
+```
+
+**`orders` / `orders[0]`** (same output — 1 array in path):
+```
+#   | id | qty
+1:0 | A1 | 2
+1:1 | A2 | 5
+2:0 | B1 | 1
+```
+
+#### JSONArray of Primitive
+
+```json
+// Record pos=1
+{ "tags": ["dev", "ops"] }
+// Record pos=2
+{ "tags": ["dev"] }
+```
+
+**`tags` / `tags[0]`** (same output — 1 array in path):
+```
+#   | value
+1:0 | dev
+1:1 | ops
+2:0 | dev
+```
+
+When the path contains multiple `[n]` segments, the `#` column gains additional levels:
+
+```json
+// Record pos=1
+{ "orders": [{ "tags": ["urgent", "gift"] }, { "tags": ["normal"] }] }
+```
+
+**`orders[0].tags`** (2 arrays in path — `[0]` + leaf):
+```
+#     | value
+1:0:0 | urgent
+1:0:1 | gift
+1:1:0 | normal
+```
+
+#### Primitive
+
+```json
+// Record pos=1
+{ "score": 88 }
+// Record pos=2
+{ "score": 72 }
+```
+
+**`score`** (0 arrays in path):
+```
+#  | score
+1  | 88
+2  | 72
+```
+
+#### Nested Values
+
+When a column value is itself a JSON object or array, it is rendered as `{...}` or `[...]` —
+display is 1 level deep only.
+
+```json
+// Record pos=1
+{ "user": { "name": "Alice", "address": { "city": "Tokyo" }, "tags": ["dev", "ops"] } }
+```
+
+**`user`**:
+```
+#  | name  | address | tags
+1  | Alice | {...}   | [...]
+```
+
+### 1.5 `#` Column
+
+The number of `:` separators in `#` equals the number of arrays traversed along the path
+(including the leaf node if the leaf itself is a JSONArray).
+
+| Selected path | Arrays traversed | `#` format |
+|---|---|---|
+| `score` | 0 | `pos` |
+| `user` | 0 | `pos` |
+| `orders` | 1 (leaf array) | `pos:i` |
+| `orders[0]` | 1 (`[0]` segment) | `pos:i` |
+| `orders[0].shipping` | 1 (`[0]` segment) | `pos:i` |
+| `orders[0].tags` | 2 (`[0]` + leaf array) | `pos:i:j` |
+
+Record position numbering:
+
+| Format | Position basis | Example `#` |
+|---|---|---|
+| JSON Lines | 1-based line number | `3:0`, `3:1` |
+| JSON Array | 0-based element index | `2:0`, `2:1` |
+
+### 1.6 Null Handling
+
+| Situation | Output |
+|---|---|
+| `KeyPath` followed successfully; leaf value is JSON `null` | Null row is output (one row with null cell values) |
+| A `KeyPath` segment is absent in the record | Record is silently skipped |
+
+### 1.7 Error Cases
+
+| Condition | Error dialog message | When it occurs |
+|---|---|---|
+| No records produce any rows after full scan | `"No matching records found."` | All records have an empty array `[]` at the target path |
+| Rows were collected but all collected objects have no keys | `"All child objects have no keys"` | All records have an array of empty objects (e.g. `[{}, {}]`) at the target path — rows are collected but the schema has zero columns |
+
+### 1.8 Non-Functional
+
+- Zero allocation in cell extraction hot paths (`Utf8JsonReader` on `ReadOnlySpan<byte>`)
+- Native AOT compatible (no reflection)
+- All classes stay under 300 lines
+- 1-pass file scan; schema and rows are accumulated in memory as new columns are discovered
+  during the scan, then applied to the UI in a single `_uiThreadInvoke` call after the scan
+  completes (no second scan required)
+- Cancellable via `CancellationToken`
+
+---
+
+## 2. Architecture
+
+### 2.1 Motivation: FocusedTableSource Refactor
+
+**Current state (Phase 1)**
+
+`FocusedTableSource` renders the `#` column via `FormatHashColumn(row)`, which returns
+`"{_recordPosition}:{row}"` using a single `long? _recordPosition` shared across all rows.
+This works because Phase 1 DrillDown operates on a single `JsonArrayTreeNode` — all child rows
+come from the same record, so `_recordPosition` is constant and `row` serves as both the
+table row index and the array element index within that record.
+
+**Problems Phase 2 introduces**
+
+1. **`row` no longer equals the array element index** — Phase 2 aggregates rows from many
+   records. The table row index (`row`) increments continuously across all records, but the
+   array element index resets to 0 for each new record. `FormatHashColumn(row)` therefore
+   produces the wrong element index for any record after the first.
+
+2. **Primitive leaves** — Phase 1 assumed all rows are JSON objects. Phase 2 also encounters
+   primitive leaves, requiring branching on whether the leaf value is a primitive or an object.
+   See Section 3.7 for details.
+
+**Solution: `FocusedTableRow`**
+
+Each row pre-computes its own `#` string at scan time — when the correct element index is
+known — and carries its own bytes. `FocusedTableSource` reads `_rows[row].HashValue` for the
+`#` column and `_rows[row].Bytes` for cell extraction — no per-table format logic needed.
+
+`DrillDownState` drops the `ChildRawValues / Format / RecordPosition` triple and stores
+`IReadOnlyList<FocusedTableRow>` instead.
+
+### 2.2 Data Flow
+
+```
+[User presses x on any tree node in MorphTreeView → ActionMenu shows "DrillDown"]
+
+── JSON Object (Phase 1, retained) ─────────────────────────────────────────────────────────
+  Condition: selected node is JsonArrayTreeNode; all children are JsonObjectTreeNode
+  AppKeyHandler → ActionMenuDialog(["DrillDown"])
+                → ViewManager.DrillDown(request)
+                → ModeController.DrillDown(request)
+                      DrillDownSchemaExtractor.ExtractFromNode(nodeBytes, format)
+                      build FocusedTableRow[] inline (hash = $"[{i}]")
+                      → DrillDownState { Rows, Schema }
+                → SwitchToFocusedTable(drillDown)
+
+── JSON Lines / JSON Array (Phase 2, new) ────────────────────────────────────────────────
+  Condition: any node selected (no type restriction)
+  AppKeyHandler → BuildKeyPath(selectedNode) → keyPath
+                → ActionMenuDialog(["DrillDown"])
+                → ViewManager.FullAggregationDrillDownAsync(request)
+                → ModeController.FullAggregationDrillDownAsync(request)
+                      await Task.Run(() =>
+                          FullAggregationScanner.Scan(filePath, format, keyPath, ct))
+                      → Result<DrillDownState>
+                → on UI thread (_uiThreadInvoke):
+                      _state.DrillDown = drillDown
+                      _state.CurrentMode = ViewMode.FocusedTable
+                      SwitchToFocusedTable(drillDown)
+```
+
+### 2.3 New Components
+
+| Component | Layer | File | Responsibility |
+|-----------|-------|------|----------------|
+| `FocusedTableRow` | Engine | `src/Engine/IO/DrillDown/FocusedTableRow.cs` | Value type pairing child bytes with pre-computed `#` value |
+| `SchemaScanner` | Engine | `src/Engine/IO/DrillDown/SchemaScanner.cs` | Stateless static helpers for accumulating key order / column types across multiple JSON objects and building the final `TableSchema`; shared by `DrillDownSchemaExtractor` and `FullAggregationScanner` |
+| `FullAggregationScanner` | Engine | `src/Engine/IO/DrillDown/FullAggregationScanner.cs` | Full file scan: traverse KeyPath for each record; collect rows for all leaf types; build union schema |
+
+### 2.4 Modified Files
+
+| File | Change |
+|------|--------|
+| `src/Engine/IO/DrillDown/DrillDownSchemaExtractor.cs` | `BuildSchema` delegates to new `SchemaScanner` static helpers instead of owning them; `ScanObject`/`RegisterKeyIfNew`/`IncrementObservationCounts`/`MergeColumnType` move out |
+| `src/App/DrillDownState.cs` | Replace `ChildRawValues / Format / RecordPosition` with `IReadOnlyList<FocusedTableRow> Rows` |
+| `src/App/Views/FocusedTableSource.cs` | Refactor: accept `DrillDownState` with new `Rows`; replace `FormatHashColumn` with `_rows[row].HashValue` |
+| `src/App/DrillDownRequest.cs` | Split the single record into an abstract `DrillDownRequest` base plus `SingleDrillDownRequest` and `FullAggregationDrillDownRequest` |
+| `src/App/Views/JsonObjectTreeNode.cs` | Add `public ITreeNode? ParentNode { get; init; }` |
+| `src/App/Views/JsonArrayTreeNode.cs` | Add `public ITreeNode? ParentNode { get; init; }` |
+| `src/App/Views/JsonValueTreeNode.cs` | Add `public string? KeyName { get; init; }` and `public ITreeNode? ParentNode { get; init; }` |
+| `src/App/Views/JsonTreeNodeHelper.cs` | Add `ITreeNode? parentNode` parameter to `CreateChildNode`, `CreateNestedObjectNode`, `CreateNestedArrayNode` |
+| `src/App/ModeController.cs` | Update `DrillDown()` to build rows inline; add `FullAggregationDrillDownAsync()` returning `Result<DrillDownState>` |
+| `src/App/ViewManager.cs` | Add `FullAggregationDrillDownAsync()`; assign `_state.DrillDown` / `_state.CurrentMode` inside `_uiThreadInvoke` |
+| `src/App/AppKeyHandler.cs` | Single "DrillDown" option for all formats; add `BuildKeyPath`; dispatch Phase 1 vs Phase 2 by format |
+| `tests/.../FocusedTableSourceTests.cs` | Update for new constructor shape |
+| `tests/.../FullAggregationScannerTests.cs` | New: scanner unit tests |
+
+---
+
+## 3. Component Design
+
+### 3.1 FocusedTableRow (new)
+
+**File:** `src/Engine/IO/DrillDown/FocusedTableRow.cs`
+**Namespace:** `DataMorph.Engine.IO.DrillDown`
+**Estimated size:** ~5 lines
+
+```csharp
+/// <summary>A single row in the FocusedTable: child object bytes and its pre-computed # value.</summary>
+public readonly record struct FocusedTableRow(JsonRawBytes Bytes, string HashValue);
+```
+
+`public` visibility: referenced by App layer (`FocusedTableSource`, `ModeController`).
+
+`struct` is chosen over `class` as a minor optimization: when stored in `IReadOnlyList<FocusedTableRow>`, elements are laid out inline in the backing array, avoiding per-element object header allocation and one level of indirection. The benefit is marginal at typical row counts (hundreds to thousands) because the actual data (`byte[]` behind `JsonRawBytes` and `string`) still lives on the heap. A `readonly record` (class) would be equally valid.
+
+`Bytes` always contains valid JSON object bytes. For object and array-of-object leaves this is the
+raw child bytes from the file. For primitive leaves and array-of-primitive leaves, `Bytes` holds a
+synthetic object constructed by `FullAggregationScanner` (see Section 3.7).
+
+### 3.2 DrillDownState (modified)
+
+**File:** `src/App/DrillDownState.cs`
+
+Replace the three-field constructor with:
+
+```csharp
+internal sealed record DrillDownState(
+    IReadOnlyList<FocusedTableRow> Rows,
+    TableSchema Schema);
+```
+
+`Format` and `RecordPosition` are removed — each `FocusedTableRow.HashValue` already holds the
+final `#` string, making them redundant.
+
+### 3.3 FocusedTableSource (refactored)
+
+**File:** `src/App/Views/FocusedTableSource.cs`
+
+Constructor accepts `DrillDownState` (unchanged call site).
+Internal state changes:
+
+| Old field | New field | Change |
+|-----------|-----------|--------|
+| `_childRawValues` | `_rows` (`IReadOnlyList<FocusedTableRow>`) | Replaces raw bytes list |
+| `_recordPosition` | *(removed)* | Hash pre-computed per row |
+
+```
+Rows    = _rows.Count                                            (unchanged)
+Columns = _schema.ColumnCount + 1                               (unchanged)
+this[row, 0] → _rows[row].HashValue                            (replaces FormatHashColumn)
+this[row, n] → JsonObjectCellExtractor.ExtractCell(
+                   _rows[row].Bytes.Span,
+                   _columnNamesUtf8[n - 1])                    (unchanged)
+```
+
+`FormatHashColumn()` is removed. Because all rows carry synthesized or real JSON objects in
+`Bytes`, `JsonObjectCellExtractor` works without modification.
+
+### 3.4 DrillDownRequest (modified)
+
+**File:** `src/App/DrillDownRequest.cs`
+
+Replace the single `DrillDownRequest` with a base type and two dedicated subtypes,
+aligned with the already-split method signatures in `ViewManager` and `ModeController`.
+
+```csharp
+internal abstract record DrillDownRequest(DataFormat Format);
+
+/// <summary>Single-node DrillDown: JSON Object format, operates on the selected node only.</summary>
+internal sealed record SingleDrillDownRequest(
+    DataFormat Format,
+    JsonRawBytes NodeBytes)
+    : DrillDownRequest(Format);
+
+/// <summary>Full-aggregation DrillDown: JSON Lines / JSON Array format, scans the entire file.</summary>
+internal sealed record FullAggregationDrillDownRequest(
+    DataFormat Format,
+    IReadOnlyList<string> KeyPath)
+    : DrillDownRequest(Format);
+```
+
+`KeyPath` is the ordered list of path segments from root to the selected node, built by
+`AppKeyHandler.BuildKeyPath` at trigger time.
+
+### 3.5 JsonObjectTreeNode / JsonArrayTreeNode / JsonValueTreeNode (modified)
+
+**Files:** `src/App/Views/JsonObjectTreeNode.cs`, `src/App/Views/JsonArrayTreeNode.cs`,
+`src/App/Views/JsonValueTreeNode.cs`
+
+Add `ParentNode` to `JsonObjectTreeNode` and `JsonArrayTreeNode`:
+
+```csharp
+public ITreeNode? ParentNode { get; init; }
+```
+
+`JsonValueTreeNode` represents primitive leaf nodes. It currently has no `KeyName` or `ParentNode`.
+Add both properties so `BuildKeyPath` can traverse through it:
+
+```csharp
+// Add to JsonValueTreeNode
+public string? KeyName { get; init; }
+public ITreeNode? ParentNode { get; init; }
+```
+
+The `KeyName` for a `JsonValueTreeNode` is the label already passed at construction time
+(the property name, e.g., `"score"`).
+
+In `JsonTreeNodeHelper.CreateChildNode` (and its variants `CreateNestedObjectNode`,
+`CreateNestedArrayNode`), add a `ITreeNode? parentNode` parameter and pass it through when
+constructing each node type:
+
+```csharp
+new JsonObjectTreeNode(...)
+{
+    KeyName    = label,
+    ParentNode = parentNode,
+}
+new JsonValueTreeNode(...)
+{
+    KeyName    = label,
+    ParentNode = parentNode,
+}
+```
+
+Root nodes have `ParentNode = null`.
+
+**Memory cost:** one 8-byte pointer per node. No list object is allocated per node at
+construction time.
+
+### 3.6 SchemaScanner (new)
+
+**File:** `src/Engine/IO/DrillDown/SchemaScanner.cs`
+**Namespace:** `DataMorph.Engine.IO.DrillDown`
+
+Stateless static class holding the schema-accumulation logic previously private to
+`DrillDownSchemaExtractor`. Both `DrillDownSchemaExtractor.BuildSchema` (Phase 1) and
+`FullAggregationScanner` (Phase 2) call these methods directly and own their own accumulator
+collections (`keyOrder`, `keySet`, `columnTypes`, `keyObservedCount`) as local variables —
+`SchemaScanner` holds no state of its own. Signatures are unchanged from the current
+`DrillDownSchemaExtractor` implementation; only the owning class changes.
+
+```csharp
+internal static class SchemaScanner
+{
+    public static void ScanObject(
+        ReadOnlySpan<byte> objectBytes,
+        List<string> keyOrder,
+        HashSet<string> keySet,
+        Dictionary<string, ColumnType> columnTypes,
+        HashSet<string> observedKeys);
+
+    public static void RegisterKeyIfNew(
+        string key,
+        List<string> keyOrder,
+        HashSet<string> keySet);
+
+    public static void IncrementObservationCounts(
+        HashSet<string> observedKeys,
+        Dictionary<string, int> keyObservedCount);
+
+    public static TableSchema BuildTableSchema(
+        List<string> keyOrder,
+        Dictionary<string, ColumnType> columnTypes,
+        Dictionary<string, int> keyObservedCount,
+        int totalRowCount,    // pass rows.Count after the scan loop completes
+        DataFormat format);
+}
+```
+
+`ScanSingleProperty` and `MergeColumnType` move here too, as `private` implementation details of
+`ScanObject`.
+
+**Why a separate class instead of exposing `DrillDownSchemaExtractor` internals:** making these
+methods `internal` on `DrillDownSchemaExtractor` would make `FullAggregationScanner` (a Phase 2
+component) depend on a Phase 1 component's implementation details. With `SchemaScanner` as a
+sibling that both depend on, neither scanner depends on the other.
+
+**`DrillDownSchemaExtractor.BuildSchema`** (Phase 1) becomes a thin caller with no behavior
+change from the current implementation:
+
+```csharp
+private static Result<TableSchema> BuildSchema(List<JsonRawBytes> childRawValues, DataFormat format)
+{
+    List<string> keyOrder = [];
+    var keySet = new HashSet<string>(StringComparer.Ordinal);
+    var columnTypes = new Dictionary<string, ColumnType>(StringComparer.Ordinal);
+    var keyObservedCount = new Dictionary<string, int>(StringComparer.Ordinal);
+
+    foreach (var childBytes in childRawValues)
+    {
+        var observedKeys = new HashSet<string>(StringComparer.Ordinal);
+        SchemaScanner.ScanObject(childBytes.Span, keyOrder, keySet, columnTypes, observedKeys);
+        SchemaScanner.IncrementObservationCounts(observedKeys, keyObservedCount);
+    }
+
+    if (keyOrder.Count == 0)
+        return Results.Failure<TableSchema>("All child objects have no keys");
+
+    return Results.Success(SchemaScanner.BuildTableSchema(
+        keyOrder, columnTypes, keyObservedCount, childRawValues.Count, format));
+}
+```
+
+### 3.7 FullAggregationScanner (new)
+
+**File:** `src/Engine/IO/DrillDown/FullAggregationScanner.cs`
+**Namespace:** `DataMorph.Engine.IO.DrillDown`
+**Estimated size:** ~250 lines
+
+`public` visibility: called by `ModeController` (App layer) cross-assembly.
+
+#### API
+
+```csharp
+public static class FullAggregationScanner
+{
+    /// <summary>
+    /// Scans <paramref name="filePath"/> for all records and traverses <paramref name="keyPath"/>
+    /// to collect leaf values of every matching path. Supports all leaf types: JSON Object,
+    /// JSON Array of Object, JSON Array of Primitive, and scalar Primitive.
+    /// Returns <c>Failure</c> when format is JSON Object, no rows are collected, or
+    /// all collected leaf objects have no keys.
+    /// </summary>
+    public static Result<(TableSchema schema, IReadOnlyList<FocusedTableRow> rows)> Scan(
+        string filePath,
+        DataFormat format,
+        IReadOnlyList<string> keyPath,
+        CancellationToken cancellationToken = default);
+}
+```
+
+#### Top-Level Algorithm
+
+`colName` / `colNameUtf8` are derived from `keyPath` and never change during a scan.
+They are computed once here and threaded through as parameters to avoid per-record allocation.
+
+```
+if format == JsonObject → return Failure("JSON Object format does not support full aggregation.")
+
+Open file with MmapService
+List<FocusedTableRow> rows     = []
+List<string>          keyOrder = []
+keySet           = new HashSet<string>(StringComparer.Ordinal)
+columnTypes      = new Dictionary<string, ColumnType>(StringComparer.Ordinal)
+keyObservedCount = new Dictionary<string, int>(StringComparer.Ordinal)
+
+colName     = LastKeySegment(keyPath)           // pre-computed once
+colNameUtf8 = Encoding.UTF8.GetBytes(colName)  // pre-computed once
+
+dispatch:
+    format == JsonLines → ScanLines(mmap, keyPath, colName, colNameUtf8,
+                                    rows, keyOrder, keySet, columnTypes,
+                                    keyObservedCount, cancellationToken)
+    format == JsonArray → ScanElements(mmap, keyPath, colName, colNameUtf8,
+                                       rows, keyOrder, keySet, columnTypes,
+                                       keyObservedCount, cancellationToken)
+
+if rows.Count == 0 → return Failure("No matching records found.")
+if keyOrder.Count == 0 → return Failure("All child objects have no keys")
+
+schema = SchemaScanner.BuildTableSchema(
+    keyOrder, columnTypes, keyObservedCount, rows.Count, format)
+return Success((schema, rows))
+```
+
+#### ScanLines (JSON Lines)
+
+Newline detection mirrors `RowReader.FindNextLineLength` — UTF-8 BOM detection, `Array.MaxLength`
+guard, and trailing-line-without-newline handling.
+
+```
+recordPosition = 1L   (1-based)
+scan line by line:
+    for each line bytes (trimmed of \r\n):
+        cancellationToken.ThrowIfCancellationRequested()
+        if line is empty → recordPosition++; continue
+        TryExtractRows(lineBytes, keyPath, recordPosition.ToString(),
+                       colName, colNameUtf8, rows,
+                       keyOrder, keySet, columnTypes, keyObservedCount)
+        recordPosition++
+```
+
+#### ScanElements (JSON Array)
+
+```
+recordPosition = 0L   (0-based)
+using Utf8JsonReader on mmap span:
+    expect StartArray token at root depth
+    for each element at depth 1:
+        cancellationToken.ThrowIfCancellationRequested()
+        elementBytes = extract element bytes
+        TryExtractRows(elementBytes, keyPath, recordPosition.ToString(),
+                       colName, colNameUtf8, rows,
+                       keyOrder, keySet, columnTypes, keyObservedCount)
+        recordPosition++
+```
+
+#### TryExtractRows
+
+```
+input: recordBytes, keyPath, posHash (string), colName, colNameUtf8, rows,
+       keyOrder, keySet, columnTypes, keyObservedCount
+
+TraverseKeyPath(recordBytes, keyPath, segmentIndex: 0, posHash,
+                colName, colNameUtf8, rows,
+                keyOrder, keySet, columnTypes, keyObservedCount)
+```
+
+#### TraverseKeyPath (recursive; depth bounded by keyPath.Count)
+
+```
+input: currentBytes, keyPath, segIdx, posHash,
+       colName, colNameUtf8, rows, keyOrder, keySet, columnTypes, keyObservedCount
+
+if segIdx == keyPath.Count:
+    CollectLeafRows(currentBytes, posHash, colName, colNameUtf8,
+                    rows, keyOrder, keySet, columnTypes, keyObservedCount)
+    return
+
+segment = keyPath[segIdx]
+
+if segment starts with '[':
+    // Index segment → expand all array elements
+    if first token of currentBytes != StartArray → return  // wrong type, skip silently
+    elementIdx = 0
+    for each element bytes in currentBytes (via Utf8JsonReader):
+        TraverseKeyPath(elementBytes, keyPath, segIdx + 1, $"{posHash}:{elementIdx}",
+                        colName, colNameUtf8, rows,
+                        keyOrder, keySet, columnTypes, keyObservedCount)
+        elementIdx++
+else:
+    // Key segment → navigate into object
+    if first token of currentBytes != StartObject → return  // wrong type, skip silently
+    valueBytes = FindValueByKey(currentBytes, segment)
+    if valueBytes is null → return  // key absent, skip silently
+    TraverseKeyPath(valueBytes, keyPath, segIdx + 1, posHash,
+                    colName, colNameUtf8, rows,
+                    keyOrder, keySet, columnTypes, keyObservedCount)
+```
+
+#### CollectLeafRows
+
+Determines row(s) to emit based on the token type at the leaf position reached after
+full KeyPath traversal.
+
+```
+input: leafBytes, posHash, colName, colNameUtf8, rows,
+       keyOrder, keySet, columnTypes, keyObservedCount
+
+tokenType = first JSON token of leafBytes
+
+case StartObject:
+    // JSONObject leaf — one row per record (or per array element from TraverseKeyPath)
+    rows.Add(new FocusedTableRow(leafBytes, posHash))
+    observedKeys = new HashSet<string>(StringComparer.Ordinal)
+    SchemaScanner.ScanObject(leafBytes.Span, keyOrder, keySet,
+                              columnTypes, observedKeys)
+    SchemaScanner.IncrementObservationCounts(observedKeys, keyObservedCount)
+
+case StartArray:
+    // JSONArray leaf — expand each element; # gains one level
+    elementIdx = 0
+    for each element in leafBytes (via Utf8JsonReader):
+        elHash = $"{posHash}:{elementIdx}"
+        if element is StartObject:
+            rows.Add(new FocusedTableRow(elementBytes, elHash))
+            observedKeys = new HashSet<string>(StringComparer.Ordinal)
+            SchemaScanner.ScanObject(elementBytes.Span, keyOrder, keySet,
+                                      columnTypes, observedKeys)
+            SchemaScanner.IncrementObservationCounts(observedKeys, keyObservedCount)
+        else:
+            // Primitive element → synthesize {"value": <element>}
+            synthBytes = SynthesizeObject("value"u8, elementBytes.Span)
+            rows.Add(new FocusedTableRow(synthBytes, elHash))
+            SchemaScanner.RegisterKeyIfNew("value", keyOrder, keySet)
+            var valueObserved = new HashSet<string>(StringComparer.Ordinal) { "value" }
+            SchemaScanner.IncrementObservationCounts(valueObserved, keyObservedCount)
+        elementIdx++
+
+default (Primitive):
+    // Primitive leaf → synthesize {<colName>: <leaf>}
+    // colName and colNameUtf8 are pre-computed from LastKeySegment(keyPath)
+    synthBytes = SynthesizeObject(colNameUtf8, leafBytes.Span)
+    rows.Add(new FocusedTableRow(synthBytes, posHash))
+    SchemaScanner.RegisterKeyIfNew(colName, keyOrder, keySet)
+    var colObserved = new HashSet<string>(StringComparer.Ordinal) { colName }
+    SchemaScanner.IncrementObservationCounts(colObserved, keyObservedCount)
+    // Note: ScanObject is NOT called here, so no type inference is performed.
+    // The synthesized column will receive ColumnType.Text (BuildTableSchema default).
+    // This is a known Phase 2 limitation — numeric primitive leaves are not typed as Number.
+```
+
+> **Phase 2 Limitation:** Synthesized primitive columns (`"value"` for array-of-primitive leaves,
+> and the key-named column for scalar primitive leaves) always receive `ColumnType.Text`.
+> `ScanObject` is not called on synthesized objects, so `TypeInferrer` never runs for these paths.
+> As a result, a numeric field such as `{"score": 88}` will be typed as `Text`, not `Number`.
+> Typed inference for synthesized primitives is deferred to a future phase.
+
+#### FindValueByKey (private)
+
+Parses `objectBytes` as a JSON object with `Utf8JsonReader`, returns
+`JsonByteExtractor.ExtractNestedBytes` for the value when `PropertyName == key`; returns `null`
+if the key is absent.
+
+#### SynthesizeObject (private)
+
+Creates a synthetic single-key JSON object for primitive rows so that `JsonObjectCellExtractor`
+can extract cell values without modification:
+
+```csharp
+private static JsonRawBytes SynthesizeObject(ReadOnlySpan<byte> keyUtf8, ReadOnlySpan<byte> valueBytes)
+{
+    var buffer = new ArrayBufferWriter<byte>();
+    var writer = new Utf8JsonWriter(buffer);
+    writer.WriteStartObject();
+    writer.WritePropertyName(keyUtf8);
+    writer.WriteRawValue(valueBytes, skipInputValidation: true);
+    writer.WriteEndObject();
+    writer.Flush();
+    return new JsonRawBytes(buffer.WrittenMemory);
+}
+```
+
+Uses `Utf8JsonWriter` for correct JSON encoding (Native AOT compatible, no reflection).
+`skipInputValidation: true` is safe because `valueBytes` originates from `Utf8JsonReader`.
+
+#### LastKeySegment (private)
+
+```csharp
+private static string LastKeySegment(IReadOnlyList<string> keyPath)
+{
+    for (var i = keyPath.Count - 1; i >= 0; i--)
+        if (!keyPath[i].StartsWith('['))
+            return keyPath[i];
+    return "value"; // fallback: all segments are index segments
+}
+```
+
+### 3.8 ModeController (modified)
+
+**File:** `src/App/ModeController.cs`
+
+#### Update `DrillDown()` — Phase 1 row creation
+
+```csharp
+public Result DrillDown(SingleDrillDownRequest request)
+{
+    ArgumentNullException.ThrowIfNull(request);
+
+    var result = DrillDownSchemaExtractor.ExtractFromNode(request.NodeBytes, request.Format);
+    if (result.IsFailure)
+        return Results.Failure(result.Error);
+
+    var children = result.Value.childRawValues;
+    var rows = new FocusedTableRow[children.Count];
+    for (var i = 0; i < children.Count; i++)
+        rows[i] = new FocusedTableRow(children[i], $"[{i}]");
+
+    _state.DrillDown = new DrillDownState(rows, result.Value.schema);
+    _state.CurrentMode = ViewMode.FocusedTable;
+    return Results.Success();
+}
+```
+
+#### New `FullAggregationDrillDownAsync()`
+
+Returns `Result<DrillDownState>` rather than mutating `AppState`. All state mutation is
+deferred to the UI thread in `ViewManager` (see Section 3.9).
+
+```csharp
+/// <summary>
+/// Executes the DrillDown Phase 2 file scan on a background thread and returns the result.
+/// Does not mutate AppState — the caller is responsible for applying the result on the UI thread.
+/// </summary>
+public async ValueTask<Result<DrillDownState>> FullAggregationDrillDownAsync(FullAggregationDrillDownRequest request)
+{
+    ArgumentNullException.ThrowIfNull(request);
+
+    // Capture by value before Task.Run to avoid reading _state on the thread-pool thread.
+    var filePath = _state.CurrentFilePath;
+    var ct = _state.Cts.Token;
+
+    var result = await Task.Run(() =>
+        FullAggregationScanner.Scan(filePath, request.Format, request.KeyPath, ct), ct);
+
+    if (result.IsFailure)
+        return Results.Failure<DrillDownState>(result.Error);
+
+    return Results.Success(new DrillDownState(result.Value.rows, result.Value.schema));
+}
+```
+
+Note: `FullAggregationDrillDownAsync` always suspends via `Task.Run` and never completes
+synchronously, so `ValueTask` provides no allocation benefit over `Task` here. `ValueTask` is
+retained for API consistency with other async `ModeController` methods.
+
+**Current limitation:** `FullAggregationScanner.Scan` accumulates all `rows` and the schema in
+memory and returns them only once, after the entire file has been scanned. The table has no
+visibility into the scan until it is 100% complete, so for very large files (millions of
+records) the UI shows no change for the whole scan duration.
+
+**Future optimization:** streaming partial results (new rows/columns) to the table as the scan
+progresses would require `Scan` to report progress incrementally (e.g., via a throttled
+callback) and `DrillDownState` to change from a one-shot immutable result into a structure the
+UI thread can append to over time. Deferred to a future phase (see Scope).
+
+### 3.9 ViewManager (modified)
+
+**File:** `src/App/ViewManager.cs`
+
+All mutations of `_state.DrillDown` and `_state.CurrentMode` are performed inside
+`_uiThreadInvoke` to eliminate cross-thread writes.
+
+```csharp
+/// <summary>
+/// Orchestrates the DrillDown Phase 2 transition: offloads file scan to a background thread
+/// via ModeController, then applies state and switches to FocusedTable view on the UI thread.
+/// </summary>
+internal async ValueTask FullAggregationDrillDownAsync(FullAggregationDrillDownRequest request)
+{
+    var result = await _modeController.FullAggregationDrillDownAsync(request);
+    _uiThreadInvoke(() =>
+    {
+        if (result.IsFailure)
+        {
+            ShowError(result.Error);
+            return;
+        }
+
+        _state.DrillDown = result.Value;
+        _state.CurrentMode = ViewMode.FocusedTable;
+        SwitchToFocusedTable(result.Value);
+    });
+}
+```
+
+`SwitchToFocusedTable(DrillDownState)` is unchanged.
+
+### 3.10 AppKeyHandler (modified)
+
+**File:** `src/App/AppKeyHandler.cs` — `HandleActionMenu()` tree-view branch
+
+```
+if currentView is MorphTreeView tv:
+    if tv.SelectedObject is not ITreeNode selectedNode → return false
+
+    var format = FormatDetector.Detect(_state.CurrentFilePath)
+    if format.IsFailure → show error, return false
+
+    if format.Value == DataFormat.JsonObject:
+        // Phase 1: retain existing behavior — only JsonArrayTreeNode with JsonObject children
+        if selectedNode is not JsonArrayTreeNode arrayNode → return false
+        if arrayNode.Children.Count == 0 → return false
+        if any child is not JsonObjectTreeNode → return false
+
+        var request = new SingleDrillDownRequest(
+            Format: format.Value,
+            NodeBytes: arrayNode.RawJson)
+
+        void onConfirmed(string _) → _viewManager.DrillDown(request)
+
+    else:
+        // Phase 2: JSON Lines / JSON Array — any node type, always full scan
+        var keyPath = BuildKeyPath(selectedNode)
+
+        var request = new FullAggregationDrillDownRequest(
+            Format: format.Value,
+            KeyPath: keyPath)
+
+        void onConfirmed(string _)
+            _ = _viewManager.FullAggregationDrillDownAsync(request)
+                    .AsTask()
+                    .ContinueWith(HandleTaskError, TaskScheduler.Default)
+
+    var dialog = new ActionMenuDialog(["DrillDown"], onConfirmed)
+    _app.Run(dialog)
+    return true
+```
+
+`HandleTaskError` follows the same error-reporting pattern used elsewhere in `AppKeyHandler`
+for fire-and-forget async operations.
+
+#### BuildKeyPath (private static)
+
+Traverses the `ParentNode` chain from the selected node up to the root, collecting `KeyName`
+segments in bottom-up order, then reverses to produce a root-to-leaf path.
+
+```csharp
+private static IReadOnlyList<string> BuildKeyPath(ITreeNode node)
+{
+    List<string> segments = [];
+    ITreeNode? current = node;
+
+    while (current is JsonObjectTreeNode or JsonArrayTreeNode or JsonValueTreeNode)
+    {
+        var (keyName, parent) = current switch
+        {
+            JsonObjectTreeNode obj => (obj.KeyName, obj.ParentNode),
+            JsonArrayTreeNode arr  => (arr.KeyName, arr.ParentNode),
+            JsonValueTreeNode val  => (val.KeyName, val.ParentNode),
+            _                      => throw new UnreachableException(),
+        };
+
+        if (keyName is not null)
+            segments.Add(keyName);
+
+        current = parent;
+    }
+
+    segments.Reverse();
+    return segments;
+}
+```
+
+Root nodes have `ParentNode = null` and `KeyName = null`; the loop stops when `current` is
+none of the three handled types (i.e., root sentinel or unknown type).
+
+---
+
+## 4. Thread Safety
+
+| Component | Safety | Mechanism |
+|-----------|--------|-----------|
+| `FocusedTableRow` | Thread-safe | Immutable record struct |
+| `SchemaScanner` | Thread-safe | Stateless static class; holds no fields, operates only on collections passed in by the caller |
+| `FullAggregationScanner.Scan` | Thread-safe | Stateless static method; all state is local |
+| `DrillDownState` | UI thread only | Immutable after construction; consumed only on UI thread |
+| `ModeController.FullAggregationDrillDownAsync` | Safe | Returns `Result<DrillDownState>` without mutating `AppState`; no cross-thread writes |
+| `ViewManager.FullAggregationDrillDownAsync` | Safe | `_state.DrillDown` and `_state.CurrentMode` assigned exclusively inside `_uiThreadInvoke` |
+| `JsonObjectTreeNode / JsonArrayTreeNode / JsonValueTreeNode ParentNode` | Thread-safe | `init`-only; set once at construction; read-only thereafter |
+
+---
+
+## 5. Test Plan
+
+### 5.1 FullAggregationScannerTests
+
+Scenarios that share identical logic for `DataFormat.JsonLines` and `DataFormat.JsonArray`
+must be written as `[Theory]` with `[InlineData(DataFormat.JsonLines)]` /
+`[InlineData(DataFormat.JsonArray)]`, not as duplicate `[Fact]` methods.
+
+**Path traversal and leaf collection:**
+
+| Scenario | Test kind | Expected |
+|----------|-----------|----------|
+| JSONObject leaf — key in all records → 1 row per record | `[Theory]` | Correct rows; `#` = `{pos}` |
+| JSONArray-of-JSONObject leaf — key in all records → rows per element | `[Theory]` | Correct rows; `#` = `{pos}:{i}` |
+| JSONArray-of-Primitive leaf — key in all records → rows with `value` column | `[Theory]` | Correct rows; `#` = `{pos}:{i}`; column = `"value"` |
+| Primitive leaf (scalar value) | `[Theory]` | Correct rows; `#` = `{pos}`; column = last key segment |
+| `[n]` segment in path → same output as selecting the parent array directly | `[Theory]` | Identical rows from `["orders"]` and `["orders", "[0]"]` |
+| Deep path with 2 `[n]` segments → `#` has 2 `:` separators | `[Theory]` | `#` = `{pos}:{i}:{j}` |
+| Key missing in some records → skipped silently | `[Theory]` | Only rows from matching records |
+| Key segment followed by non-object token → skip record silently | `[Theory]` | Only rows from matching records |
+| Index segment followed by non-array token → skip record silently | `[Theory]` | Only rows from matching records |
+| No records match → `Result.Failure` | `[Theory]` | `"No matching records found."` |
+| JSON Object format → `Result.Failure` | `[Fact]` | Error about unsupported format |
+| All matched leaf objects are `{}` (empty) → `Result.Failure` | `[Theory]` | `"All child objects have no keys"` |
+| Union schema: varying keys across records → all present; missing nullable | `[Theory]` | All keys; nullable where absent |
+| Cancellation mid-scan → `OperationCanceledException` propagates | `[Theory]` | Exception thrown |
+| Nested object/array value in object row → rendered as `{...}` / `[...]` | `[Theory]` | Cell value is `{...}` or `[...]` |
+| Leaf value is JSON `null` → one null row emitted (Section 1.6) | `[Theory]` | One row with null cell values; not skipped |
+| Empty array `[]` at leaf position → record contributes 0 rows; others still collected | `[Theory]` | Rows from non-empty-array records only |
+| Mixed array: some elements are objects, others are primitives | `[Theory]` | Object elements produce object rows; primitive elements produce `{"value": x}` rows |
+| UTF-8 multi-byte property name as column identifier | `[Theory]` | Column name round-trips correctly through `Encoding.UTF8.GetBytes` / `Utf8JsonReader` |
+
+### 5.2 FocusedTableSourceTests (updated)
+
+| Scenario | Expected |
+|----------|----------|
+| `Rows` = row count | Correct |
+| `Columns` = schema.ColumnCount + 1 | Correct |
+| `ColumnNames[0]` = `"#"` | Correct |
+| `this[row, 0]` = `row.HashValue` | Correct (pre-computed, format-agnostic) |
+| `this[row, n]` (n > 0) delegates to `JsonObjectCellExtractor` | Correct cell value |
+| `row < 0` or `row >= Rows` | `ArgumentOutOfRangeException` |
+| `col < 0` or `col >= Columns` | `ArgumentOutOfRangeException` |
+
+### 5.3 ModeController — Phase 1 DrillDown (updated)
+
+Verify that `DrillDown()` still produces correct `DrillDownState.Rows`:
+
+| Scenario | Expected `HashValue` for child 0 |
+|----------|----------------------------------|
+| JSON Object, 3 children | `"[0]"` |
+| JSON Object, 1 child | `"[0]"` |
+
+---
+
+## 6. Files to Create / Modify
+
+| File | Action | Purpose |
+|------|--------|---------|
+| `src/Engine/IO/DrillDown/FocusedTableRow.cs` | Create | Value type: child bytes + pre-computed hash value |
+| `src/Engine/IO/DrillDown/SchemaScanner.cs` | Create | Stateless static helpers (`ScanObject`, `RegisterKeyIfNew`, `IncrementObservationCounts`, `BuildTableSchema`) shared by `DrillDownSchemaExtractor` and `FullAggregationScanner` |
+| `src/Engine/IO/DrillDown/FullAggregationScanner.cs` | Create | Full file scan: traverse KeyPath; collect rows for all leaf types; build union schema |
+| `src/Engine/IO/DrillDown/DrillDownSchemaExtractor.cs` | Modify | `BuildSchema` delegates to `SchemaScanner`; `ScanObject`/`RegisterKeyIfNew`/`IncrementObservationCounts`/`MergeColumnType` move out |
+| `src/App/DrillDownState.cs` | Modify | Replace `ChildRawValues / Format / RecordPosition` with `IReadOnlyList<FocusedTableRow> Rows` |
+| `src/App/Views/FocusedTableSource.cs` | Modify | Accept new `DrillDownState`; replace `FormatHashColumn` with `_rows[row].HashValue` |
+| `src/App/DrillDownRequest.cs` | Modify | Split the single record into an abstract `DrillDownRequest` base plus `SingleDrillDownRequest` and `FullAggregationDrillDownRequest` |
+| `src/App/Views/JsonObjectTreeNode.cs` | Modify | Add `public ITreeNode? ParentNode { get; init; }` |
+| `src/App/Views/JsonArrayTreeNode.cs` | Modify | Add `public ITreeNode? ParentNode { get; init; }` |
+| `src/App/Views/JsonValueTreeNode.cs` | Modify | Add `public string? KeyName { get; init; }` and `public ITreeNode? ParentNode { get; init; }` |
+| `src/App/Views/JsonTreeNodeHelper.cs` | Modify | Add `ITreeNode? parentNode` parameter to `CreateChildNode`, `CreateNestedObjectNode`, `CreateNestedArrayNode`; pass through to node constructors |
+| `src/App/ModeController.cs` | Modify | Update `DrillDown()` to build rows inline; add `FullAggregationDrillDownAsync()` returning `Result<DrillDownState>` |
+| `src/App/ViewManager.cs` | Modify | Add `FullAggregationDrillDownAsync()`; assign state inside `_uiThreadInvoke` |
+| `src/App/AppKeyHandler.cs` | Modify | Single "DrillDown" option; add `BuildKeyPath`; dispatch Phase 1 (JSON Object) vs Phase 2 (JSON Lines/Array) |
+| `tests/.../FocusedTableSourceTests.cs` | Modify | Update for new `DrillDownState` shape |
+| `tests/.../FullAggregationScannerTests.cs` | Create | Scanner unit tests |
+
+---
+
+## 7. Acceptance Criteria
+
+- [ ] `x` key on any tree node (JSON Lines / JSON Array) opens ActionMenu with a single "DrillDown" option
+- [ ] `x` key on a non-JsonArrayTreeNode node in a JSON Object file does NOT show the ActionMenu
+- [ ] "DrillDown" on a JSONObject leaf collects one row per record; `#` = record position
+- [ ] "DrillDown" on a JSONArray-of-JSONObject leaf collects one row per child element; `#` = `{pos}:{i}`
+- [ ] "DrillDown" on a JSONArray-of-Primitive leaf shows a single `value` column; `#` = `{pos}:{i}`
+- [ ] "DrillDown" on a Primitive leaf shows a single column named after the key; `#` = record position
+- [ ] Selecting `orders` and `orders[0]` produces identical DrillDown output
+- [ ] Records where the key path is absent or the token type mismatches are silently skipped
+- [ ] If no records produce any rows, an error dialog is shown
+- [ ] `#` column depth (number of `:` separators) equals the number of arrays traversed along the path
+- [ ] Phase 1 "DrillDown" on JSON Object format continues to work correctly after the refactor
+- [ ] `FocusedTableSource` and `DrillDownState` use `FocusedTableRow` (no per-source Format/RecordPosition)
+- [ ] Unit tests pass for `FullAggregationScanner` and updated `FocusedTableSourceTests`

--- a/src/App/AppKeyHandler.cs
+++ b/src/App/AppKeyHandler.cs
@@ -222,11 +222,9 @@ internal sealed class AppKeyHandler : IDisposable
                 return false;
             }
 
-            var request = new DrillDownRequest(
+            var request = new SingleDrillDownRequest(
                 Format: treeFormat.Value,
-                NodeBytes: arrayNode.RawJson,
-                KeyName: arrayNode.KeyName,
-                RecordPosition: arrayNode.RecordPosition);
+                NodeBytes: arrayNode.RawJson);
 
             void onDrillDownConfirmed(string actionName) => _viewManager.DrillDown(request);
 
@@ -237,6 +235,29 @@ internal sealed class AppKeyHandler : IDisposable
 
         return false;
     }
+
+    /// <summary>
+    /// Full Aggregation DrillDown: JSON Lines / JSON Array format, any node type, always a full file scan.
+    /// Not yet wired into <see cref="HandleActionMenu"/> — routing is added in Step 2.
+    /// </summary>
+    private bool HandleFullAggregationDrillDown(ITreeNode selectedNode, DataFormat format) =>
+        throw new NotImplementedException();
+
+    /// <summary>
+    /// Reports an unhandled exception from a fire-and-forget async operation via the error view.
+    /// </summary>
+    private void HandleTaskError(Task task) =>
+        throw new NotImplementedException();
+
+    /// <summary>
+    /// Traverses the <c>ParentNode</c> chain from <paramref name="node"/> up to the root,
+    /// collecting <c>KeyName</c> segments in bottom-up order, then reverses to produce a
+    /// root-to-leaf KeyPath.
+    /// </summary>
+    /// <param name="node">The selected tree node to build the KeyPath from.</param>
+    /// <returns>An ordered list of path segments from root to <paramref name="node"/>.</returns>
+    private static IReadOnlyList<string> BuildKeyPath(ITreeNode node) =>
+        throw new NotImplementedException();
 
     /// <summary>
     /// Handles the clear action stack shortcut (c).

--- a/src/App/AppKeyHandler.cs
+++ b/src/App/AppKeyHandler.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using DataMorph.App.Views;
 using DataMorph.App.Views.Dialogs;
@@ -199,18 +200,7 @@ internal sealed class AppKeyHandler : IDisposable
 
         if (currentView is MorphTreeView tv)
         {
-            if (tv.SelectedObject is not JsonArrayTreeNode arrayNode)
-            {
-                return false;
-            }
-
-            var children = arrayNode.Children;
-            if (children.Count == 0)
-            {
-                return false;
-            }
-
-            if (children.Any(c => c is not JsonObjectTreeNode))
+            if (tv.SelectedObject is not ITreeNode selectedNode)
             {
                 return false;
             }
@@ -222,32 +212,90 @@ internal sealed class AppKeyHandler : IDisposable
                 return false;
             }
 
-            var request = new SingleDrillDownRequest(
-                Format: treeFormat.Value,
-                NodeBytes: arrayNode.RawJson);
+            if (treeFormat.Value == DataFormat.JsonObject)
+            {
+                return HandleSingleDrillDown(selectedNode, treeFormat.Value);
+            }
 
-            void onDrillDownConfirmed(string actionName) => _viewManager.DrillDown(request);
-
-            var dialog = new ActionMenuDialog(["DrillDown"], onDrillDownConfirmed);
-            _app.Run(dialog);
-            return true;
+            return HandleFullAggregationDrillDown(selectedNode, treeFormat.Value);
         }
 
         return false;
     }
 
     /// <summary>
-    /// Full Aggregation DrillDown: JSON Lines / JSON Array format, any node type, always a full file scan.
-    /// Not yet wired into <see cref="HandleActionMenu"/> — routing is added in Step 2.
+    /// Single-node DrillDown: JSON Object format only. Requires the selected node to be a
+    /// <see cref="JsonArrayTreeNode"/> whose direct children are all <see cref="JsonObjectTreeNode"/>.
     /// </summary>
-    private bool HandleFullAggregationDrillDown(ITreeNode selectedNode, DataFormat format) =>
-        throw new NotImplementedException();
+    [SuppressMessage(
+        "Reliability",
+        "CA2000:Dispose objects before losing scope",
+        Justification = "The dialog is managed by Terminal.Gui's IApplication.Run() and will be disposed automatically."
+    )]
+    private bool HandleSingleDrillDown(ITreeNode selectedNode, DataFormat format)
+    {
+        if (selectedNode is not JsonArrayTreeNode arrayNode)
+        {
+            return false;
+        }
+
+        var children = arrayNode.Children;
+        if (children.Count == 0)
+        {
+            return false;
+        }
+
+        if (children.Any(c => c is not JsonObjectTreeNode))
+        {
+            return false;
+        }
+
+        var request = new SingleDrillDownRequest(
+            Format: format,
+            NodeBytes: arrayNode.RawJson);
+
+        void onDrillDownConfirmed(string actionName) => _viewManager.DrillDown(request);
+
+        var dialog = new ActionMenuDialog(["DrillDown"], onDrillDownConfirmed);
+        _app.Run(dialog);
+        return true;
+    }
+
+    /// <summary>
+    /// Full Aggregation DrillDown: JSON Lines / JSON Array format, any node type, always a full file scan.
+    /// </summary>
+    [SuppressMessage(
+        "Reliability",
+        "CA2000:Dispose objects before losing scope",
+        Justification = "The dialog is managed by Terminal.Gui's IApplication.Run() and will be disposed automatically."
+    )]
+    private bool HandleFullAggregationDrillDown(ITreeNode selectedNode, DataFormat format)
+    {
+        var keyPath = BuildKeyPath(selectedNode);
+        var request = new FullAggregationDrillDownRequest(
+            Format: format,
+            KeyPath: keyPath);
+
+        void onDrillDownConfirmed(string actionName) =>
+            _ = _viewManager.FullAggregationDrillDownAsync(request)
+                .AsTask()
+                .ContinueWith(HandleTaskError, TaskScheduler.Default);
+
+        var dialog = new ActionMenuDialog(["DrillDown"], onDrillDownConfirmed);
+        _app.Run(dialog);
+        return true;
+    }
 
     /// <summary>
     /// Reports an unhandled exception from a fire-and-forget async operation via the error view.
     /// </summary>
-    private void HandleTaskError(Task task) =>
-        throw new NotImplementedException();
+    private void HandleTaskError(Task task)
+    {
+        if (task.IsFaulted && task.Exception is not null)
+        {
+            _app.Invoke(() => _viewManager.ShowError(task.Exception.InnerException?.Message ?? task.Exception.Message));
+        }
+    }
 
     /// <summary>
     /// Traverses the <c>ParentNode</c> chain from <paramref name="node"/> up to the root,
@@ -256,8 +304,38 @@ internal sealed class AppKeyHandler : IDisposable
     /// </summary>
     /// <param name="node">The selected tree node to build the KeyPath from.</param>
     /// <returns>An ordered list of path segments from root to <paramref name="node"/>.</returns>
-    private static IReadOnlyList<string> BuildKeyPath(ITreeNode node) =>
-        throw new NotImplementedException();
+    [SuppressMessage(
+        "Performance",
+        "CA1859:Use concrete types when possible for improved performance",
+        Justification = "IReadOnlyList<string> is the KeyPath contract shared with FullAggregationDrillDownRequest; " +
+            "the concrete List<string> used to build it is an implementation detail that should not leak out."
+    )]
+    internal static IReadOnlyList<string> BuildKeyPath(ITreeNode node)
+    {
+        List<string> segments = [];
+        var current = node;
+
+        while (current is JsonObjectTreeNode or JsonArrayTreeNode or JsonValueTreeNode)
+        {
+            var (keyName, parent) = current switch
+            {
+                JsonObjectTreeNode obj => (obj.KeyName, obj.ParentNode),
+                JsonArrayTreeNode arr => (arr.KeyName, arr.ParentNode),
+                JsonValueTreeNode val => (val.KeyName, val.ParentNode),
+                _ => throw new UnreachableException(),
+            };
+
+            if (keyName is not null)
+            {
+                segments.Add(keyName);
+            }
+
+            current = parent;
+        }
+
+        segments.Reverse();
+        return segments;
+    }
 
     /// <summary>
     /// Handles the clear action stack shortcut (c).

--- a/src/App/AppKeyHandler.cs
+++ b/src/App/AppKeyHandler.cs
@@ -3,6 +3,7 @@ using System.Diagnostics.CodeAnalysis;
 using DataMorph.App.Views;
 using DataMorph.App.Views.Dialogs;
 using DataMorph.App.Views.JsonTreeNodes;
+using DataMorph.Engine.IO.DrillDown;
 using DataMorph.Engine.Types;
 using Terminal.Gui.App;
 using Terminal.Gui.Drivers;
@@ -307,12 +308,12 @@ internal sealed class AppKeyHandler : IDisposable
     [SuppressMessage(
         "Performance",
         "CA1859:Use concrete types when possible for improved performance",
-        Justification = "IReadOnlyList<string> is the KeyPath contract shared with FullAggregationDrillDownRequest; " +
-            "the concrete List<string> used to build it is an implementation detail that should not leak out."
+        Justification = "IReadOnlyList<KeyPathSegment> is the KeyPath contract shared with FullAggregationDrillDownRequest; " +
+            "the concrete List<KeyPathSegment> used to build it is an implementation detail that should not leak out."
     )]
-    internal static IReadOnlyList<string> BuildKeyPath(ITreeNode node)
+    internal static IReadOnlyList<KeyPathSegment> BuildKeyPath(ITreeNode node)
     {
-        List<string> segments = [];
+        List<KeyPathSegment> segments = [];
         var current = node;
 
         while (current is JsonObjectTreeNode or JsonArrayTreeNode or JsonValueTreeNode)
@@ -327,7 +328,11 @@ internal sealed class AppKeyHandler : IDisposable
 
             if (keyName is not null)
             {
-                segments.Add(keyName);
+                // An array element's parent is the JsonArrayTreeNode that labeled it "[n]"; every
+                // other node is an object property. Tagging by parent type — not by the label text —
+                // keeps a literal object key such as "[0]" from colliding with an index marker.
+                var kind = parent is JsonArrayTreeNode ? KeyPathSegmentKind.Index : KeyPathSegmentKind.Key;
+                segments.Add(new KeyPathSegment(keyName, kind));
             }
 
             current = parent;

--- a/src/App/DrillDownRequest.cs
+++ b/src/App/DrillDownRequest.cs
@@ -2,18 +2,22 @@ using DataMorph.Engine.Types;
 
 namespace DataMorph.App;
 
+/// <summary>Base type for DrillDown command requests.</summary>
+/// <param name="Format">Source file format.</param>
+internal abstract record DrillDownRequest(DataFormat Format);
+
+/// <summary>Single-node DrillDown: JSON Object format, operates on the selected node only.</summary>
 /// <param name="Format">Source file format.</param>
 /// <param name="NodeBytes">Raw bytes of the selected node's JSON value.</param>
-/// <param name="KeyName">
-///   Property name this node represents (e.g. "tags").
-///   Null when the selected node is a root-level node (JSON Lines line or JSON Array element).
-/// </param>
-/// <param name="RecordPosition">
-///   1-based line number (JSON Lines) or 0-based element index (JSON Array) of the ancestor
-///   root record. Null for JSON Object format.
-/// </param>
-internal sealed record DrillDownRequest(
+internal sealed record SingleDrillDownRequest(
     DataFormat Format,
-    JsonRawBytes NodeBytes,
-    string? KeyName = null,
-    long? RecordPosition = null);
+    JsonRawBytes NodeBytes)
+    : DrillDownRequest(Format);
+
+/// <summary>Full-aggregation DrillDown: JSON Lines / JSON Array format, scans the entire file.</summary>
+/// <param name="Format">Source file format.</param>
+/// <param name="KeyPath">Ordered path segments from root to the selected node.</param>
+internal sealed record FullAggregationDrillDownRequest(
+    DataFormat Format,
+    IReadOnlyList<string> KeyPath)
+    : DrillDownRequest(Format);

--- a/src/App/DrillDownRequest.cs
+++ b/src/App/DrillDownRequest.cs
@@ -1,3 +1,4 @@
+using DataMorph.Engine.IO.DrillDown;
 using DataMorph.Engine.Types;
 
 namespace DataMorph.App;
@@ -19,5 +20,5 @@ internal sealed record SingleDrillDownRequest(
 /// <param name="KeyPath">Ordered path segments from root to the selected node.</param>
 internal sealed record FullAggregationDrillDownRequest(
     DataFormat Format,
-    IReadOnlyList<string> KeyPath)
+    IReadOnlyList<KeyPathSegment> KeyPath)
     : DrillDownRequest(Format);

--- a/src/App/DrillDownState.cs
+++ b/src/App/DrillDownState.cs
@@ -1,5 +1,5 @@
+using DataMorph.Engine.IO.DrillDown;
 using DataMorph.Engine.Models;
-using DataMorph.Engine.Types;
 
 namespace DataMorph.App;
 
@@ -7,7 +7,5 @@ namespace DataMorph.App;
 /// Holds the in-memory state produced by the DrillDown command.
 /// </summary>
 internal sealed record DrillDownState(
-    IReadOnlyList<JsonRawBytes> ChildRawValues,
-    TableSchema Schema,
-    DataFormat Format,
-    long? RecordPosition);
+    IReadOnlyList<FocusedTableRow> Rows,
+    TableSchema Schema);

--- a/src/App/ModeController.cs
+++ b/src/App/ModeController.cs
@@ -124,6 +124,23 @@ internal sealed class ModeController
     /// </summary>
     /// <param name="request">The full-aggregation DrillDown request carrying the KeyPath.</param>
     /// <returns>A <see cref="Result{T}"/> containing the scanned <see cref="DrillDownState"/> on success.</returns>
-    public ValueTask<Result<DrillDownState>> FullAggregationDrillDownAsync(FullAggregationDrillDownRequest request) =>
-        throw new NotImplementedException();
+    public async ValueTask<Result<DrillDownState>> FullAggregationDrillDownAsync(FullAggregationDrillDownRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        // Capture by value before Task.Run to avoid reading _state on the thread-pool thread.
+        var filePath = _state.CurrentFilePath;
+        var ct = _state.Cts.Token;
+
+        var result = await Task.Run(
+            () => FullAggregationScanner.Scan(filePath, request.Format, request.KeyPath, ct),
+            ct);
+
+        if (result.IsFailure)
+        {
+            return Results.Failure<DrillDownState>(result.Error);
+        }
+
+        return Results.Success(new DrillDownState(result.Value.rows, result.Value.schema));
+    }
 }

--- a/src/App/ModeController.cs
+++ b/src/App/ModeController.cs
@@ -90,12 +90,12 @@ internal sealed class ModeController
     }
 
     /// <summary>
-    /// Executes the DrillDown command for the given request.
+    /// Executes the Single DrillDown command for the given request.
     /// Parses the selected node's bytes in memory, infers schema, and stores results in AppState.
     /// </summary>
     /// <param name="request">The DrillDown request carrying the selected node bytes and context.</param>
     /// <returns>A <see cref="Result"/> indicating success or the reason for failure.</returns>
-    public Result DrillDown(DrillDownRequest request)
+    public Result DrillDown(SingleDrillDownRequest request)
     {
         ArgumentNullException.ThrowIfNull(request);
 
@@ -105,13 +105,25 @@ internal sealed class ModeController
             return Results.Failure(result.Error);
         }
 
-        _state.DrillDown = new DrillDownState(
-            result.Value.childRawValues,
-            result.Value.schema,
-            request.Format,
-            request.RecordPosition);
+        var children = result.Value.childRawValues;
+        var rows = new FocusedTableRow[children.Count];
+        for (var i = 0; i < children.Count; i++)
+        {
+            rows[i] = new FocusedTableRow(children[i], $"[{i}]");
+        }
+
+        _state.DrillDown = new DrillDownState(rows, result.Value.schema);
         _state.CurrentMode = ViewMode.FocusedTable;
 
         return Results.Success();
     }
+
+    /// <summary>
+    /// Executes the Full Aggregation DrillDown file scan on a background thread and returns the result.
+    /// Does not mutate AppState — the caller is responsible for applying the result on the UI thread.
+    /// </summary>
+    /// <param name="request">The full-aggregation DrillDown request carrying the KeyPath.</param>
+    /// <returns>A <see cref="Result{T}"/> containing the scanned <see cref="DrillDownState"/> on success.</returns>
+    public ValueTask<Result<DrillDownState>> FullAggregationDrillDownAsync(FullAggregationDrillDownRequest request) =>
+        throw new NotImplementedException();
 }

--- a/src/App/ViewManager.cs
+++ b/src/App/ViewManager.cs
@@ -480,10 +480,10 @@ internal sealed class ViewManager : IDisposable
     }
 
     /// <summary>
-    /// Orchestrates the DrillDown transition: delegates schema extraction to ModeController,
+    /// Orchestrates the Single DrillDown transition: delegates schema extraction to ModeController,
     /// then switches to FocusedTable view on the UI thread.
     /// </summary>
-    internal void DrillDown(DrillDownRequest request)
+    internal void DrillDown(SingleDrillDownRequest request)
     {
         var result = _modeController.DrillDown(request);
 
@@ -504,6 +504,13 @@ internal sealed class ViewManager : IDisposable
             SwitchToFocusedTable(drillDown);
         });
     }
+
+    /// <summary>
+    /// Orchestrates the Full Aggregation DrillDown transition: offloads file scan to a background thread
+    /// via ModeController, then applies state and switches to FocusedTable view on the UI thread.
+    /// </summary>
+    internal ValueTask FullAggregationDrillDownAsync(FullAggregationDrillDownRequest request) =>
+        throw new NotImplementedException();
 
     /// <summary>
     /// Creates FocusedTableSource and FocusedTableView, then switches to the FocusedTable view.

--- a/src/App/ViewManager.cs
+++ b/src/App/ViewManager.cs
@@ -509,8 +509,28 @@ internal sealed class ViewManager : IDisposable
     /// Orchestrates the Full Aggregation DrillDown transition: offloads file scan to a background thread
     /// via ModeController, then applies state and switches to FocusedTable view on the UI thread.
     /// </summary>
-    internal ValueTask FullAggregationDrillDownAsync(FullAggregationDrillDownRequest request) =>
-        throw new NotImplementedException();
+    internal async ValueTask FullAggregationDrillDownAsync(FullAggregationDrillDownRequest request)
+    {
+        var result = await _modeController.FullAggregationDrillDownAsync(request);
+        _uiThreadInvoke(() =>
+        {
+            // Fail fast before any state mutation: if the ViewManager was disposed between the
+            // background scan completing and this callback running, leave AppState untouched.
+            // SwitchToFocusedTable has its own guard, but state is written here first, so without
+            // this check a dispose race would corrupt AppState before the view-side throw.
+            ObjectDisposedException.ThrowIf(_disposed, this);
+
+            if (result.IsFailure)
+            {
+                ShowError(result.Error);
+                return;
+            }
+
+            _state.DrillDown = result.Value;
+            _state.CurrentMode = ViewMode.FocusedTable;
+            SwitchToFocusedTable(result.Value);
+        });
+    }
 
     /// <summary>
     /// Creates FocusedTableSource and FocusedTableView, then switches to the FocusedTable view.
@@ -518,6 +538,7 @@ internal sealed class ViewManager : IDisposable
     [SuppressMessage("Reliability", "CA2000", Justification = "Owned by container via SwapView.")]
     internal void SwitchToFocusedTable(DrillDownState drillDown)
     {
+        ObjectDisposedException.ThrowIf(_disposed, this);
         var source = new Views.FocusedTableSource(drillDown);
         var view = new Views.FocusedTableView
         {

--- a/src/App/Views/FocusedTableSource.cs
+++ b/src/App/Views/FocusedTableSource.cs
@@ -1,4 +1,5 @@
 using System.Text;
+using DataMorph.Engine.IO.DrillDown;
 using DataMorph.Engine.IO.Json;
 using DataMorph.Engine.Models;
 using Terminal.Gui.Views;
@@ -6,29 +7,26 @@ using Terminal.Gui.Views;
 namespace DataMorph.App.Views;
 
 /// <summary>
-/// ITableSource backed by pre-materialized child object bytes.
-/// Renders the # column using format-specific formatting.
+/// ITableSource backed by pre-materialized <see cref="FocusedTableRow"/> rows.
 /// </summary>
 internal sealed class FocusedTableSource : ITableSource
 {
-    private readonly IReadOnlyList<JsonRawBytes> _childRawValues;
+    private readonly IReadOnlyList<FocusedTableRow> _rows;
     private readonly TableSchema _schema;
-    private readonly long? _recordPosition;
     private readonly string[] _columnNames;
     private readonly byte[][] _columnNamesUtf8;
 
     internal FocusedTableSource(DrillDownState drillDown)
     {
         ArgumentNullException.ThrowIfNull(drillDown);
-        _childRawValues = drillDown.ChildRawValues;
+        _rows = drillDown.Rows;
         _schema = drillDown.Schema;
-        _recordPosition = drillDown.RecordPosition;
         _columnNames = ["#", .. drillDown.Schema.Columns.Select(c => c.Name)];
         _columnNamesUtf8 = [.. drillDown.Schema.Columns.Select(c => Encoding.UTF8.GetBytes(c.Name))];
     }
 
     /// <inheritdoc/>
-    public int Rows => _childRawValues.Count;
+    public int Rows => _rows.Count;
 
     /// <inheritdoc/>
     public int Columns => _schema.ColumnCount + 1;
@@ -53,17 +51,10 @@ internal sealed class FocusedTableSource : ITableSource
 
             if (col == 0)
             {
-                return FormatHashColumn(row);
+                return _rows[row].HashValue;
             }
 
-            return JsonObjectCellExtractor.ExtractCell(_childRawValues[row].Span, _columnNamesUtf8[col - 1]);
+            return JsonObjectCellExtractor.ExtractCell(_rows[row].Bytes.Span, _columnNamesUtf8[col - 1]);
         }
     }
-
-    /// <summary>
-    /// Formats the # column value for the given row index using format-specific rules.
-    /// JSON Lines / JSON Array: {recordPosition}:{row}; JSON Object: [{row}].
-    /// </summary>
-    private string FormatHashColumn(int row) =>
-        _recordPosition is { } pos ? $"{pos}:{row}" : $"[{row}]";
 }

--- a/src/App/Views/JsonTreeNodes/JsonArrayTreeNode.cs
+++ b/src/App/Views/JsonTreeNodes/JsonArrayTreeNode.cs
@@ -18,6 +18,9 @@ internal sealed class JsonArrayTreeNode : TreeNode
     /// <summary>Ancestor root record position. Same semantics as JsonObjectTreeNode.RecordPosition.</summary>
     public long? RecordPosition { get; init; }
 
+    /// <summary>Parent node in the tree, used to build a KeyPath via upward traversal. Null for root nodes.</summary>
+    public ITreeNode? ParentNode { get; init; }
+
     /// <summary>Raw JSON bytes of this node.</summary>
     internal JsonRawBytes RawJson => _rawJson;
 
@@ -88,7 +91,8 @@ internal sealed class JsonArrayTreeNode : TreeNode
                 ref reader,
                 $"[{elementIndex}]",
                 _rawJson,
-                RecordPosition
+                RecordPosition,
+                this
             );
             if (elementNode is not null)
             {

--- a/src/App/Views/JsonTreeNodes/JsonObjectTreeNode.cs
+++ b/src/App/Views/JsonTreeNodes/JsonObjectTreeNode.cs
@@ -21,6 +21,9 @@ internal sealed class JsonObjectTreeNode : TreeNode
     /// </summary>
     public long? RecordPosition { get; init; }
 
+    /// <summary>Parent node in the tree, used to build a KeyPath via upward traversal. Null for root nodes.</summary>
+    public ITreeNode? ParentNode { get; init; }
+
     /// <summary>
     /// Initializes a new instance of the <see cref="JsonObjectTreeNode"/> class.
     /// </summary>
@@ -95,7 +98,7 @@ internal sealed class JsonObjectTreeNode : TreeNode
                 break;
             }
 
-            var childNode = JsonTreeNodeHelper.CreateChildNode(ref reader, propertyName, _rawJson, RecordPosition);
+            var childNode = JsonTreeNodeHelper.CreateChildNode(ref reader, propertyName, _rawJson, RecordPosition, this);
             if (childNode is not null)
             {
                 children.Add(childNode);

--- a/src/App/Views/JsonTreeNodes/JsonTreeNodeHelper.cs
+++ b/src/App/Views/JsonTreeNodes/JsonTreeNodeHelper.cs
@@ -16,40 +16,52 @@ internal static class JsonTreeNodeHelper
     /// <param name="label">The display label prefix (e.g. "name" or "[0]").</param>
     /// <param name="rawJson">The raw JSON bytes for extracting nested structures.</param>
     /// <param name="recordPosition">Ancestor root record position to propagate to child nodes.</param>
+    /// <param name="parentNode">The parent node, used to build a KeyPath via upward traversal.</param>
     /// <returns>A tree node representing the current token, or null if unrecognized.</returns>
     internal static ITreeNode? CreateChildNode(
         ref Utf8JsonReader reader,
         string label,
         JsonRawBytes rawJson,
-        long? recordPosition = null
+        long? recordPosition = null,
+        ITreeNode? parentNode = null
     )
     {
         return reader.TokenType switch
         {
-            JsonTokenType.StartObject => CreateNestedObjectNode(ref reader, label, rawJson, recordPosition),
-            JsonTokenType.StartArray => CreateNestedArrayNode(ref reader, label, rawJson, recordPosition),
+            JsonTokenType.StartObject => CreateNestedObjectNode(ref reader, label, rawJson, recordPosition, parentNode),
+            JsonTokenType.StartArray => CreateNestedArrayNode(ref reader, label, rawJson, recordPosition, parentNode),
             JsonTokenType.String => new JsonValueTreeNode(
                 $"{label}: \"{EscapeString(reader.GetString() ?? string.Empty)}\""
             )
             {
                 ValueKind = JsonValueKind.String,
+                KeyName = label,
+                ParentNode = parentNode,
             },
-            JsonTokenType.Number => CreateNumberNode(ref reader, label),
+            JsonTokenType.Number => CreateNumberNode(ref reader, label, parentNode),
             JsonTokenType.True => new JsonValueTreeNode($"{label}: true")
             {
                 ValueKind = JsonValueKind.True,
+                KeyName = label,
+                ParentNode = parentNode,
             },
             JsonTokenType.False => new JsonValueTreeNode($"{label}: false")
             {
                 ValueKind = JsonValueKind.False,
+                KeyName = label,
+                ParentNode = parentNode,
             },
             JsonTokenType.Null => new JsonValueTreeNode($"{label}: <null>")
             {
                 ValueKind = JsonValueKind.Null,
+                KeyName = label,
+                ParentNode = parentNode,
             },
             _ => new JsonValueTreeNode($"{label}: <unknown>")
             {
                 ValueKind = JsonValueKind.Undefined,
+                KeyName = label,
+                ParentNode = parentNode,
             },
         };
     }
@@ -70,7 +82,8 @@ internal static class JsonTreeNodeHelper
         ref Utf8JsonReader reader,
         string label,
         JsonRawBytes rawJson,
-        long? recordPosition
+        long? recordPosition,
+        ITreeNode? parentNode
     )
     {
         var objectBytes = JsonByteExtractor.ExtractNestedBytes(ref reader, rawJson);
@@ -78,6 +91,7 @@ internal static class JsonTreeNodeHelper
         {
             KeyName = label,
             RecordPosition = recordPosition,
+            ParentNode = parentNode,
         };
     }
 
@@ -85,7 +99,8 @@ internal static class JsonTreeNodeHelper
         ref Utf8JsonReader reader,
         string label,
         JsonRawBytes rawJson,
-        long? recordPosition
+        long? recordPosition,
+        ITreeNode? parentNode
     )
     {
         var arrayBytes = JsonByteExtractor.ExtractNestedBytes(ref reader, rawJson);
@@ -93,16 +108,19 @@ internal static class JsonTreeNodeHelper
         {
             KeyName = label,
             RecordPosition = recordPosition,
+            ParentNode = parentNode,
         };
     }
 
-    private static JsonValueTreeNode CreateNumberNode(ref Utf8JsonReader reader, string label)
+    private static JsonValueTreeNode CreateNumberNode(ref Utf8JsonReader reader, string label, ITreeNode? parentNode)
     {
         if (reader.TryGetDecimal(out var decimalValue))
         {
             return new JsonValueTreeNode($"{label}: {decimalValue}")
             {
                 ValueKind = JsonValueKind.Number,
+                KeyName = label,
+                ParentNode = parentNode,
             };
         }
 
@@ -110,6 +128,8 @@ internal static class JsonTreeNodeHelper
         return new JsonValueTreeNode($"{label}: {doubleValue}")
         {
             ValueKind = JsonValueKind.Number,
+            KeyName = label,
+            ParentNode = parentNode,
         };
     }
 }

--- a/src/App/Views/JsonTreeNodes/JsonValueTreeNode.cs
+++ b/src/App/Views/JsonTreeNodes/JsonValueTreeNode.cs
@@ -23,4 +23,10 @@ internal sealed class JsonValueTreeNode : TreeNode
     /// Gets or initializes the JSON value kind of this node.
     /// </summary>
     public JsonValueKind ValueKind { get; init; }
+
+    /// <summary>Property name this node represents. Null for root-level nodes.</summary>
+    public string? KeyName { get; init; }
+
+    /// <summary>Parent node in the tree, used to build a KeyPath via upward traversal. Null for root nodes.</summary>
+    public ITreeNode? ParentNode { get; init; }
 }

--- a/src/Engine/IO/DrillDown/DrillDownSchemaExtractor.cs
+++ b/src/Engine/IO/DrillDown/DrillDownSchemaExtractor.cs
@@ -1,6 +1,5 @@
 using System.Text.Json;
 using DataMorph.Engine.IO.Json;
-using DataMorph.Engine.IO.JsonLines;
 using DataMorph.Engine.Models;
 using DataMorph.Engine.Types;
 
@@ -96,8 +95,8 @@ public static class DrillDownSchemaExtractor
         foreach (var childBytes in childRawValues)
         {
             var observedKeys = new HashSet<string>(StringComparer.Ordinal);
-            ScanObject(childBytes.Span, keyOrder, keySet, columnTypes, observedKeys);
-            IncrementObservationCounts(observedKeys, keyObservedCount);
+            SchemaScanner.ScanObject(childBytes.Span, keyOrder, keySet, columnTypes, observedKeys);
+            SchemaScanner.IncrementObservationCounts(observedKeys, keyObservedCount);
         }
 
         if (keyOrder.Count == 0)
@@ -105,119 +104,7 @@ public static class DrillDownSchemaExtractor
             return Results.Failure<TableSchema>("All child objects have no keys");
         }
 
-        List<ColumnSchema> columns = [];
-        for (var i = 0; i < keyOrder.Count; i++)
-        {
-            var key = keyOrder[i];
-            var observedCount = keyObservedCount.GetValueOrDefault(key);
-            columns.Add(new ColumnSchema
-            {
-                Name = key,
-                Type = columnTypes.GetValueOrDefault(key, ColumnType.Text),
-                IsNullable = observedCount < childRawValues.Count,
-                ColumnIndex = i,
-            });
-        }
-
-        return Results.Success(new TableSchema { Columns = columns, SourceFormat = format });
-    }
-
-    private static void IncrementObservationCounts(
-        HashSet<string> observedKeys,
-        Dictionary<string, int> keyObservedCount)
-    {
-        foreach (var key in observedKeys)
-        {
-            keyObservedCount[key] = keyObservedCount.GetValueOrDefault(key) + 1;
-        }
-    }
-
-    private static void ScanObject(
-        ReadOnlySpan<byte> objectBytes,
-        List<string> keyOrder,
-        HashSet<string> keySet,
-        Dictionary<string, ColumnType> columnTypes,
-        HashSet<string> observedKeys)
-    {
-        var reader = new Utf8JsonReader(objectBytes);
-
-        if (!reader.Read() || reader.TokenType != JsonTokenType.StartObject)
-        {
-            return;
-        }
-
-        while (reader.Read())
-        {
-            if (reader.TokenType == JsonTokenType.EndObject)
-            {
-                break;
-            }
-
-            ScanSingleProperty(ref reader, keyOrder, keySet, columnTypes, observedKeys);
-        }
-    }
-
-    private static void ScanSingleProperty(
-        ref Utf8JsonReader reader,
-        List<string> keyOrder,
-        HashSet<string> keySet,
-        Dictionary<string, ColumnType> columnTypes,
-        HashSet<string> observedKeys)
-    {
-        if (reader.TokenType != JsonTokenType.PropertyName)
-        {
-            return;
-        }
-
-        var key = reader.GetString() ?? string.Empty;
-
-        if (!reader.Read())
-        {
-            return;
-        }
-
-        var tokenType = reader.TokenType;
-        var valueSpan = reader.ValueSpan;
-
-        if (tokenType is JsonTokenType.StartObject or JsonTokenType.StartArray)
-        {
-            reader.Skip();
-        }
-
-        RegisterKeyIfNew(key, keyOrder, keySet);
-
-        if (TypeInferrer.IsNullToken(tokenType))
-        {
-            return;
-        }
-
-        var inferredType = TypeInferrer.InferType(tokenType, valueSpan);
-        observedKeys.Add(key);
-        MergeColumnType(key, inferredType, columnTypes);
-    }
-
-    private static void MergeColumnType(
-        string key,
-        ColumnType inferredType,
-        Dictionary<string, ColumnType> columnTypes)
-    {
-        if (!columnTypes.TryGetValue(key, out var existingType))
-        {
-            columnTypes[key] = inferredType;
-            return;
-        }
-
-        columnTypes[key] = ColumnTypeResolver.Resolve(existingType, inferredType);
-    }
-
-    private static void RegisterKeyIfNew(string key, List<string> keyOrder, HashSet<string> keySet)
-    {
-        if (keySet.Contains(key))
-        {
-            return;
-        }
-
-        keyOrder.Add(key);
-        keySet.Add(key);
+        return Results.Success(SchemaScanner.BuildTableSchema(
+            keyOrder, columnTypes, keyObservedCount, childRawValues.Count, format));
     }
 }

--- a/src/Engine/IO/DrillDown/FileChunkReader.cs
+++ b/src/Engine/IO/DrillDown/FileChunkReader.cs
@@ -1,0 +1,75 @@
+namespace DataMorph.Engine.IO.DrillDown;
+
+/// <summary>
+/// Stateless buffer-management helpers for chunked forward scans over a memory-mapped file.
+/// Shared implementation detail of <see cref="FullAggregationScanner"/>, split out to keep both
+/// classes under the project's per-class line limit.
+/// </summary>
+internal static class FileChunkReader
+{
+    internal const int BufferSize = 1024 * 1024;
+
+    /// <summary>
+    /// Returns the byte length of a leading UTF-8 BOM at the start of <paramref name="mmap"/>, or
+    /// <c>0</c> when no BOM is present.
+    /// </summary>
+    internal static long SkipUtf8Bom(MmapService mmap)
+    {
+        if (mmap.Length < 3)
+        {
+            return 0;
+        }
+
+        Span<byte> header = stackalloc byte[3];
+        mmap.Read(0, header);
+        return header[0] == 0xEF && header[1] == 0xBB && header[2] == 0xBF ? 3 : 0;
+    }
+
+    /// <summary>
+    /// Trims a single trailing CR byte from <paramref name="line"/>, if present, so CRLF and LF
+    /// line endings produce identical line contents.
+    /// </summary>
+    internal static ReadOnlySpan<byte> TrimTrailingCr(ReadOnlySpan<byte> line) =>
+        line.Length > 0 && line[^1] == (byte)'\r' ? line[..^1] : line;
+
+    /// <summary>
+    /// Reads the byte range <c>[startOffset, endOffset)</c> from <paramref name="mmap"/> into a
+    /// freshly-allocated buffer.
+    /// </summary>
+    internal static JsonRawBytes ReadFileRange(MmapService mmap, long startOffset, long endOffset)
+    {
+        var length = (int)(endOffset - startOffset);
+        var bytes = new byte[length];
+        mmap.Read(startOffset, bytes);
+        return bytes;
+    }
+
+    /// <summary>
+    /// Tops up <paramref name="buffer"/> with the next chunk of <paramref name="mmap"/> starting at
+    /// <paramref name="fileOffset"/>, preserving the first <paramref name="remainingLen"/> bytes
+    /// already in the buffer.
+    /// </summary>
+    /// <param name="mmap">The memory-mapped file to read from.</param>
+    /// <param name="buffer">The buffer to top up in place.</param>
+    /// <param name="remainingLen">The count of unread bytes already present at the start of <paramref name="buffer"/>.</param>
+    /// <param name="fileOffset">The file offset to resume reading from.</param>
+    /// <param name="sizeContext">Description used in the overflow exception message.</param>
+    /// <returns>The new data length in the buffer, and the advanced file offset.</returns>
+    internal static (int dataEnd, long fileOffset) FillBuffer(
+        MmapService mmap, byte[] buffer, int remainingLen, long fileOffset, string sizeContext)
+    {
+        if (remainingLen == BufferSize)
+        {
+            throw new NotSupportedException($"{sizeContext} exceeds maximum supported size.");
+        }
+
+        var available = mmap.Length - fileOffset;
+        var toRead = (int)Math.Min(BufferSize - remainingLen, Math.Max(0L, available));
+        if (toRead > 0)
+        {
+            mmap.Read(fileOffset, buffer.AsSpan(remainingLen, toRead));
+        }
+
+        return (remainingLen + toRead, fileOffset + toRead);
+    }
+}

--- a/src/Engine/IO/DrillDown/FocusedTableRow.cs
+++ b/src/Engine/IO/DrillDown/FocusedTableRow.cs
@@ -1,0 +1,4 @@
+namespace DataMorph.Engine.IO.DrillDown;
+
+/// <summary>A single row in the FocusedTable: child object bytes and its pre-computed # value.</summary>
+public readonly record struct FocusedTableRow(JsonRawBytes Bytes, string HashValue);

--- a/src/Engine/IO/DrillDown/FullAggregationScanner.cs
+++ b/src/Engine/IO/DrillDown/FullAggregationScanner.cs
@@ -1,0 +1,119 @@
+using DataMorph.Engine.Models;
+using DataMorph.Engine.Types;
+
+namespace DataMorph.Engine.IO.DrillDown;
+
+/// <summary>
+/// Full-file DrillDown scan: traverses a KeyPath for every record in the file and
+/// collects the leaf values reached, building a union <see cref="TableSchema"/> across all
+/// collected rows. Supports all leaf types: JSON Object, JSON Array of Object,
+/// JSON Array of Primitive, and scalar Primitive.
+/// </summary>
+public static class FullAggregationScanner
+{
+    /// <summary>
+    /// Scans <paramref name="filePath"/> for all records and traverses <paramref name="keyPath"/>
+    /// to collect leaf values of every matching path. Supports all leaf types: JSON Object,
+    /// JSON Array of Object, JSON Array of Primitive, and scalar Primitive.
+    /// Returns <c>Failure</c> when format is JSON Object, no rows are collected, or
+    /// all collected leaf objects have no keys.
+    /// </summary>
+    public static Result<(TableSchema schema, IReadOnlyList<FocusedTableRow> rows)> Scan(
+        string filePath,
+        DataFormat format,
+        IReadOnlyList<string> keyPath,
+        CancellationToken cancellationToken = default)
+    {
+        throw new NotImplementedException();
+    }
+
+    private static void ScanLines(
+        MmapService mmap,
+        IReadOnlyList<string> keyPath,
+        string colName,
+        byte[] colNameUtf8,
+        List<FocusedTableRow> rows,
+        List<string> keyOrder,
+        HashSet<string> keySet,
+        Dictionary<string, ColumnType> columnTypes,
+        Dictionary<string, int> keyObservedCount,
+        CancellationToken cancellationToken)
+    {
+        throw new NotImplementedException();
+    }
+
+    private static void ScanElements(
+        MmapService mmap,
+        IReadOnlyList<string> keyPath,
+        string colName,
+        byte[] colNameUtf8,
+        List<FocusedTableRow> rows,
+        List<string> keyOrder,
+        HashSet<string> keySet,
+        Dictionary<string, ColumnType> columnTypes,
+        Dictionary<string, int> keyObservedCount,
+        CancellationToken cancellationToken)
+    {
+        throw new NotImplementedException();
+    }
+
+    private static void TryExtractRows(
+        JsonRawBytes recordBytes,
+        IReadOnlyList<string> keyPath,
+        string posHash,
+        string colName,
+        byte[] colNameUtf8,
+        List<FocusedTableRow> rows,
+        List<string> keyOrder,
+        HashSet<string> keySet,
+        Dictionary<string, ColumnType> columnTypes,
+        Dictionary<string, int> keyObservedCount)
+    {
+        throw new NotImplementedException();
+    }
+
+    private static void TraverseKeyPath(
+        JsonRawBytes currentBytes,
+        IReadOnlyList<string> keyPath,
+        int segmentIndex,
+        string posHash,
+        string colName,
+        byte[] colNameUtf8,
+        List<FocusedTableRow> rows,
+        List<string> keyOrder,
+        HashSet<string> keySet,
+        Dictionary<string, ColumnType> columnTypes,
+        Dictionary<string, int> keyObservedCount)
+    {
+        throw new NotImplementedException();
+    }
+
+    private static void CollectLeafRows(
+        JsonRawBytes leafBytes,
+        string posHash,
+        string colName,
+        byte[] colNameUtf8,
+        List<FocusedTableRow> rows,
+        List<string> keyOrder,
+        HashSet<string> keySet,
+        Dictionary<string, ColumnType> columnTypes,
+        Dictionary<string, int> keyObservedCount)
+    {
+        throw new NotImplementedException();
+    }
+
+    private static JsonRawBytes? FindValueByKey(JsonRawBytes objectBytes, string key)
+    {
+        throw new NotImplementedException();
+    }
+
+    private static JsonRawBytes SynthesizeObject(ReadOnlySpan<byte> keyUtf8, ReadOnlySpan<byte> valueBytes)
+    {
+        throw new NotImplementedException();
+    }
+
+    private static string LastKeySegment(IReadOnlyList<string> keyPath)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/src/Engine/IO/DrillDown/FullAggregationScanner.cs
+++ b/src/Engine/IO/DrillDown/FullAggregationScanner.cs
@@ -1,3 +1,7 @@
+using System.Buffers;
+using System.Globalization;
+using System.Text;
+using System.Text.Json;
 using DataMorph.Engine.Models;
 using DataMorph.Engine.Types;
 
@@ -24,8 +28,60 @@ public static class FullAggregationScanner
         IReadOnlyList<string> keyPath,
         CancellationToken cancellationToken = default)
     {
-        throw new NotImplementedException();
+        ArgumentException.ThrowIfNullOrWhiteSpace(filePath);
+        ArgumentNullException.ThrowIfNull(keyPath);
+
+        if (format == DataFormat.JsonObject)
+        {
+            return Results.Failure<(TableSchema, IReadOnlyList<FocusedTableRow>)>(
+                "JSON Object format does not support full aggregation.");
+        }
+
+        var mmapResult = MmapService.Open(filePath);
+        if (mmapResult.IsFailure)
+        {
+            return Results.Failure<(TableSchema, IReadOnlyList<FocusedTableRow>)>(mmapResult.Error);
+        }
+
+        using var mmap = mmapResult.Value;
+
+        List<FocusedTableRow> rows = [];
+        List<string> keyOrder = [];
+        var keySet = new HashSet<string>(StringComparer.Ordinal);
+        var columnTypes = new Dictionary<string, ColumnType>(StringComparer.Ordinal);
+        var keyObservedCount = new Dictionary<string, int>(StringComparer.Ordinal);
+
+        var colName = KeyPathTraverser.LastKeySegment(keyPath);
+        var colNameUtf8 = Encoding.UTF8.GetBytes(colName);
+
+        ScanFunc scan = format == DataFormat.JsonLines ? ScanLines : ScanElements;
+        scan(mmap, keyPath, colName, colNameUtf8, rows, keyOrder, keySet, columnTypes, keyObservedCount, cancellationToken);
+
+        if (rows.Count == 0)
+        {
+            return Results.Failure<(TableSchema, IReadOnlyList<FocusedTableRow>)>("No matching records found.");
+        }
+
+        if (keyOrder.Count == 0)
+        {
+            return Results.Failure<(TableSchema, IReadOnlyList<FocusedTableRow>)>("All child objects have no keys");
+        }
+
+        var schema = SchemaScanner.BuildTableSchema(keyOrder, columnTypes, keyObservedCount, rows.Count, format);
+        return Results.Success<(TableSchema, IReadOnlyList<FocusedTableRow>)>((schema, rows));
     }
+
+    private delegate void ScanFunc(
+        MmapService mmap,
+        IReadOnlyList<string> keyPath,
+        string colName,
+        byte[] colNameUtf8,
+        List<FocusedTableRow> rows,
+        List<string> keyOrder,
+        HashSet<string> keySet,
+        Dictionary<string, ColumnType> columnTypes,
+        Dictionary<string, int> keyObservedCount,
+        CancellationToken cancellationToken);
 
     private static void ScanLines(
         MmapService mmap,
@@ -39,7 +95,78 @@ public static class FullAggregationScanner
         Dictionary<string, int> keyObservedCount,
         CancellationToken cancellationToken)
     {
-        throw new NotImplementedException();
+        var buffer = ArrayPool<byte>.Shared.Rent(FileChunkReader.BufferSize);
+        try
+        {
+            var fileOffset = FileChunkReader.SkipUtf8Bom(mmap);
+            var recordPosition = 1L;
+            var remainingLen = 0;
+
+            while (true)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                (var dataEnd, fileOffset) = FileChunkReader.FillBuffer(mmap, buffer, remainingLen, fileOffset, "JSON line");
+                var isFinalBlock = fileOffset >= mmap.Length;
+                var consumed = 0;
+
+                while (true)
+                {
+                    var newlineIndex = buffer.AsSpan(consumed, dataEnd - consumed).IndexOf((byte)'\n');
+                    if (newlineIndex == -1)
+                    {
+                        break;
+                    }
+
+                    ExtractAndProcessLine(
+                        buffer.AsSpan(consumed, newlineIndex), recordPosition, keyPath,
+                        colName, colNameUtf8, rows, keyOrder, keySet, columnTypes, keyObservedCount);
+                    recordPosition++;
+                    consumed += newlineIndex + 1;
+                }
+
+                if (isFinalBlock)
+                {
+                    ExtractAndProcessLine(
+                        buffer.AsSpan(consumed, dataEnd - consumed), recordPosition, keyPath,
+                        colName, colNameUtf8, rows, keyOrder, keySet, columnTypes, keyObservedCount);
+                    return;
+                }
+
+                remainingLen = dataEnd - consumed;
+                if (remainingLen > 0)
+                {
+                    buffer.AsSpan(consumed, remainingLen).CopyTo(buffer);
+                }
+            }
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(buffer);
+        }
+    }
+
+    private static void ExtractAndProcessLine(
+        ReadOnlySpan<byte> lineSpan,
+        long recordPosition,
+        IReadOnlyList<string> keyPath,
+        string colName,
+        byte[] colNameUtf8,
+        List<FocusedTableRow> rows,
+        List<string> keyOrder,
+        HashSet<string> keySet,
+        Dictionary<string, ColumnType> columnTypes,
+        Dictionary<string, int> keyObservedCount)
+    {
+        var trimmed = FileChunkReader.TrimTrailingCr(lineSpan);
+        if (trimmed.IsEmpty)
+        {
+            return;
+        }
+
+        KeyPathTraverser.ExtractRows(
+            trimmed.ToArray(), keyPath, recordPosition.ToString(CultureInfo.InvariantCulture),
+            colName, colNameUtf8, rows, keyOrder, keySet, columnTypes, keyObservedCount);
     }
 
     private static void ScanElements(
@@ -54,13 +181,70 @@ public static class FullAggregationScanner
         Dictionary<string, int> keyObservedCount,
         CancellationToken cancellationToken)
     {
-        throw new NotImplementedException();
+        var buffer = ArrayPool<byte>.Shared.Rent(FileChunkReader.BufferSize);
+        try
+        {
+            var state = default(JsonReaderState);
+            var bufferOriginFileOffset = 0L;
+            var fileReadOffset = 0L;
+            var remainingLen = 0;
+            var recordPosition = 0L;
+            var currentElementStart = -1L;
+
+            while (true)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                (var dataEnd, fileReadOffset) = FileChunkReader.FillBuffer(mmap, buffer, remainingLen, fileReadOffset, "JSON element");
+                var isFinalBlock = fileReadOffset >= mmap.Length;
+
+                var reader = new Utf8JsonReader(buffer.AsSpan(0, dataEnd), isFinalBlock, state);
+                var rootDone = false;
+
+                while (!rootDone && reader.Read())
+                {
+                    (rootDone, currentElementStart, recordPosition) = ProcessElementToken(
+                        ref reader, mmap, bufferOriginFileOffset, currentElementStart, recordPosition,
+                        keyPath, colName, colNameUtf8, rows, keyOrder, keySet, columnTypes, keyObservedCount);
+                }
+
+                if (rootDone)
+                {
+                    return;
+                }
+
+                state = reader.CurrentState;
+                var consumed = (int)reader.BytesConsumed;
+                bufferOriginFileOffset += consumed;
+                remainingLen = dataEnd - consumed;
+                if (remainingLen > 0)
+                {
+                    buffer.AsSpan(consumed, remainingLen).CopyTo(buffer);
+                }
+            }
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(buffer);
+        }
     }
 
-    private static void TryExtractRows(
-        JsonRawBytes recordBytes,
+    /// <summary>
+    /// Handles a single token read from the top-level array during <see cref="ScanElements"/>,
+    /// tracking the start of the current element and dispatching a completed element (or a
+    /// depth-1 primitive) to <see cref="KeyPathTraverser.ExtractRows"/>.
+    /// </summary>
+    /// <returns>
+    /// Whether the root array has ended, plus the updated <c>currentElementStart</c> and
+    /// <c>recordPosition</c> to carry into the next token.
+    /// </returns>
+    private static (bool isRootDone, long currentElementStart, long recordPosition) ProcessElementToken(
+        ref Utf8JsonReader reader,
+        MmapService mmap,
+        long bufferOriginFileOffset,
+        long currentElementStart,
+        long recordPosition,
         IReadOnlyList<string> keyPath,
-        string posHash,
         string colName,
         byte[] colNameUtf8,
         List<FocusedTableRow> rows,
@@ -69,51 +253,40 @@ public static class FullAggregationScanner
         Dictionary<string, ColumnType> columnTypes,
         Dictionary<string, int> keyObservedCount)
     {
-        throw new NotImplementedException();
-    }
+        if (reader.CurrentDepth == 0 && reader.TokenType == JsonTokenType.EndArray)
+        {
+            return (true, currentElementStart, recordPosition);
+        }
 
-    private static void TraverseKeyPath(
-        JsonRawBytes currentBytes,
-        IReadOnlyList<string> keyPath,
-        int segmentIndex,
-        string posHash,
-        string colName,
-        byte[] colNameUtf8,
-        List<FocusedTableRow> rows,
-        List<string> keyOrder,
-        HashSet<string> keySet,
-        Dictionary<string, ColumnType> columnTypes,
-        Dictionary<string, int> keyObservedCount)
-    {
-        throw new NotImplementedException();
-    }
+        if (reader.CurrentDepth != 1)
+        {
+            return (false, currentElementStart, recordPosition);
+        }
 
-    private static void CollectLeafRows(
-        JsonRawBytes leafBytes,
-        string posHash,
-        string colName,
-        byte[] colNameUtf8,
-        List<FocusedTableRow> rows,
-        List<string> keyOrder,
-        HashSet<string> keySet,
-        Dictionary<string, ColumnType> columnTypes,
-        Dictionary<string, int> keyObservedCount)
-    {
-        throw new NotImplementedException();
-    }
+        if (reader.TokenType is JsonTokenType.StartObject or JsonTokenType.StartArray)
+        {
+            var updatedStart = currentElementStart < 0
+                ? bufferOriginFileOffset + reader.TokenStartIndex
+                : currentElementStart;
+            return (false, updatedStart, recordPosition);
+        }
 
-    private static JsonRawBytes? FindValueByKey(JsonRawBytes objectBytes, string key)
-    {
-        throw new NotImplementedException();
-    }
+        if (reader.TokenType is JsonTokenType.EndObject or JsonTokenType.EndArray)
+        {
+            var elementEnd = bufferOriginFileOffset + reader.BytesConsumed;
+            var elementBytes = FileChunkReader.ReadFileRange(mmap, currentElementStart, elementEnd);
+            KeyPathTraverser.ExtractRows(
+                elementBytes, keyPath, recordPosition.ToString(CultureInfo.InvariantCulture),
+                colName, colNameUtf8, rows, keyOrder, keySet, columnTypes, keyObservedCount);
+            return (false, -1L, recordPosition + 1);
+        }
 
-    private static JsonRawBytes SynthesizeObject(ReadOnlySpan<byte> keyUtf8, ReadOnlySpan<byte> valueBytes)
-    {
-        throw new NotImplementedException();
-    }
-
-    private static string LastKeySegment(IReadOnlyList<string> keyPath)
-    {
-        throw new NotImplementedException();
+        // Primitive element at depth 1 (number, string, bool, null).
+        var primitiveBytes = FileChunkReader.ReadFileRange(
+            mmap, bufferOriginFileOffset + reader.TokenStartIndex, bufferOriginFileOffset + reader.BytesConsumed);
+        KeyPathTraverser.ExtractRows(
+            primitiveBytes, keyPath, recordPosition.ToString(CultureInfo.InvariantCulture),
+            colName, colNameUtf8, rows, keyOrder, keySet, columnTypes, keyObservedCount);
+        return (false, currentElementStart, recordPosition + 1);
     }
 }

--- a/src/Engine/IO/DrillDown/FullAggregationScanner.cs
+++ b/src/Engine/IO/DrillDown/FullAggregationScanner.cs
@@ -25,7 +25,7 @@ public static class FullAggregationScanner
     public static Result<(TableSchema schema, IReadOnlyList<FocusedTableRow> rows)> Scan(
         string filePath,
         DataFormat format,
-        IReadOnlyList<string> keyPath,
+        IReadOnlyList<KeyPathSegment> keyPath,
         CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(filePath);
@@ -73,7 +73,7 @@ public static class FullAggregationScanner
 
     private delegate void ScanFunc(
         MmapService mmap,
-        IReadOnlyList<string> keyPath,
+        IReadOnlyList<KeyPathSegment> keyPath,
         string colName,
         byte[] colNameUtf8,
         List<FocusedTableRow> rows,
@@ -85,7 +85,7 @@ public static class FullAggregationScanner
 
     private static void ScanLines(
         MmapService mmap,
-        IReadOnlyList<string> keyPath,
+        IReadOnlyList<KeyPathSegment> keyPath,
         string colName,
         byte[] colNameUtf8,
         List<FocusedTableRow> rows,
@@ -149,7 +149,7 @@ public static class FullAggregationScanner
     private static void ExtractAndProcessLine(
         ReadOnlySpan<byte> lineSpan,
         long recordPosition,
-        IReadOnlyList<string> keyPath,
+        IReadOnlyList<KeyPathSegment> keyPath,
         string colName,
         byte[] colNameUtf8,
         List<FocusedTableRow> rows,
@@ -171,7 +171,7 @@ public static class FullAggregationScanner
 
     private static void ScanElements(
         MmapService mmap,
-        IReadOnlyList<string> keyPath,
+        IReadOnlyList<KeyPathSegment> keyPath,
         string colName,
         byte[] colNameUtf8,
         List<FocusedTableRow> rows,
@@ -244,7 +244,7 @@ public static class FullAggregationScanner
         long bufferOriginFileOffset,
         long currentElementStart,
         long recordPosition,
-        IReadOnlyList<string> keyPath,
+        IReadOnlyList<KeyPathSegment> keyPath,
         string colName,
         byte[] colNameUtf8,
         List<FocusedTableRow> rows,

--- a/src/Engine/IO/DrillDown/FullAggregationScanner.cs
+++ b/src/Engine/IO/DrillDown/FullAggregationScanner.cs
@@ -1,4 +1,5 @@
 using System.Buffers;
+using System.Diagnostics;
 using System.Globalization;
 using System.Text;
 using System.Text.Json;
@@ -45,56 +46,41 @@ public static class FullAggregationScanner
 
         using var mmap = mmapResult.Value;
 
+        var scanData = format switch
+        {
+            DataFormat.JsonLines => ScanLines(mmap, keyPath, cancellationToken),
+            DataFormat.JsonArray => ScanElements(mmap, keyPath, cancellationToken),
+            _ => throw new UnreachableException($"Full aggregation scan does not handle format '{format}'."),
+        };
+
+        if (scanData.Rows.Count == 0)
+        {
+            return Results.Failure<(TableSchema, IReadOnlyList<FocusedTableRow>)>("No matching records found.");
+        }
+
+        if (scanData.KeyOrder.Count == 0)
+        {
+            return Results.Failure<(TableSchema, IReadOnlyList<FocusedTableRow>)>("All child objects have no keys");
+        }
+
+        var schema = SchemaScanner.BuildTableSchema(scanData.KeyOrder, scanData.ColumnTypes, scanData.KeyObservedCount, scanData.Rows.Count, format);
+        return Results.Success<(TableSchema, IReadOnlyList<FocusedTableRow>)>((schema, scanData.Rows));
+    }
+
+    private static ScanData ScanLines(
+        MmapService mmap,
+        IReadOnlyList<KeyPathSegment> keyPath,
+        CancellationToken cancellationToken)
+    {
+        var colName = KeyPathTraverser.LastKeySegment(keyPath);
+        var colNameUtf8 = Encoding.UTF8.GetBytes(colName);
+
         List<FocusedTableRow> rows = [];
         List<string> keyOrder = [];
         var keySet = new HashSet<string>(StringComparer.Ordinal);
         var columnTypes = new Dictionary<string, ColumnType>(StringComparer.Ordinal);
         var keyObservedCount = new Dictionary<string, int>(StringComparer.Ordinal);
 
-        var colName = KeyPathTraverser.LastKeySegment(keyPath);
-        var colNameUtf8 = Encoding.UTF8.GetBytes(colName);
-
-        ScanFunc scan = format == DataFormat.JsonLines ? ScanLines : ScanElements;
-        scan(mmap, keyPath, colName, colNameUtf8, rows, keyOrder, keySet, columnTypes, keyObservedCount, cancellationToken);
-
-        if (rows.Count == 0)
-        {
-            return Results.Failure<(TableSchema, IReadOnlyList<FocusedTableRow>)>("No matching records found.");
-        }
-
-        if (keyOrder.Count == 0)
-        {
-            return Results.Failure<(TableSchema, IReadOnlyList<FocusedTableRow>)>("All child objects have no keys");
-        }
-
-        var schema = SchemaScanner.BuildTableSchema(keyOrder, columnTypes, keyObservedCount, rows.Count, format);
-        return Results.Success<(TableSchema, IReadOnlyList<FocusedTableRow>)>((schema, rows));
-    }
-
-    private delegate void ScanFunc(
-        MmapService mmap,
-        IReadOnlyList<KeyPathSegment> keyPath,
-        string colName,
-        byte[] colNameUtf8,
-        List<FocusedTableRow> rows,
-        List<string> keyOrder,
-        HashSet<string> keySet,
-        Dictionary<string, ColumnType> columnTypes,
-        Dictionary<string, int> keyObservedCount,
-        CancellationToken cancellationToken);
-
-    private static void ScanLines(
-        MmapService mmap,
-        IReadOnlyList<KeyPathSegment> keyPath,
-        string colName,
-        byte[] colNameUtf8,
-        List<FocusedTableRow> rows,
-        List<string> keyOrder,
-        HashSet<string> keySet,
-        Dictionary<string, ColumnType> columnTypes,
-        Dictionary<string, int> keyObservedCount,
-        CancellationToken cancellationToken)
-    {
         var buffer = ArrayPool<byte>.Shared.Rent(FileChunkReader.BufferSize);
         try
         {
@@ -130,7 +116,7 @@ public static class FullAggregationScanner
                     ExtractAndProcessLine(
                         buffer.AsSpan(consumed, dataEnd - consumed), recordPosition, keyPath,
                         colName, colNameUtf8, rows, keyOrder, keySet, columnTypes, keyObservedCount);
-                    return;
+                    return new ScanData(rows, keyOrder, columnTypes, keyObservedCount);
                 }
 
                 remainingLen = dataEnd - consumed;
@@ -169,18 +155,20 @@ public static class FullAggregationScanner
             colName, colNameUtf8, rows, keyOrder, keySet, columnTypes, keyObservedCount);
     }
 
-    private static void ScanElements(
+    private static ScanData ScanElements(
         MmapService mmap,
         IReadOnlyList<KeyPathSegment> keyPath,
-        string colName,
-        byte[] colNameUtf8,
-        List<FocusedTableRow> rows,
-        List<string> keyOrder,
-        HashSet<string> keySet,
-        Dictionary<string, ColumnType> columnTypes,
-        Dictionary<string, int> keyObservedCount,
         CancellationToken cancellationToken)
     {
+        var colName = KeyPathTraverser.LastKeySegment(keyPath);
+        var colNameUtf8 = Encoding.UTF8.GetBytes(colName);
+
+        List<FocusedTableRow> rows = [];
+        List<string> keyOrder = [];
+        var keySet = new HashSet<string>(StringComparer.Ordinal);
+        var columnTypes = new Dictionary<string, ColumnType>(StringComparer.Ordinal);
+        var keyObservedCount = new Dictionary<string, int>(StringComparer.Ordinal);
+
         var buffer = ArrayPool<byte>.Shared.Rent(FileChunkReader.BufferSize);
         try
         {
@@ -210,7 +198,7 @@ public static class FullAggregationScanner
 
                 if (rootDone)
                 {
-                    return;
+                    return new ScanData(rows, keyOrder, columnTypes, keyObservedCount);
                 }
 
                 state = reader.CurrentState;
@@ -289,4 +277,10 @@ public static class FullAggregationScanner
             colName, colNameUtf8, rows, keyOrder, keySet, columnTypes, keyObservedCount);
         return (false, currentElementStart, recordPosition + 1);
     }
+
+    private readonly record struct ScanData(
+        List<FocusedTableRow> Rows,
+        List<string> KeyOrder,
+        Dictionary<string, ColumnType> ColumnTypes,
+        Dictionary<string, int> KeyObservedCount);
 }

--- a/src/Engine/IO/DrillDown/KeyPathSegment.cs
+++ b/src/Engine/IO/DrillDown/KeyPathSegment.cs
@@ -1,0 +1,11 @@
+namespace DataMorph.Engine.IO.DrillDown;
+
+/// <summary>
+/// One tagged segment of a DrillDown KeyPath: an object property name or an array-element index.
+/// Carrying the kind explicitly removes ambiguity between an index marker such as "[0]" and a
+/// literal object key that starts with '[' — which would otherwise be misread as an index and
+/// cause traversal to silently skip every record.
+/// </summary>
+/// <param name="Value">The property name (e.g. "orders") or the index label (e.g. "[0]").</param>
+/// <param name="Kind">Whether <paramref name="Value"/> addresses an object property or an array element.</param>
+public readonly record struct KeyPathSegment(string Value, KeyPathSegmentKind Kind);

--- a/src/Engine/IO/DrillDown/KeyPathSegmentKind.cs
+++ b/src/Engine/IO/DrillDown/KeyPathSegmentKind.cs
@@ -1,0 +1,13 @@
+namespace DataMorph.Engine.IO.DrillDown;
+
+/// <summary>
+/// Whether a <see cref="KeyPathSegment"/> addresses a JSON object property or a JSON array element.
+/// </summary>
+public enum KeyPathSegmentKind
+{
+    /// <summary>The segment is an object property name (e.g. "orders").</summary>
+    Key,
+
+    /// <summary>The segment is an array-element index label (e.g. "[0]").</summary>
+    Index,
+}

--- a/src/Engine/IO/DrillDown/KeyPathTraverser.cs
+++ b/src/Engine/IO/DrillDown/KeyPathTraverser.cs
@@ -20,7 +20,7 @@ internal static class KeyPathTraverser
     /// </summary>
     public static void ExtractRows(
         JsonRawBytes recordBytes,
-        IReadOnlyList<string> keyPath,
+        IReadOnlyList<KeyPathSegment> keyPath,
         string posHash,
         string colName,
         byte[] colNameUtf8,
@@ -40,13 +40,13 @@ internal static class KeyPathTraverser
     /// for a scalar primitive leaf. Falls back to <c>"value"</c> when every segment is an index
     /// segment (e.g. an empty or all-<c>[n]</c> path).
     /// </summary>
-    public static string LastKeySegment(IReadOnlyList<string> keyPath)
+    public static string LastKeySegment(IReadOnlyList<KeyPathSegment> keyPath)
     {
         for (var i = keyPath.Count - 1; i >= 0; i--)
         {
-            if (!keyPath[i].StartsWith('['))
+            if (keyPath[i].Kind == KeyPathSegmentKind.Key)
             {
-                return keyPath[i];
+                return keyPath[i].Value;
             }
         }
 
@@ -55,7 +55,7 @@ internal static class KeyPathTraverser
 
     private static void TraverseKeyPath(
         JsonRawBytes currentBytes,
-        IReadOnlyList<string> keyPath,
+        IReadOnlyList<KeyPathSegment> keyPath,
         int segmentIndex,
         string posHash,
         string colName,
@@ -74,7 +74,7 @@ internal static class KeyPathTraverser
 
         var segment = keyPath[segmentIndex];
 
-        if (segment.StartsWith('['))
+        if (segment.Kind == KeyPathSegmentKind.Index)
         {
             var reader = new Utf8JsonReader(currentBytes.Span);
             if (!reader.Read() || reader.TokenType != JsonTokenType.StartArray)
@@ -114,7 +114,7 @@ internal static class KeyPathTraverser
             return;
         }
 
-        var valueBytes = FindValueByKey(currentBytes, segment);
+        var valueBytes = FindValueByKey(currentBytes, segment.Value);
         if (valueBytes is null)
         {
             return; // Key absent, or current value is not an object — skip record silently.

--- a/src/Engine/IO/DrillDown/KeyPathTraverser.cs
+++ b/src/Engine/IO/DrillDown/KeyPathTraverser.cs
@@ -1,0 +1,281 @@
+using System.Buffers;
+using System.Text.Json;
+using DataMorph.Engine.IO.Json;
+using DataMorph.Engine.Types;
+
+namespace DataMorph.Engine.IO.DrillDown;
+
+/// <summary>
+/// Stateless helpers that traverse a KeyPath through a single record's bytes and collect the
+/// leaf row(s) reached, accumulating schema information along the way. Shared implementation
+/// detail of <see cref="FullAggregationScanner"/>, split out to keep both classes under the
+/// project's per-class line limit.
+/// </summary>
+internal static class KeyPathTraverser
+{
+    /// <summary>
+    /// Traverses <paramref name="keyPath"/> starting from <paramref name="recordBytes"/> and
+    /// collects the row(s) reached at the leaf, if any. Records where the path is absent or the
+    /// token type mismatches a segment are silently skipped (no rows added).
+    /// </summary>
+    public static void ExtractRows(
+        JsonRawBytes recordBytes,
+        IReadOnlyList<string> keyPath,
+        string posHash,
+        string colName,
+        byte[] colNameUtf8,
+        List<FocusedTableRow> rows,
+        List<string> keyOrder,
+        HashSet<string> keySet,
+        Dictionary<string, ColumnType> columnTypes,
+        Dictionary<string, int> keyObservedCount)
+    {
+        TraverseKeyPath(
+            recordBytes, keyPath, 0, posHash, colName, colNameUtf8,
+            rows, keyOrder, keySet, columnTypes, keyObservedCount);
+    }
+
+    /// <summary>
+    /// Returns the last non-index segment of <paramref name="keyPath"/> — the column name used
+    /// for a scalar primitive leaf. Falls back to <c>"value"</c> when every segment is an index
+    /// segment (e.g. an empty or all-<c>[n]</c> path).
+    /// </summary>
+    public static string LastKeySegment(IReadOnlyList<string> keyPath)
+    {
+        for (var i = keyPath.Count - 1; i >= 0; i--)
+        {
+            if (!keyPath[i].StartsWith('['))
+            {
+                return keyPath[i];
+            }
+        }
+
+        return "value";
+    }
+
+    private static void TraverseKeyPath(
+        JsonRawBytes currentBytes,
+        IReadOnlyList<string> keyPath,
+        int segmentIndex,
+        string posHash,
+        string colName,
+        byte[] colNameUtf8,
+        List<FocusedTableRow> rows,
+        List<string> keyOrder,
+        HashSet<string> keySet,
+        Dictionary<string, ColumnType> columnTypes,
+        Dictionary<string, int> keyObservedCount)
+    {
+        if (segmentIndex == keyPath.Count)
+        {
+            CollectLeafRows(currentBytes, posHash, colName, colNameUtf8, rows, keyOrder, keySet, columnTypes, keyObservedCount);
+            return;
+        }
+
+        var segment = keyPath[segmentIndex];
+
+        if (segment.StartsWith('['))
+        {
+            var reader = new Utf8JsonReader(currentBytes.Span);
+            if (!reader.Read() || reader.TokenType != JsonTokenType.StartArray)
+            {
+                return; // Wrong type at this path position — skip record silently.
+            }
+
+            if (segmentIndex == keyPath.Count - 1)
+            {
+                // A trailing index segment expands the same array that would be reached by
+                // selecting it directly as the leaf (e.g. "tags" and "tags[0]" must produce
+                // identical output, including the "value" column for primitive elements).
+                CollectArrayLeafRows(currentBytes, posHash, rows, keyOrder, keySet, columnTypes, keyObservedCount);
+                return;
+            }
+
+            var elementIndex = 0;
+            while (reader.Read())
+            {
+                if (reader.TokenType == JsonTokenType.EndArray)
+                {
+                    break;
+                }
+
+                if (reader.CurrentDepth != 1)
+                {
+                    continue;
+                }
+
+                var elementBytes = ExtractElementBytes(ref reader, currentBytes);
+                TraverseKeyPath(
+                    elementBytes, keyPath, segmentIndex + 1, $"{posHash}:{elementIndex}", colName, colNameUtf8,
+                    rows, keyOrder, keySet, columnTypes, keyObservedCount);
+                elementIndex++;
+            }
+
+            return;
+        }
+
+        var valueBytes = FindValueByKey(currentBytes, segment);
+        if (valueBytes is null)
+        {
+            return; // Key absent, or current value is not an object — skip record silently.
+        }
+
+        TraverseKeyPath(
+            valueBytes.Value, keyPath, segmentIndex + 1, posHash, colName, colNameUtf8,
+            rows, keyOrder, keySet, columnTypes, keyObservedCount);
+    }
+
+    private static void CollectLeafRows(
+        JsonRawBytes leafBytes,
+        string posHash,
+        string colName,
+        byte[] colNameUtf8,
+        List<FocusedTableRow> rows,
+        List<string> keyOrder,
+        HashSet<string> keySet,
+        Dictionary<string, ColumnType> columnTypes,
+        Dictionary<string, int> keyObservedCount)
+    {
+        var reader = new Utf8JsonReader(leafBytes.Span);
+        if (!reader.Read())
+        {
+            return;
+        }
+
+        if (reader.TokenType == JsonTokenType.StartObject)
+        {
+            rows.Add(new FocusedTableRow(leafBytes, posHash));
+            var observedKeys = new HashSet<string>(StringComparer.Ordinal);
+            SchemaScanner.ScanObject(leafBytes.Span, keyOrder, keySet, columnTypes, observedKeys);
+            SchemaScanner.IncrementObservationCounts(observedKeys, keyObservedCount);
+            return;
+        }
+
+        if (reader.TokenType == JsonTokenType.StartArray)
+        {
+            CollectArrayLeafRows(leafBytes, posHash, rows, keyOrder, keySet, columnTypes, keyObservedCount);
+            return;
+        }
+
+        // Primitive leaf (including null) — synthesize a single-key object so
+        // JsonObjectCellExtractor can extract it without modification.
+        // Note: ScanObject is NOT called here, so no type inference is performed;
+        // the synthesized column always receives ColumnType.Text (Phase 2 limitation).
+        var synthBytes = SynthesizeObject(colNameUtf8, leafBytes.Span);
+        rows.Add(new FocusedTableRow(synthBytes, posHash));
+        SchemaScanner.RegisterKeyIfNew(colName, keyOrder, keySet);
+        SchemaScanner.IncrementObservationCounts([colName], keyObservedCount);
+    }
+
+    private static void CollectArrayLeafRows(
+        JsonRawBytes leafBytes,
+        string posHash,
+        List<FocusedTableRow> rows,
+        List<string> keyOrder,
+        HashSet<string> keySet,
+        Dictionary<string, ColumnType> columnTypes,
+        Dictionary<string, int> keyObservedCount)
+    {
+        var reader = new Utf8JsonReader(leafBytes.Span);
+        if (!reader.Read() || reader.TokenType != JsonTokenType.StartArray)
+        {
+            return;
+        }
+
+        var elementIndex = 0;
+        while (reader.Read())
+        {
+            if (reader.TokenType == JsonTokenType.EndArray)
+            {
+                break;
+            }
+
+            if (reader.CurrentDepth != 1)
+            {
+                continue;
+            }
+
+            var isObjectElement = reader.TokenType == JsonTokenType.StartObject;
+            var elementBytes = ExtractElementBytes(ref reader, leafBytes);
+            var elementHash = $"{posHash}:{elementIndex}";
+
+            if (isObjectElement)
+            {
+                rows.Add(new FocusedTableRow(elementBytes, elementHash));
+                var observedKeys = new HashSet<string>(StringComparer.Ordinal);
+                SchemaScanner.ScanObject(elementBytes.Span, keyOrder, keySet, columnTypes, observedKeys);
+                SchemaScanner.IncrementObservationCounts(observedKeys, keyObservedCount);
+                elementIndex++;
+                continue;
+            }
+
+            // Primitive element (including null) — synthesize {"value": element}.
+            var synthBytes = SynthesizeObject("value"u8, elementBytes.Span);
+            rows.Add(new FocusedTableRow(synthBytes, elementHash));
+            SchemaScanner.RegisterKeyIfNew("value", keyOrder, keySet);
+            SchemaScanner.IncrementObservationCounts(["value"], keyObservedCount);
+            elementIndex++;
+        }
+    }
+
+    private static JsonRawBytes ExtractElementBytes(ref Utf8JsonReader reader, JsonRawBytes containingBytes)
+    {
+        if (reader.TokenType is JsonTokenType.StartObject or JsonTokenType.StartArray)
+        {
+            return JsonByteExtractor.ExtractNestedBytes(ref reader, containingBytes);
+        }
+
+        var start = (int)reader.TokenStartIndex;
+        var end = (int)reader.BytesConsumed;
+        return containingBytes.Slice(start, end - start);
+    }
+
+    private static JsonRawBytes? FindValueByKey(JsonRawBytes objectBytes, string key)
+    {
+        var reader = new Utf8JsonReader(objectBytes.Span);
+        if (!reader.Read() || reader.TokenType != JsonTokenType.StartObject)
+        {
+            return null;
+        }
+
+        while (reader.Read())
+        {
+            if (reader.TokenType == JsonTokenType.EndObject)
+            {
+                return null;
+            }
+
+            if (reader.TokenType != JsonTokenType.PropertyName)
+            {
+                continue;
+            }
+
+            if (!reader.ValueTextEquals(key))
+            {
+                reader.Skip();
+                continue;
+            }
+
+            if (!reader.Read())
+            {
+                return null;
+            }
+
+            return ExtractElementBytes(ref reader, objectBytes);
+        }
+
+        return null;
+    }
+
+    private static JsonRawBytes SynthesizeObject(ReadOnlySpan<byte> keyUtf8, ReadOnlySpan<byte> valueBytes)
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        using var writer = new Utf8JsonWriter(buffer);
+        writer.WriteStartObject();
+        writer.WritePropertyName(keyUtf8);
+        writer.WriteRawValue(valueBytes, skipInputValidation: true);
+        writer.WriteEndObject();
+        writer.Flush();
+        return buffer.WrittenMemory;
+    }
+}

--- a/src/Engine/IO/DrillDown/SchemaScanner.cs
+++ b/src/Engine/IO/DrillDown/SchemaScanner.cs
@@ -1,0 +1,154 @@
+using System.Text.Json;
+using DataMorph.Engine.IO.JsonLines;
+using DataMorph.Engine.Models;
+using DataMorph.Engine.Types;
+
+namespace DataMorph.Engine.IO.DrillDown;
+
+/// <summary>
+/// Stateless schema-accumulation helpers shared by <see cref="DrillDownSchemaExtractor"/> and the
+/// full-aggregation scanner. Holds no state of its own; all accumulator collections are owned and
+/// passed in by the caller.
+/// </summary>
+internal static class SchemaScanner
+{
+    /// <summary>
+    /// Scans a single JSON object's top-level properties, registering new keys in first-seen
+    /// order and inferring their column types. Records the observed (non-null) keys into
+    /// <paramref name="observedKeys"/> for nullability accounting.
+    /// </summary>
+    public static void ScanObject(
+        ReadOnlySpan<byte> objectBytes,
+        List<string> keyOrder,
+        HashSet<string> keySet,
+        Dictionary<string, ColumnType> columnTypes,
+        HashSet<string> observedKeys)
+    {
+        var reader = new Utf8JsonReader(objectBytes);
+
+        if (!reader.Read() || reader.TokenType != JsonTokenType.StartObject)
+        {
+            return;
+        }
+
+        while (reader.Read())
+        {
+            if (reader.TokenType == JsonTokenType.EndObject)
+            {
+                break;
+            }
+
+            ScanSingleProperty(ref reader, keyOrder, keySet, columnTypes, observedKeys);
+        }
+    }
+
+    /// <summary>
+    /// Registers <paramref name="key"/> in <paramref name="keyOrder"/> (preserving first-seen
+    /// order) when it has not been observed before.
+    /// </summary>
+    public static void RegisterKeyIfNew(string key, List<string> keyOrder, HashSet<string> keySet)
+    {
+        if (keySet.Contains(key))
+        {
+            return;
+        }
+
+        keyOrder.Add(key);
+        keySet.Add(key);
+    }
+
+    /// <summary>
+    /// Increments the observation count for each key observed in the current object.
+    /// </summary>
+    public static void IncrementObservationCounts(
+        HashSet<string> observedKeys,
+        Dictionary<string, int> keyObservedCount)
+    {
+        foreach (var key in observedKeys)
+        {
+            keyObservedCount[key] = keyObservedCount.GetValueOrDefault(key) + 1;
+        }
+    }
+
+    /// <summary>
+    /// Builds the final <see cref="TableSchema"/> from the accumulated key order, types, and
+    /// observation counts. A key is marked nullable when it was not observed in every row
+    /// (<paramref name="totalRowCount"/>).
+    /// </summary>
+    public static TableSchema BuildTableSchema(
+        List<string> keyOrder,
+        Dictionary<string, ColumnType> columnTypes,
+        Dictionary<string, int> keyObservedCount,
+        int totalRowCount,
+        DataFormat format)
+    {
+        List<ColumnSchema> columns = [];
+        for (var i = 0; i < keyOrder.Count; i++)
+        {
+            var key = keyOrder[i];
+            var observedCount = keyObservedCount.GetValueOrDefault(key);
+            columns.Add(new ColumnSchema
+            {
+                Name = key,
+                Type = columnTypes.GetValueOrDefault(key, ColumnType.Text),
+                IsNullable = observedCount < totalRowCount,
+                ColumnIndex = i,
+            });
+        }
+
+        return new TableSchema { Columns = columns, SourceFormat = format };
+    }
+
+    private static void ScanSingleProperty(
+        ref Utf8JsonReader reader,
+        List<string> keyOrder,
+        HashSet<string> keySet,
+        Dictionary<string, ColumnType> columnTypes,
+        HashSet<string> observedKeys)
+    {
+        if (reader.TokenType != JsonTokenType.PropertyName)
+        {
+            return;
+        }
+
+        var key = reader.GetString() ?? string.Empty;
+
+        if (!reader.Read())
+        {
+            return;
+        }
+
+        var tokenType = reader.TokenType;
+        var valueSpan = reader.ValueSpan;
+
+        if (tokenType is JsonTokenType.StartObject or JsonTokenType.StartArray)
+        {
+            reader.Skip();
+        }
+
+        RegisterKeyIfNew(key, keyOrder, keySet);
+
+        if (TypeInferrer.IsNullToken(tokenType))
+        {
+            return;
+        }
+
+        var inferredType = TypeInferrer.InferType(tokenType, valueSpan);
+        observedKeys.Add(key);
+        MergeColumnType(key, inferredType, columnTypes);
+    }
+
+    private static void MergeColumnType(
+        string key,
+        ColumnType inferredType,
+        Dictionary<string, ColumnType> columnTypes)
+    {
+        if (!columnTypes.TryGetValue(key, out var existingType))
+        {
+            columnTypes[key] = inferredType;
+            return;
+        }
+
+        columnTypes[key] = ColumnTypeResolver.Resolve(existingType, inferredType);
+    }
+}

--- a/tests/DataMorph.Tests/App/AppKeyHandlerTests.cs
+++ b/tests/DataMorph.Tests/App/AppKeyHandlerTests.cs
@@ -1,8 +1,11 @@
 using AwesomeAssertions;
 using DataMorph.App;
 using DataMorph.App.Views;
+using DataMorph.App.Views.JsonTreeNodes;
+using DataMorph.Engine.IO.DrillDown;
 using Terminal.Gui.App;
 using Terminal.Gui.Drivers;
+using Terminal.Gui.Input;
 using Terminal.Gui.Views;
 
 namespace DataMorph.Tests.App;
@@ -200,8 +203,124 @@ public sealed class AppKeyHandlerTests
         state.ActionStack.Should().BeEmpty();
     }
 
-    // Note: MessageBox.Query display is not unit-testable (requires TUI event loop).
-    // This scenario requires integration testing with TUI event loop support.
+    // MessageBox.Query display is not unit-testable; requires TUI event loop integration testing.
+
+    // BuildKeyPath is exposed as internal static (same pattern as IsGlobalShortcut) so its tests call it directly. HandleSingleDrillDown and HandleActionMenu are tested indirectly through the real ActionMenuDialog; the DrillDown path is driven by an app.Iteration Enter-key press.
+    [Fact]
+    public void BuildKeyPath_WithRootSelection_ReturnsEmptyKeyPath()
+    {
+        // Arrange
+        ITreeNode rootNode = new JsonValueTreeNode("root");
+
+        // Act
+        var keyPath = AppKeyHandler.BuildKeyPath(rootNode);
+
+        // Assert
+        keyPath.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void BuildKeyPath_WithNestedObjectArraySelection_ReturnsOrderedSegmentsWithIndex()
+    {
+        // Arrange
+        var root = new JsonObjectTreeNode("{}"u8.ToArray());
+        var ordersArray = new JsonArrayTreeNode("[]"u8.ToArray()) { KeyName = "orders", ParentNode = root };
+        var element0 = new JsonObjectTreeNode("{}"u8.ToArray()) { KeyName = "[0]", ParentNode = ordersArray };
+
+        // Act
+        var keyPath = AppKeyHandler.BuildKeyPath(element0);
+
+        // Assert
+        keyPath.Should().Equal(
+            new KeyPathSegment("orders", KeyPathSegmentKind.Key),
+            new KeyPathSegment("[0]", KeyPathSegmentKind.Index));
+    }
+
+    [Fact]
+    public void HandleActionMenu_WithJsonObjectFormatAndArrayNode_DispatchesSingleDrillDown()
+    {
+        // Arrange
+        var filePath = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid()}.json");
+        File.WriteAllText(filePath, "{\"orders\":[{\"id\":1},{\"id\":2}]}");
+        try
+        {
+            using var app = CreateTestApp();
+            using var state = new AppState { CurrentFilePath = filePath };
+            using var window = new Window();
+            var modeController = new ModeController(state);
+            using var viewManager = new ViewManager(window, state, modeController, action => action());
+            viewManager.SwitchToJsonObjectTree([("orders", "[{\"id\":1},{\"id\":2}]"u8.ToArray())]);
+            var treeView = (MorphTreeView)viewManager.GetCurrentView()!;
+            treeView.SelectedObject = JsonObjectTreeView.CreateKeyNode("orders", "[{\"id\":1},{\"id\":2}]"u8.ToArray());
+            var fileDialogHandler = new FileDialogHandler(app, state, viewManager, _ => { }, () => { });
+            var recipeCommandHandler = new RecipeCommandHandler(app, state, viewManager);
+            using var handler = new AppKeyHandler(app, state, viewManager, fileDialogHandler, recipeCommandHandler, null);
+            app.Iteration += (_, _) => app.Keyboard.RaiseKeyDownEvent(Key.Enter);
+
+            // Act — HandleActionMenu detects JsonObject format and dispatches to HandleSingleDrillDown,
+            // which runs an ActionMenuDialog confirmed here via the Enter-key pattern.
+            var result = handler.HandleActionMenu();
+
+            // Assert
+            result.Should().BeTrue();
+            state.CurrentMode.Should().Be(ViewMode.FocusedTable);
+            viewManager.GetCurrentView().Should().BeOfType<FocusedTableView>();
+        }
+        finally
+        {
+            File.Delete(filePath);
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(InvalidSingleDrillDownSelections))]
+    public void HandleActionMenu_WhenSelectedNodeInvalidForSingleDrillDown_ReturnsFalse(ITreeNode selectedNode)
+    {
+        // Arrange — drive the guards indirectly through HandleActionMenu (same pattern as
+        // HandleActionMenu_WhenCurrentViewIsNotMorphTableView_ReturnsFalse). The guard clauses
+        // return before the ActionMenuDialog is shown, so no Enter-key confirmation is needed.
+        var filePath = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid()}.json");
+        File.WriteAllText(filePath, "{\"orders\":[{\"id\":1},{\"id\":2}]}");
+        try
+        {
+            using var app = CreateTestApp();
+            using var state = new AppState { CurrentFilePath = filePath };
+            using var window = new Window();
+            var modeController = new ModeController(state);
+            using var viewManager = new ViewManager(window, state, modeController, action => action());
+            viewManager.SwitchToJsonObjectTree([("orders", "[{\"id\":1},{\"id\":2}]"u8.ToArray())]);
+            var treeView = (MorphTreeView)viewManager.GetCurrentView()!;
+            treeView.SelectedObject = selectedNode;
+            var fileDialogHandler = new FileDialogHandler(app, state, viewManager, _ => { }, () => { });
+            var recipeCommandHandler = new RecipeCommandHandler(app, state, viewManager);
+            using var handler = new AppKeyHandler(app, state, viewManager, fileDialogHandler, recipeCommandHandler, null);
+
+            // Act
+            var result = handler.HandleActionMenu();
+
+            // Assert
+            result.Should().BeFalse();
+        }
+        finally
+        {
+            File.Delete(filePath);
+        }
+    }
+
+    /// <summary>
+    /// One ITreeNode fixture per HandleSingleDrillDown guard clause (see the guard comments below for details).
+    /// </summary>
+    public static IEnumerable<object[]> InvalidSingleDrillDownSelections()
+    {
+        // Guard 1: a primitive value node is not a JsonArrayTreeNode.
+        yield return [(object)new JsonValueTreeNode("not-an-array")];
+
+        // Guard 2: array whose lazy Children parse to zero elements.
+        yield return [(object)new JsonArrayTreeNode("[]"u8.ToArray())];
+
+        // Guard 3: mixed-type children (object + value) fail the "all children must be objects" check.
+        yield return [(object)new JsonArrayTreeNode("[{},1]"u8.ToArray())];
+    }
 
     private static IApplication CreateTestApp()
     {

--- a/tests/DataMorph.Tests/App/FileDialogHandlerTests.cs
+++ b/tests/DataMorph.Tests/App/FileDialogHandlerTests.cs
@@ -2,6 +2,7 @@ using AwesomeAssertions;
 using DataMorph.App;
 using DataMorph.App.Views;
 using DataMorph.Engine.IO;
+using DataMorph.Engine.IO.DrillDown;
 using DataMorph.Engine.Models;
 using DataMorph.Engine.Types;
 using Terminal.Gui.App;
@@ -200,10 +201,8 @@ public sealed class FileDialogHandlerTests : IDisposable
             Columns = [new ColumnSchema { Name = "col1", Type = ColumnType.Text }]
         };
         state.DrillDown = new DrillDownState(
-            [JsonRawBytes.Empty],
-            schema,
-            DataFormat.JsonObject,
-            RecordPosition: 1);
+            [new FocusedTableRow(JsonRawBytes.Empty, "[0]")],
+            schema);
 
         var handler = new FileDialogHandler(app, state, viewManager, _ => { }, () => { });
 

--- a/tests/DataMorph.Tests/App/ModeControllerTests.cs
+++ b/tests/DataMorph.Tests/App/ModeControllerTests.cs
@@ -139,4 +139,18 @@ public sealed class ModeControllerTests : IDisposable
         result.IsSuccess.Should().BeTrue();
         state.CurrentMode.Should().Be(ViewMode.JsonLinesTree);
     }
+
+    [Theory]
+    [InlineData(3)]
+    [InlineData(1)]
+    public void DrillDown_JsonObjectWithChildren_FirstRowHashValueIsBracketZero(int childCount)
+    {
+        // Arrange
+        _ = childCount; // Use parameter to suppress xUnit1026
+
+        // Act
+
+        // Assert
+        Assert.Fail("Skeleton test - replace with real assertions.");
+    }
 }

--- a/tests/DataMorph.Tests/App/ModeControllerTests.cs
+++ b/tests/DataMorph.Tests/App/ModeControllerTests.cs
@@ -1,6 +1,7 @@
 using System.Text;
 using AwesomeAssertions;
 using DataMorph.App;
+using DataMorph.Engine.IO.DrillDown;
 using DataMorph.Engine.IO.JsonLines;
 
 namespace DataMorph.Tests.App;
@@ -175,7 +176,7 @@ public sealed class ModeControllerTests : IDisposable
         var controller = new ModeController(state);
         var request = new FullAggregationDrillDownRequest(
             Format: DataMorph.Engine.Types.DataFormat.JsonLines,
-            KeyPath: ["user"]);
+            KeyPath: [new KeyPathSegment("user", KeyPathSegmentKind.Key)]);
 
         // Act
         var result = await controller.FullAggregationDrillDownAsync(request);
@@ -197,7 +198,7 @@ public sealed class ModeControllerTests : IDisposable
         var controller = new ModeController(state);
         var request = new FullAggregationDrillDownRequest(
             Format: DataMorph.Engine.Types.DataFormat.JsonLines,
-            KeyPath: ["missing"]);
+            KeyPath: [new KeyPathSegment("missing", KeyPathSegmentKind.Key)]);
 
         // Act
         var result = await controller.FullAggregationDrillDownAsync(request);

--- a/tests/DataMorph.Tests/App/ModeControllerTests.cs
+++ b/tests/DataMorph.Tests/App/ModeControllerTests.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using AwesomeAssertions;
 using DataMorph.App;
 using DataMorph.Engine.IO.JsonLines;
@@ -143,14 +144,68 @@ public sealed class ModeControllerTests : IDisposable
     [Theory]
     [InlineData(3)]
     [InlineData(1)]
-    public void DrillDown_JsonObjectWithChildren_FirstRowHashValueIsBracketZero(int childCount)
+    public void DrillDown_JsonObjectWithChildren_PopulatesAllRowsAndSwitchesToFocusedTable(int childCount)
     {
         // Arrange
-        _ = childCount; // Use parameter to suppress xUnit1026
+        var children = string.Join(",", Enumerable.Range(0, childCount).Select(i => $$"""{"id":{{i}}}"""));
+        JsonRawBytes nodeBytes = Encoding.UTF8.GetBytes($"[{children}]");
+        var request = new SingleDrillDownRequest(
+            Format: DataMorph.Engine.Types.DataFormat.JsonObject,
+            NodeBytes: nodeBytes);
+        using var state = new AppState();
+        var controller = new ModeController(state);
+        var expectedHashValues = Enumerable.Range(0, childCount).Select(i => $"[{i}]");
 
         // Act
+        var result = controller.DrillDown(request);
 
         // Assert
-        Assert.Fail("Skeleton test - replace with real assertions.");
+        result.IsSuccess.Should().BeTrue();
+        state.CurrentMode.Should().Be(ViewMode.FocusedTable);
+        state.DrillDown.Should().BeOfType<DrillDownState>().Which.Rows.Select(r => r.HashValue).Should().Equal(expectedHashValues);
+    }
+
+    [Fact]
+    public async Task FullAggregationDrillDownAsync_ValidJsonLinesFile_ReturnsSuccessWithoutMutatingState()
+    {
+        // Arrange
+        await File.WriteAllTextAsync(
+            _jsonlFilePath, "{\"user\":{\"name\":\"Alice\"}}\n{\"user\":{\"name\":\"Bob\"}}");
+        using var state = new AppState { CurrentFilePath = _jsonlFilePath };
+        var controller = new ModeController(state);
+        var request = new FullAggregationDrillDownRequest(
+            Format: DataMorph.Engine.Types.DataFormat.JsonLines,
+            KeyPath: ["user"]);
+
+        // Act
+        var result = await controller.FullAggregationDrillDownAsync(request);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Rows.Should().HaveCount(2);
+        result.Value.Schema.Columns.Select(c => c.Name).Should().Equal("name");
+        state.DrillDown.Should().BeNull();
+        state.CurrentMode.Should().Be(ViewMode.FileSelection);
+    }
+
+    [Fact]
+    public async Task FullAggregationDrillDownAsync_ScanFails_ReturnsFailureWithoutMutatingState()
+    {
+        // Arrange
+        await File.WriteAllTextAsync(_jsonlFilePath, "{\"user\":{\"name\":\"Alice\"}}");
+        using var state = new AppState { CurrentFilePath = _jsonlFilePath };
+        var controller = new ModeController(state);
+        var request = new FullAggregationDrillDownRequest(
+            Format: DataMorph.Engine.Types.DataFormat.JsonLines,
+            KeyPath: ["missing"]);
+
+        // Act
+        var result = await controller.FullAggregationDrillDownAsync(request);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Be("No matching records found.");
+        state.DrillDown.Should().BeNull();
+        state.CurrentMode.Should().Be(ViewMode.FileSelection);
     }
 }

--- a/tests/DataMorph.Tests/App/ViewManagerTests.cs
+++ b/tests/DataMorph.Tests/App/ViewManagerTests.cs
@@ -2,6 +2,7 @@ using AwesomeAssertions;
 using DataMorph.App;
 using DataMorph.App.Views;
 using DataMorph.Engine.IO;
+using DataMorph.Engine.IO.DrillDown;
 using DataMorph.Engine.IO.JsonArray;
 using DataMorph.Engine.Models;
 using DataMorph.Engine.Types;
@@ -539,6 +540,121 @@ public sealed class ViewManagerTests : IDisposable
             Enumerable.OfType<Shortcut>(currentStatusBar.SubViews),
             s => s.HelpText);
         hints.Should().NotContainMatch("*Tree/Table*");
+    }
+
+    [Fact]
+    public async Task FullAggregationDrillDownAsync_WhenScanSucceeds_SwitchesToFocusedTable()
+    {
+        // Arrange — real file + matching KeyPath; ModeController is sealed and can't be mocked, so
+        // success is driven by an actual scan over an actual file.
+        var filePath = CreateTempFile(".jsonl", "{\"user\":{\"name\":\"Alice\"}}\n");
+        using var app = CreateTestApp();
+        using var state = new AppState { CurrentFilePath = filePath };
+        using var window = new Window();
+        var modeController = new ModeController(state);
+        using var viewManager = new ViewManager(window, state, modeController, action => action());
+
+        var request = new FullAggregationDrillDownRequest(
+            DataFormat.JsonLines,
+            [new KeyPathSegment("user", KeyPathSegmentKind.Key)]);
+
+        // Act — immediate-execution uiThreadInvoke applies the scanned result synchronously
+        await viewManager.FullAggregationDrillDownAsync(request);
+
+        // Assert
+        state.CurrentMode.Should().Be(ViewMode.FocusedTable);
+        state.DrillDown.Should().NotBeNull();
+        viewManager.GetCurrentView().Should().BeOfType<FocusedTableView>();
+    }
+
+    [Fact]
+    public async Task FullAggregationDrillDownAsync_WhenScanFails_ShowsErrorPlaceholder()
+    {
+        // Arrange — real file + non-matching KeyPath, so the sealed ModeController's scan fails.
+        var filePath = CreateTempFile(".jsonl", "{\"user\":{\"name\":\"Alice\"}}\n");
+        using var app = CreateTestApp();
+        using var state = new AppState { CurrentFilePath = filePath };
+        using var window = new Window();
+        var modeController = new ModeController(state);
+        using var viewManager = new ViewManager(window, state, modeController, action => action());
+
+        var request = new FullAggregationDrillDownRequest(
+            DataFormat.JsonLines,
+            [new KeyPathSegment("missing", KeyPathSegmentKind.Key)]);
+
+        // Act
+        await viewManager.FullAggregationDrillDownAsync(request);
+
+        // Assert — failure routes through ShowError into a PlaceholderView carrying the message
+        state.CurrentMode.Should().Be(ViewMode.PlaceholderView);
+        viewManager.GetCurrentView().Should().BeOfType<PlaceholderView>().Which.Text.Should().Be("No matching records found.");
+    }
+
+    [Fact]
+    public async Task FullAggregationDrillDownAsync_WithDeferredUiThreadInvoke_DoesNotMutateStateUntilCallback()
+    {
+        // Arrange — inject a deferred-capture uiThreadInvoke so state changes only happen once the
+        // captured callback runs, mirroring how a real TUI posts work to the UI thread.
+        var filePath = CreateTempFile(".jsonl", "{\"user\":{\"name\":\"Alice\"}}\n");
+        using var app = CreateTestApp();
+        using var state = new AppState { CurrentFilePath = filePath };
+        using var window = new Window();
+        var modeController = new ModeController(state);
+
+        List<Action> capturedCallbacks = [];
+        using var viewManager = new ViewManager(
+            window, state, modeController, cb => capturedCallbacks.Add(cb));
+
+        var request = new FullAggregationDrillDownRequest(
+            DataFormat.JsonLines,
+            [new KeyPathSegment("user", KeyPathSegmentKind.Key)]);
+
+        // Act — the background scan completes; the callback is captured but NOT yet executed
+        await viewManager.FullAggregationDrillDownAsync(request);
+
+        // Assert — phase 1: state must be untouched before the UI-thread callback runs
+        capturedCallbacks.Should().ContainSingle();
+        state.DrillDown.Should().BeNull();
+        state.CurrentMode.Should().Be(ViewMode.FileSelection);
+
+        // Act — dispatch the captured callback (what the real UI thread would run)
+        capturedCallbacks[0].Invoke();
+
+        // Assert — phase 2: only now does the successful result reach AppState and switch the view
+        state.CurrentMode.Should().Be(ViewMode.FocusedTable);
+        state.DrillDown.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task FullAggregationDrillDownAsync_WhenViewManagerDisposedBeforeCallback_Throws()
+    {
+        // Arrange — a success scan is required to reach SwitchToFocusedTable's dispose guard;
+        // dispose before invoking the captured callback to simulate the race.
+        var filePath = CreateTempFile(".jsonl", "{\"user\":{\"name\":\"Alice\"}}\n");
+        using var app = CreateTestApp();
+        using var state = new AppState { CurrentFilePath = filePath };
+        using var window = new Window();
+        var modeController = new ModeController(state);
+
+        List<Action> capturedCallbacks = [];
+        // Not 'using' — disposed manually below to simulate the race between scan completion and dispatch.
+        var viewManager = new ViewManager(
+            window, state, modeController, cb => capturedCallbacks.Add(cb));
+
+        var request = new FullAggregationDrillDownRequest(
+            DataFormat.JsonLines,
+            [new KeyPathSegment("user", KeyPathSegmentKind.Key)]);
+
+        // Act — scan completes and the callback is captured; dispose BEFORE the callback executes
+        await viewManager.FullAggregationDrillDownAsync(request);
+        viewManager.Dispose();
+
+        // Assert — the fail-fast guard throws before any state mutation.
+        capturedCallbacks.Should().ContainSingle();
+        var act = () => capturedCallbacks[0].Invoke();
+        act.Should().Throw<ObjectDisposedException>();
+        state.DrillDown.Should().BeNull();
+        state.CurrentMode.Should().Be(ViewMode.FileSelection);
     }
 
     /// <summary>

--- a/tests/DataMorph.Tests/App/Views/FocusedTableSourceTests.cs
+++ b/tests/DataMorph.Tests/App/Views/FocusedTableSourceTests.cs
@@ -1,6 +1,7 @@
 using AwesomeAssertions;
 using DataMorph.App;
 using DataMorph.App.Views;
+using DataMorph.Engine.IO.DrillDown;
 using DataMorph.Engine.Models;
 using DataMorph.Engine.Types;
 
@@ -8,10 +9,10 @@ namespace DataMorph.Tests.App.Views;
 
 public sealed class FocusedTableSourceTests
 {
-    private static readonly IReadOnlyList<JsonRawBytes> DefaultChildRawValues =
+    private static readonly IReadOnlyList<FocusedTableRow> DefaultRows =
     [
-        "{\"name\": \"Alice\", \"age\": 30}"u8.ToArray(),
-        "{\"name\": \"Bob\", \"age\": 25}"u8.ToArray(),
+        new FocusedTableRow("{\"name\": \"Alice\", \"age\": 30}"u8.ToArray(), "[0]"),
+        new FocusedTableRow("{\"name\": \"Bob\", \"age\": 25}"u8.ToArray(), "[1]"),
     ];
 
     private static readonly TableSchema DefaultSchema = new()
@@ -25,11 +26,9 @@ public sealed class FocusedTableSourceTests
     };
 
     private static DrillDownState CreateState(
-        IReadOnlyList<JsonRawBytes>? childRawValues = null,
-        TableSchema? schema = null,
-        DataFormat format = DataFormat.JsonLines,
-        long? recordPosition = 22) =>
-        new(childRawValues ?? DefaultChildRawValues, schema ?? DefaultSchema, format, recordPosition);
+        IReadOnlyList<FocusedTableRow>? rows = null,
+        TableSchema? schema = null) =>
+        new(rows ?? DefaultRows, schema ?? DefaultSchema);
 
     [Fact]
     public void Constructor_NullDrillDownState_ThrowsArgumentNullException()
@@ -42,7 +41,7 @@ public sealed class FocusedTableSourceTests
     }
 
     [Fact]
-    public void Rows_ReturnsChildCount()
+    public void Rows_ReturnsRowCount()
     {
         // Arrange
         var source = new FocusedTableSource(CreateState());
@@ -81,46 +80,18 @@ public sealed class FocusedTableSourceTests
     }
 
     [Theory]
-    [InlineData(0, "22:0")]
-    [InlineData(1, "22:1")]
-    public void Indexer_JsonLines_HashColumnFormatsAsLineNumberColonIndex(int row, string expected)
+    [InlineData(0, "[0]")]
+    [InlineData(1, "[1]")]
+    public void Indexer_HashColumn_ReturnsRowHashValue(int row, string expected)
     {
         // Arrange
-        var source = new FocusedTableSource(CreateState(format: DataFormat.JsonLines, recordPosition: 22));
+        var source = new FocusedTableSource(CreateState());
 
         // Act
         var hashCell = source[row, 0];
 
         // Assert
         hashCell.Should().Be(expected);
-    }
-
-    [Theory]
-    [InlineData(0, "5:0")]
-    [InlineData(1, "5:1")]
-    public void Indexer_JsonArray_HashColumnFormatsAsElementIndexColonIndex(int row, string expected)
-    {
-        // Arrange
-        var source = new FocusedTableSource(CreateState(format: DataFormat.JsonArray, recordPosition: 5));
-
-        // Act
-        var hashCell = source[row, 0];
-
-        // Assert
-        hashCell.Should().Be(expected);
-    }
-
-    [Fact]
-    public void Indexer_JsonObject_HashColumnFormatsAsBracketIndex()
-    {
-        // Arrange
-        var source = new FocusedTableSource(CreateState(format: DataFormat.JsonObject, recordPosition: null));
-
-        // Act
-        var hashCell = source[0, 0];
-
-        // Assert
-        hashCell.Should().Be("[0]");
     }
 
     [Fact]

--- a/tests/DataMorph.Tests/App/Views/JsonTreeNodes/JsonTreeNodeHelperTests.cs
+++ b/tests/DataMorph.Tests/App/Views/JsonTreeNodes/JsonTreeNodeHelperTests.cs
@@ -2,6 +2,7 @@ using System.Text;
 using System.Text.Json;
 using AwesomeAssertions;
 using DataMorph.App.Views.JsonTreeNodes;
+using Terminal.Gui.Views;
 
 namespace DataMorph.Tests.App.Views.JsonTreeNodes;
 
@@ -186,49 +187,143 @@ public sealed class JsonTreeNodeHelperTests
     public void CreateChildNode_NestedObject_SetsKeyNameOnReturnedNode()
     {
         // Arrange
+        var json = "{\"key\": \"value\"}";
+        var rawJson = Encoding.UTF8.GetBytes(json);
+        var reader = new Utf8JsonReader(rawJson);
+        reader.Read(); // Move to StartObject
 
         // Act
+        var node = JsonTreeNodeHelper.CreateChildNode(ref reader, "obj", rawJson);
 
         // Assert
+        var objectNode = node.Should().BeOfType<JsonObjectTreeNode>().Subject;
+        objectNode.KeyName.Should().Be("obj");
     }
 
     [Fact]
     public void CreateChildNode_NestedArray_SetsKeyNameOnReturnedNode()
     {
         // Arrange
+        var json = "[1, 2, 3]";
+        var rawJson = Encoding.UTF8.GetBytes(json);
+        var reader = new Utf8JsonReader(rawJson);
+        reader.Read(); // Move to StartArray
 
         // Act
+        var node = JsonTreeNodeHelper.CreateChildNode(ref reader, "arr", rawJson);
 
         // Assert
+        var arrayNode = node.Should().BeOfType<JsonArrayTreeNode>().Subject;
+        arrayNode.KeyName.Should().Be("arr");
     }
 
     [Fact]
     public void CreateChildNode_WithRecordPosition_PropagatesRecordPositionToObjectNode()
     {
         // Arrange
+        var json = "{\"key\": \"value\"}";
+        var rawJson = Encoding.UTF8.GetBytes(json);
+        var reader = new Utf8JsonReader(rawJson);
+        reader.Read(); // Move to StartObject
 
         // Act
+        var node = JsonTreeNodeHelper.CreateChildNode(ref reader, "obj", rawJson, recordPosition: 5L);
 
         // Assert
+        var objectNode = node.Should().BeOfType<JsonObjectTreeNode>().Subject;
+        objectNode.RecordPosition.Should().Be(5L);
     }
 
     [Fact]
     public void CreateChildNode_WithRecordPosition_PropagatesRecordPositionToArrayNode()
     {
         // Arrange
+        var json = "[1, 2, 3]";
+        var rawJson = Encoding.UTF8.GetBytes(json);
+        var reader = new Utf8JsonReader(rawJson);
+        reader.Read(); // Move to StartArray
 
         // Act
+        var node = JsonTreeNodeHelper.CreateChildNode(ref reader, "arr", rawJson, recordPosition: 7L);
 
         // Assert
+        var arrayNode = node.Should().BeOfType<JsonArrayTreeNode>().Subject;
+        arrayNode.RecordPosition.Should().Be(7L);
     }
 
     [Fact]
     public void CreateChildNode_WithNullRecordPosition_SetsNullRecordPositionOnNode()
     {
         // Arrange
+        var json = "{\"key\": \"value\"}";
+        var rawJson = Encoding.UTF8.GetBytes(json);
+        var reader = new Utf8JsonReader(rawJson);
+        reader.Read(); // Move to StartObject
 
         // Act
+        var node = JsonTreeNodeHelper.CreateChildNode(ref reader, "obj", rawJson);
 
         // Assert
+        var objectNode = node.Should().BeOfType<JsonObjectTreeNode>().Subject;
+        objectNode.RecordPosition.Should().BeNull();
+    }
+
+    [Fact]
+    public void CreateChildNode_WithObjectToken_PropagatesParentNodeAndKeyName()
+    {
+        // Arrange
+        var rawJson = Encoding.UTF8.GetBytes("{\"k\":\"v\"}");
+        var reader = new Utf8JsonReader(rawJson);
+        reader.Read();
+        ITreeNode parent = new JsonValueTreeNode("parent");
+
+        // Act
+        var node = JsonTreeNodeHelper.CreateChildNode(ref reader, "obj", rawJson, parentNode: parent);
+
+        // Assert
+        var objectNode = node.Should().BeOfType<JsonObjectTreeNode>().Subject;
+        objectNode.KeyName.Should().Be("obj");
+        objectNode.ParentNode.Should().BeSameAs(parent);
+    }
+
+    [Fact]
+    public void CreateChildNode_WithArrayToken_PropagatesParentNodeAndKeyName()
+    {
+        // Arrange
+        var rawJson = Encoding.UTF8.GetBytes("[1]");
+        var reader = new Utf8JsonReader(rawJson);
+        reader.Read();
+        ITreeNode parent = new JsonValueTreeNode("parent");
+
+        // Act
+        var node = JsonTreeNodeHelper.CreateChildNode(ref reader, "arr", rawJson, parentNode: parent);
+
+        // Assert
+        var arrayNode = node.Should().BeOfType<JsonArrayTreeNode>().Subject;
+        arrayNode.KeyName.Should().Be("arr");
+        arrayNode.ParentNode.Should().BeSameAs(parent);
+    }
+
+    [Theory]
+    [InlineData("\"s\"", "str")]
+    [InlineData("1", "num")]
+    [InlineData("true", "t")]
+    [InlineData("false", "f")]
+    [InlineData("null", "nul")]
+    public void CreateChildNode_WithValueToken_PropagatesParentNodeAndKeyName(string json, string label)
+    {
+        // Arrange
+        var rawJson = Encoding.UTF8.GetBytes(json);
+        var reader = new Utf8JsonReader(rawJson);
+        reader.Read();
+        ITreeNode parent = new JsonValueTreeNode("parent");
+
+        // Act
+        var node = JsonTreeNodeHelper.CreateChildNode(ref reader, label, rawJson, parentNode: parent);
+
+        // Assert
+        var valueNode = node.Should().BeOfType<JsonValueTreeNode>().Subject;
+        valueNode.KeyName.Should().Be(label);
+        valueNode.ParentNode.Should().BeSameAs(parent);
     }
 }

--- a/tests/DataMorph.Tests/Engine/IO/DrillDown/FileChunkReaderTests.cs
+++ b/tests/DataMorph.Tests/Engine/IO/DrillDown/FileChunkReaderTests.cs
@@ -1,0 +1,154 @@
+using System.Text;
+using AwesomeAssertions;
+using DataMorph.Engine.IO;
+using DataMorph.Engine.IO.DrillDown;
+
+namespace DataMorph.Tests.Engine.IO.DrillDown;
+
+/// <summary>
+/// Tests for <see cref="FileChunkReader"/>'s buffer-refill path, CRLF trimming, UTF-8 BOM skipping,
+/// and range reading. Each test constructs a real <see cref="MmapService"/> over a temp file so the
+/// <see cref="FileChunkReader"/> helpers are exercised directly, not through FullAggregationScanner.
+/// The boundary carry-over scenario uses the real <see cref="FileChunkReader.BufferSize"/> (1 MiB)
+/// with a file large enough to straddle it, mirroring FullAggregationScannerTests' boundary fixture.
+/// </summary>
+public sealed class FileChunkReaderTests : IDisposable
+{
+    private readonly string _testFilePath;
+
+    public FileChunkReaderTests()
+    {
+        _testFilePath = Path.Combine(Path.GetTempPath(), $"filechunkreader_{Guid.NewGuid()}.txt");
+    }
+
+    public void Dispose()
+    {
+        if (File.Exists(_testFilePath))
+        {
+            File.Delete(_testFilePath);
+        }
+    }
+
+    [Fact]
+    public void FillBuffer_WhenLineSpansBufferBoundary_PreservesCarriedOverBytes()
+    {
+        // Arrange — file larger than BufferSize so a follow-up FillBuffer has data to top up with,
+        // mirroring FullAggregationScannerTests' 1 MiB boundary fixture.
+        const int carryOverLen = 100;
+        var padding = new string('a', FileChunkReader.BufferSize);
+        var tail = new string('b', 500);
+        File.WriteAllText(_testFilePath, padding + tail);
+        using var mmap = MmapService.Open(_testFilePath).Value;
+        var buffer = new byte[FileChunkReader.BufferSize];
+        // The first carryOverLen bytes are the leftover of a line that spans the 1 MiB boundary;
+        // mark them so we can prove FillBuffer preserves them in place.
+        buffer.AsSpan(0, carryOverLen).Fill((byte)'X');
+        var expectedCarryOver = new byte[carryOverLen];
+        Array.Fill(expectedCarryOver, (byte)'X');
+
+        // Act — resume at the 1 MiB boundary, carrying carryOverLen bytes forward.
+        var (dataEnd, fileOffset) = FileChunkReader.FillBuffer(
+            mmap, buffer, carryOverLen, FileChunkReader.BufferSize, "test");
+
+        // Assert — the carry-over bytes are intact and the tail is appended right after them.
+        dataEnd.Should().Be(carryOverLen + tail.Length);
+        fileOffset.Should().Be(FileChunkReader.BufferSize + tail.Length);
+        buffer.AsSpan(0, carryOverLen).ToArray().Should().Equal(expectedCarryOver);
+        Encoding.ASCII.GetString(buffer, carryOverLen, tail.Length).Should().Be(tail);
+    }
+
+    [Fact]
+    public void FillBuffer_WhenRemainingLengthEqualsBufferSize_ThrowsNotSupportedException()
+    {
+        // Arrange — the guard throws before any mmap/buffer read, so only the buffer capacity matters.
+        File.WriteAllText(_testFilePath, "0123456789");
+        using var mmap = MmapService.Open(_testFilePath).Value;
+        var buffer = new byte[FileChunkReader.BufferSize];
+
+        // Act
+        var act = () => FileChunkReader.FillBuffer(mmap, buffer, FileChunkReader.BufferSize, 0, "test line");
+
+        // Assert
+        act.Should().Throw<NotSupportedException>().WithMessage("test line exceeds maximum supported size.");
+    }
+
+    [Fact]
+    public void TrimTrailingCr_WithTrailingCarriageReturn_RemovesLastByte()
+    {
+        // Arrange
+        var line = "abc\r"u8;
+
+        // Act
+        var result = FileChunkReader.TrimTrailingCr(line);
+
+        // Assert
+        result.ToArray().Should().Equal("abc"u8.ToArray());
+    }
+
+    [Fact]
+    public void TrimTrailingCr_WithoutTrailingCarriageReturn_ReturnsInputUnchanged()
+    {
+        // Arrange
+        var line = "abc"u8;
+
+        // Act
+        var result = FileChunkReader.TrimTrailingCr(line);
+
+        // Assert
+        result.ToArray().Should().Equal("abc"u8.ToArray());
+    }
+
+    public static IEnumerable<object[]> SkipUtf8BomCases()
+    {
+        // Full UTF-8 BOM (EF BB BF) followed by content → skip 3 bytes.
+        yield return [(byte[])[0xEF, 0xBB, 0xBF, (byte)'{'], 3L];
+        // Full UTF-8 BOM with nothing after it → skip 3 bytes (EOF right after the BOM).
+        yield return [(byte[])[0xEF, 0xBB, 0xBF], 3L];
+        // No BOM — ordinary content of 3+ bytes → skip 0.
+        yield return [Encoding.ASCII.GetBytes("abc"), 0L];
+        // Near-miss — first two BOM bytes but the third differs (BE vs BF) → skip 0.
+        yield return [(byte[])[0xEF, 0xBB, 0xBE], 0L];
+        // File shorter than 3 bytes → skip 0 (early return before reading).
+        yield return [Encoding.ASCII.GetBytes("ab"), 0L];
+    }
+
+    [Theory]
+    [MemberData(nameof(SkipUtf8BomCases))]
+    public void SkipUtf8Bom_VariousHeaders_ReturnsExpectedSkipLength(byte[] header, long expected)
+    {
+        // Arrange
+        File.WriteAllBytes(_testFilePath, header);
+        using var mmap = MmapService.Open(_testFilePath).Value;
+
+        // Act
+        var skipLength = FileChunkReader.SkipUtf8Bom(mmap);
+
+        // Assert
+        skipLength.Should().Be(expected);
+    }
+
+    public static IEnumerable<object[]> ReadFileRangeCases()
+    {
+        // Range [2, 5) of "0123456789" → "234".
+        yield return [Encoding.ASCII.GetBytes("0123456789"), 2L, 5L, Encoding.ASCII.GetBytes("234")];
+        // Range to EOF [7, 10) of a 10-byte file → "789" (endOffset == file length).
+        yield return [Encoding.ASCII.GetBytes("0123456789"), 7L, 10L, Encoding.ASCII.GetBytes("789")];
+        // Empty range [3, 3) → zero-length result.
+        yield return [Encoding.ASCII.GetBytes("0123456789"), 3L, 3L, Array.Empty<byte>()];
+    }
+
+    [Theory]
+    [MemberData(nameof(ReadFileRangeCases))]
+    public void ReadFileRange_ForGivenRange_ReturnsExactBytes(byte[] content, long start, long end, byte[] expected)
+    {
+        // Arrange
+        File.WriteAllBytes(_testFilePath, content);
+        using var mmap = MmapService.Open(_testFilePath).Value;
+
+        // Act
+        var result = FileChunkReader.ReadFileRange(mmap, start, end);
+
+        // Assert
+        result.ToArray().Should().Equal(expected);
+    }
+}

--- a/tests/DataMorph.Tests/Engine/IO/DrillDown/FullAggregationScannerTests.cs
+++ b/tests/DataMorph.Tests/Engine/IO/DrillDown/FullAggregationScannerTests.cs
@@ -502,4 +502,34 @@ public sealed class FullAggregationScannerTests : IDisposable
         result.Value.rows[0].HashValue.Should().Be("1");
         GetProperty(result.Value.rows[0].Bytes, "score").GetInt32().Should().Be(88);
     }
+
+    [Theory]
+    [InlineData(DataFormat.JsonLines)]
+    [InlineData(DataFormat.JsonArray)]
+    public void Scan_ObjectKeyStartingWithBracket_TreatedAsKeyNotIndex(DataFormat format)
+    {
+        // Arrange — a KeyPath segment "[0]" is ambiguous: it's both a literal object key here and
+        // the marker this codebase uses for array indices. That ambiguity breaks two independent
+        // methods that read KeyPath segments: TraverseKeyPath misreads "[0]" as an index and
+        // silently skips the record entirely (asserted via IsSuccess/row count), while
+        // LastKeySegment misreads it the same way and synthesizes the wrong leaf column name
+        // (asserted via the schema column name). The "[0]" segment below is built directly, not
+        // via the KeyPath(...) helper, because that helper uses the same flawed '[' heuristic and
+        // would silently defeat this test.
+        var path = CreateTempFile(format, """{"a":{"[0]":"hello"}}""");
+        IReadOnlyList<KeyPathSegment> keyPath =
+        [
+            new KeyPathSegment("a", KeyPathSegmentKind.Key),
+            new KeyPathSegment("[0]", KeyPathSegmentKind.Key),
+        ];
+
+        // Act
+        var result = FullAggregationScanner.Scan(path, format, keyPath);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.rows.Should().HaveCount(1);
+        result.Value.schema.Columns.Select(c => c.Name).Should().Equal("[0]");
+        GetProperty(result.Value.rows[0].Bytes, "[0]").GetString().Should().Be("hello");
+    }
 }

--- a/tests/DataMorph.Tests/Engine/IO/DrillDown/FullAggregationScannerTests.cs
+++ b/tests/DataMorph.Tests/Engine/IO/DrillDown/FullAggregationScannerTests.cs
@@ -46,10 +46,7 @@ public sealed class FullAggregationScannerTests : IDisposable
     }
 
     /// <summary>
-    /// Builds a KeyPath from conventional segment labels for test scenarios: a segment matching the
-    /// "[n]" index-label form is tagged as Index, every other segment as Key. This is test shorthand
-    /// only — production BuildKeyPath tags segments by parent node type, never by label text, so a
-    /// literal "[0]" object key is correctly tagged as Key there (see the regression test below).
+    /// Test-only shorthand: builds a KeyPath tagging "[n]"-shaped segments as Index and everything else as Key. Production BuildKeyPath tags by parent node type instead, not label text.
     /// </summary>
     private static IReadOnlyList<KeyPathSegment> KeyPath(params string[] segments)
         => [.. segments.Select(static s => new KeyPathSegment(
@@ -531,5 +528,51 @@ public sealed class FullAggregationScannerTests : IDisposable
         result.Value.rows.Should().HaveCount(1);
         result.Value.schema.Columns.Select(c => c.Name).Should().Equal("[0]");
         GetProperty(result.Value.rows[0].Bytes, "[0]").GetString().Should().Be("hello");
+    }
+
+    /// <summary>
+    /// Builds a file where a padding record ends just short of FileChunkReader.BufferSize and the
+    /// following "note" record's value straddles that boundary, forcing a FillBuffer carry-over
+    /// (JsonLines) or a multi-segment Utf8JsonReader continuation (JsonArray) mid-value.
+    /// </summary>
+    private (string path, string expectedValue) CreateBoundaryStraddlingFile(DataFormat format)
+    {
+        const int remaining = 100;
+        const int targetValueLength = 500;
+        var targetValue = new string('b', targetValueLength);
+        var target = "{\"note\":\"" + targetValue + "\"}";
+
+        var wrapperOverhead = "{\"pad\":\"".Length + "\"}".Length;
+        var extraOverhead = format == DataFormat.JsonLines ? 1 : 2; // newline, or "[" + ","
+        var padLen = FileChunkReader.BufferSize - remaining - wrapperOverhead - extraOverhead;
+        var padElem = "{\"pad\":\"" + new string('a', padLen) + "\"}";
+
+        var content = format == DataFormat.JsonLines
+            ? padElem + "\n" + target
+            : "[" + padElem + "," + target + "]";
+        var extension = format == DataFormat.JsonLines ? ".jsonl" : ".json";
+
+        var path = Path.ChangeExtension(Path.GetTempFileName(), extension);
+        File.WriteAllText(path, content);
+        _tempFiles.Add(path);
+        return (path, targetValue);
+    }
+
+    // Generates a record that straddles FileChunkReader.BufferSize exactly, to confirm ScanLines/ScanElements carry leftover bytes across FillBuffer calls without corruption.
+    [Theory]
+    [InlineData(DataFormat.JsonLines)]
+    [InlineData(DataFormat.JsonArray)]
+    public void Scan_WhenLineSpansBufferBoundary_ParsesRecordWithoutCorruption(DataFormat format)
+    {
+        // Arrange
+        var (path, expectedValue) = CreateBoundaryStraddlingFile(format);
+
+        // Act
+        var result = FullAggregationScanner.Scan(path, format, KeyPath("note"));
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.rows.Should().HaveCount(1);
+        GetProperty(result.Value.rows[0].Bytes, "note").GetString().Should().Be(expectedValue);
     }
 }

--- a/tests/DataMorph.Tests/Engine/IO/DrillDown/FullAggregationScannerTests.cs
+++ b/tests/DataMorph.Tests/Engine/IO/DrillDown/FullAggregationScannerTests.cs
@@ -1,21 +1,72 @@
+using System.Globalization;
+using System.Text;
+using System.Text.Json;
+using AwesomeAssertions;
+using DataMorph.Engine.IO.DrillDown;
+using DataMorph.Engine.IO.Json;
+using DataMorph.Engine.Models;
 using DataMorph.Engine.Types;
 
 namespace DataMorph.Tests.Engine.IO.DrillDown;
 
-public sealed class FullAggregationScannerTests
+public sealed class FullAggregationScannerTests : IDisposable
 {
+    private readonly List<string> _tempFiles = [];
+
+    public void Dispose()
+    {
+        foreach (var path in _tempFiles)
+        {
+            if (File.Exists(path))
+            {
+                File.Delete(path);
+            }
+        }
+    }
+
+    private string CreateTempFile(DataFormat format, params string[] records)
+    {
+        var extension = format == DataFormat.JsonLines ? ".jsonl" : ".json";
+        var path = Path.ChangeExtension(Path.GetTempFileName(), extension);
+        var content = format == DataFormat.JsonArray
+            ? $"[{string.Join(",", records)}]"
+            : string.Join("\n", records);
+        File.WriteAllText(path, content);
+        _tempFiles.Add(path);
+        return path;
+    }
+
+    private static string Pos(DataFormat format, int recordIndex) =>
+        (format == DataFormat.JsonLines ? recordIndex + 1 : recordIndex).ToString(CultureInfo.InvariantCulture);
+
+    private static JsonElement GetProperty(JsonRawBytes bytes, string propertyName)
+    {
+        using var doc = JsonDocument.Parse(bytes);
+        return doc.RootElement.GetProperty(propertyName).Clone();
+    }
+
     [Theory]
     [InlineData(DataFormat.JsonLines)]
     [InlineData(DataFormat.JsonArray)]
     public void Scan_ObjectLeafInAllRecords_ReturnsOneRowPerRecord(DataFormat format)
     {
         // Arrange
-        _ = format; // Use parameter to suppress xUnit1026
+        var path = CreateTempFile(
+            format,
+            """{"user":{"name":"Alice","age":30}}""",
+            """{"user":{"name":"Bob","age":25}}""");
 
         // Act
+        var result = FullAggregationScanner.Scan(path, format, ["user"]);
 
         // Assert
-        Assert.Fail("Skeleton test - replace with real assertions.");
+        result.IsSuccess.Should().BeTrue();
+        result.Value.rows.Should().HaveCount(2);
+        result.Value.rows[0].HashValue.Should().Be(Pos(format, 0));
+        result.Value.rows[1].HashValue.Should().Be(Pos(format, 1));
+        GetProperty(result.Value.rows[0].Bytes, "name").GetString().Should().Be("Alice");
+        GetProperty(result.Value.rows[1].Bytes, "name").GetString().Should().Be("Bob");
+        result.Value.schema.Columns.Select(c => c.Name).Should().Equal("name", "age");
     }
 
     [Theory]
@@ -24,12 +75,21 @@ public sealed class FullAggregationScannerTests
     public void Scan_ArrayOfObjectLeafInAllRecords_ReturnsOneRowPerElement(DataFormat format)
     {
         // Arrange
-        _ = format; // Use parameter to suppress xUnit1026
+        var path = CreateTempFile(
+            format,
+            """{"orders":[{"id":"A1","qty":2},{"id":"A2","qty":5}]}""",
+            """{"orders":[{"id":"B1","qty":1}]}""");
 
         // Act
+        var result = FullAggregationScanner.Scan(path, format, ["orders"]);
 
         // Assert
-        Assert.Fail("Skeleton test - replace with real assertions.");
+        result.IsSuccess.Should().BeTrue();
+        result.Value.rows.Should().HaveCount(3);
+        result.Value.rows.Select(r => r.HashValue).Should().Equal(
+            $"{Pos(format, 0)}:0", $"{Pos(format, 0)}:1", $"{Pos(format, 1)}:0");
+        result.Value.rows.Select(r => GetProperty(r.Bytes, "id").GetString())
+            .Should().Equal("A1", "A2", "B1");
     }
 
     [Theory]
@@ -38,12 +98,22 @@ public sealed class FullAggregationScannerTests
     public void Scan_ArrayOfPrimitiveLeafInAllRecords_ReturnsRowsWithValueColumn(DataFormat format)
     {
         // Arrange
-        _ = format; // Use parameter to suppress xUnit1026
+        var path = CreateTempFile(
+            format,
+            """{"tags":["dev","ops"]}""",
+            """{"tags":["dev"]}""");
 
         // Act
+        var result = FullAggregationScanner.Scan(path, format, ["tags"]);
 
         // Assert
-        Assert.Fail("Skeleton test - replace with real assertions.");
+        result.IsSuccess.Should().BeTrue();
+        result.Value.rows.Should().HaveCount(3);
+        result.Value.rows.Select(r => r.HashValue).Should().Equal(
+            $"{Pos(format, 0)}:0", $"{Pos(format, 0)}:1", $"{Pos(format, 1)}:0");
+        result.Value.rows.Select(r => GetProperty(r.Bytes, "value").GetString())
+            .Should().Equal("dev", "ops", "dev");
+        result.Value.schema.Columns.Select(c => c.Name).Should().Equal("value");
     }
 
     [Theory]
@@ -52,12 +122,22 @@ public sealed class FullAggregationScannerTests
     public void Scan_PrimitiveLeaf_ReturnsOneRowPerRecordWithKeyNamedColumn(DataFormat format)
     {
         // Arrange
-        _ = format; // Use parameter to suppress xUnit1026
+        var path = CreateTempFile(
+            format,
+            """{"score":88}""",
+            """{"score":72}""");
 
         // Act
+        var result = FullAggregationScanner.Scan(path, format, ["score"]);
 
         // Assert
-        Assert.Fail("Skeleton test - replace with real assertions.");
+        result.IsSuccess.Should().BeTrue();
+        result.Value.rows.Should().HaveCount(2);
+        result.Value.rows[0].HashValue.Should().Be(Pos(format, 0));
+        result.Value.rows[1].HashValue.Should().Be(Pos(format, 1));
+        GetProperty(result.Value.rows[0].Bytes, "score").GetInt32().Should().Be(88);
+        GetProperty(result.Value.rows[1].Bytes, "score").GetInt32().Should().Be(72);
+        result.Value.schema.Columns.Select(c => c.Name).Should().Equal("score");
     }
 
     [Theory]
@@ -66,12 +146,19 @@ public sealed class FullAggregationScannerTests
     public void Scan_IndexSegmentInPath_ProducesSameOutputAsParentArray(DataFormat format)
     {
         // Arrange
-        _ = format; // Use parameter to suppress xUnit1026
+        var path = CreateTempFile(format, """{"orders":[{"id":"A1"},{"id":"A2"}]}""");
 
         // Act
+        var resultWithoutIndex = FullAggregationScanner.Scan(path, format, ["orders"]);
+        var resultWithIndex = FullAggregationScanner.Scan(path, format, ["orders", "[0]"]);
 
         // Assert
-        Assert.Fail("Skeleton test - replace with real assertions.");
+        resultWithoutIndex.IsSuccess.Should().BeTrue();
+        resultWithIndex.IsSuccess.Should().BeTrue();
+        resultWithoutIndex.Value.rows.Select(r => r.HashValue)
+            .Should().Equal(resultWithIndex.Value.rows.Select(r => r.HashValue));
+        resultWithoutIndex.Value.rows.Select(r => GetProperty(r.Bytes, "id").GetString())
+            .Should().Equal(resultWithIndex.Value.rows.Select(r => GetProperty(r.Bytes, "id").GetString()));
     }
 
     [Theory]
@@ -80,12 +167,20 @@ public sealed class FullAggregationScannerTests
     public void Scan_TwoIndexSegmentsInPath_HashHasTwoColonSeparators(DataFormat format)
     {
         // Arrange
-        _ = format; // Use parameter to suppress xUnit1026
+        var path = CreateTempFile(
+            format,
+            """{"orders":[{"tags":["urgent","gift"]},{"tags":["normal"]}]}""");
 
         // Act
+        var result = FullAggregationScanner.Scan(path, format, ["orders", "[0]", "tags"]);
 
         // Assert
-        Assert.Fail("Skeleton test - replace with real assertions.");
+        result.IsSuccess.Should().BeTrue();
+        result.Value.rows.Should().HaveCount(3);
+        result.Value.rows.Select(r => r.HashValue).Should().Equal(
+            $"{Pos(format, 0)}:0:0", $"{Pos(format, 0)}:0:1", $"{Pos(format, 0)}:1:0");
+        result.Value.rows.Select(r => GetProperty(r.Bytes, "value").GetString())
+            .Should().Equal("urgent", "gift", "normal");
     }
 
     [Theory]
@@ -94,12 +189,19 @@ public sealed class FullAggregationScannerTests
     public void Scan_KeyMissingInSomeRecords_SkipsThoseRecordsSilently(DataFormat format)
     {
         // Arrange
-        _ = format; // Use parameter to suppress xUnit1026
+        var path = CreateTempFile(
+            format,
+            """{"user":{"name":"Alice"}}""",
+            """{"other":"x"}""");
 
         // Act
+        var result = FullAggregationScanner.Scan(path, format, ["user"]);
 
         // Assert
-        Assert.Fail("Skeleton test - replace with real assertions.");
+        result.IsSuccess.Should().BeTrue();
+        result.Value.rows.Should().HaveCount(1);
+        result.Value.rows[0].HashValue.Should().Be(Pos(format, 0));
+        GetProperty(result.Value.rows[0].Bytes, "name").GetString().Should().Be("Alice");
     }
 
     [Theory]
@@ -108,12 +210,19 @@ public sealed class FullAggregationScannerTests
     public void Scan_KeySegmentFollowedByNonObjectToken_SkipsRecordSilently(DataFormat format)
     {
         // Arrange
-        _ = format; // Use parameter to suppress xUnit1026
+        var path = CreateTempFile(
+            format,
+            """{"user":"just a string"}""",
+            """{"user":{"name":"Bob"}}""");
 
         // Act
+        var result = FullAggregationScanner.Scan(path, format, ["user", "name"]);
 
         // Assert
-        Assert.Fail("Skeleton test - replace with real assertions.");
+        result.IsSuccess.Should().BeTrue();
+        result.Value.rows.Should().HaveCount(1);
+        result.Value.rows[0].HashValue.Should().Be(Pos(format, 1));
+        GetProperty(result.Value.rows[0].Bytes, "name").GetString().Should().Be("Bob");
     }
 
     [Theory]
@@ -122,12 +231,21 @@ public sealed class FullAggregationScannerTests
     public void Scan_IndexSegmentFollowedByNonArrayToken_SkipsRecordSilently(DataFormat format)
     {
         // Arrange
-        _ = format; // Use parameter to suppress xUnit1026
+        var path = CreateTempFile(
+            format,
+            """{"tags":"not an array"}""",
+            """{"tags":["x","y"]}""");
 
         // Act
+        var result = FullAggregationScanner.Scan(path, format, ["tags", "[0]"]);
 
         // Assert
-        Assert.Fail("Skeleton test - replace with real assertions.");
+        result.IsSuccess.Should().BeTrue();
+        result.Value.rows.Should().HaveCount(2);
+        result.Value.rows.Select(r => r.HashValue).Should().Equal(
+            $"{Pos(format, 1)}:0", $"{Pos(format, 1)}:1");
+        result.Value.rows.Select(r => GetProperty(r.Bytes, "value").GetString())
+            .Should().Equal("x", "y");
     }
 
     [Theory]
@@ -136,23 +254,28 @@ public sealed class FullAggregationScannerTests
     public void Scan_NoRecordsMatch_ReturnsFailureWithNoMatchingRecordsMessage(DataFormat format)
     {
         // Arrange
-        _ = format; // Use parameter to suppress xUnit1026
+        var path = CreateTempFile(format, """{"user":{"name":"Alice"}}""");
 
         // Act
+        var result = FullAggregationScanner.Scan(path, format, ["missing"]);
 
         // Assert
-        Assert.Fail("Skeleton test - replace with real assertions.");
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Be("No matching records found.");
     }
 
     [Fact]
     public void Scan_JsonObjectFormat_ReturnsFailure()
     {
         // Arrange
+        var path = Path.Combine(Path.GetTempPath(), "does-not-need-to-exist.json");
 
         // Act
+        var result = FullAggregationScanner.Scan(path, DataFormat.JsonObject, ["user"]);
 
         // Assert
-        Assert.Fail("Skeleton test - replace with real assertions.");
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Be("JSON Object format does not support full aggregation.");
     }
 
     [Theory]
@@ -161,12 +284,17 @@ public sealed class FullAggregationScannerTests
     public void Scan_AllMatchedLeafObjectsEmpty_ReturnsFailureWithNoKeysMessage(DataFormat format)
     {
         // Arrange
-        _ = format; // Use parameter to suppress xUnit1026
+        var path = CreateTempFile(
+            format,
+            """{"user":{}}""",
+            """{"user":{}}""");
 
         // Act
+        var result = FullAggregationScanner.Scan(path, format, ["user"]);
 
         // Assert
-        Assert.Fail("Skeleton test - replace with real assertions.");
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Be("All child objects have no keys");
     }
 
     [Theory]
@@ -175,26 +303,38 @@ public sealed class FullAggregationScannerTests
     public void Scan_VaryingKeysAcrossRecords_BuildsUnionSchemaWithNullableForMissingKeys(DataFormat format)
     {
         // Arrange
-        _ = format; // Use parameter to suppress xUnit1026
+        var path = CreateTempFile(
+            format,
+            """{"user":{"name":"Alice","age":30}}""",
+            """{"user":{"name":"Bob"}}""");
 
         // Act
+        var result = FullAggregationScanner.Scan(path, format, ["user"]);
 
         // Assert
-        Assert.Fail("Skeleton test - replace with real assertions.");
+        result.IsSuccess.Should().BeTrue();
+        result.Value.rows.Should().HaveCount(2);
+        result.Value.schema.GetColumn("name").Should().BeOfType<ColumnSchema>()
+            .Which.IsNullable.Should().BeFalse();
+        result.Value.schema.GetColumn("age").Should().BeOfType<ColumnSchema>()
+            .Which.IsNullable.Should().BeTrue();
     }
 
     [Theory]
     [InlineData(DataFormat.JsonLines)]
     [InlineData(DataFormat.JsonArray)]
-    public void Scan_CancellationRequestedMidScan_ThrowsOperationCanceledException(DataFormat format)
+    public void Scan_CancellationRequestedBeforeScanStarts_ThrowsOperationCanceledException(DataFormat format)
     {
         // Arrange
-        _ = format; // Use parameter to suppress xUnit1026
+        var path = CreateTempFile(format, """{"user":{"name":"Alice"}}""");
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
 
         // Act
+        var act = () => FullAggregationScanner.Scan(path, format, ["user"], cts.Token);
 
         // Assert
-        Assert.Fail("Skeleton test - replace with real assertions.");
+        act.Should().Throw<OperationCanceledException>();
     }
 
     [Theory]
@@ -203,12 +343,18 @@ public sealed class FullAggregationScannerTests
     public void Scan_NestedObjectOrArrayCellValue_RendersAsEllipsisPlaceholder(DataFormat format)
     {
         // Arrange
-        _ = format; // Use parameter to suppress xUnit1026
+        var path = CreateTempFile(
+            format,
+            """{"user":{"name":"Alice","address":{"city":"Tokyo"},"tags":["dev","ops"]}}""");
 
         // Act
+        var result = FullAggregationScanner.Scan(path, format, ["user"]);
 
         // Assert
-        Assert.Fail("Skeleton test - replace with real assertions.");
+        result.IsSuccess.Should().BeTrue();
+        result.Value.rows.Should().HaveCount(1);
+        JsonObjectCellExtractor.ExtractCell(result.Value.rows[0].Bytes.Span, "address"u8).Should().Be("{...}");
+        JsonObjectCellExtractor.ExtractCell(result.Value.rows[0].Bytes.Span, "tags"u8).Should().Be("[...]");
     }
 
     [Theory]
@@ -217,12 +363,15 @@ public sealed class FullAggregationScannerTests
     public void Scan_LeafValueIsNull_EmitsOneNullRow(DataFormat format)
     {
         // Arrange
-        _ = format; // Use parameter to suppress xUnit1026
+        var path = CreateTempFile(format, """{"score":null}""");
 
         // Act
+        var result = FullAggregationScanner.Scan(path, format, ["score"]);
 
         // Assert
-        Assert.Fail("Skeleton test - replace with real assertions.");
+        result.IsSuccess.Should().BeTrue();
+        result.Value.rows.Should().HaveCount(1);
+        JsonObjectCellExtractor.ExtractCell(result.Value.rows[0].Bytes.Span, "score"u8).Should().Be("<null>");
     }
 
     [Theory]
@@ -231,12 +380,19 @@ public sealed class FullAggregationScannerTests
     public void Scan_EmptyArrayAtLeafPosition_ContributesZeroRowsForThatRecord(DataFormat format)
     {
         // Arrange
-        _ = format; // Use parameter to suppress xUnit1026
+        var path = CreateTempFile(
+            format,
+            """{"tags":[]}""",
+            """{"tags":["x"]}""");
 
         // Act
+        var result = FullAggregationScanner.Scan(path, format, ["tags"]);
 
         // Assert
-        Assert.Fail("Skeleton test - replace with real assertions.");
+        result.IsSuccess.Should().BeTrue();
+        result.Value.rows.Should().HaveCount(1);
+        result.Value.rows[0].HashValue.Should().Be($"{Pos(format, 1)}:0");
+        GetProperty(result.Value.rows[0].Bytes, "value").GetString().Should().Be("x");
     }
 
     [Theory]
@@ -245,12 +401,17 @@ public sealed class FullAggregationScannerTests
     public void Scan_MixedArrayOfObjectAndPrimitiveElements_ProducesCorrespondingRowTypes(DataFormat format)
     {
         // Arrange
-        _ = format; // Use parameter to suppress xUnit1026
+        var path = CreateTempFile(format, """{"items":[{"id":"A1"},"loose-string"]}""");
 
         // Act
+        var result = FullAggregationScanner.Scan(path, format, ["items"]);
 
         // Assert
-        Assert.Fail("Skeleton test - replace with real assertions.");
+        result.IsSuccess.Should().BeTrue();
+        result.Value.rows.Should().HaveCount(2);
+        GetProperty(result.Value.rows[0].Bytes, "id").GetString().Should().Be("A1");
+        GetProperty(result.Value.rows[1].Bytes, "value").GetString().Should().Be("loose-string");
+        result.Value.schema.Columns.Select(c => c.Name).Should().Contain(["id", "value"]);
     }
 
     [Theory]
@@ -259,11 +420,75 @@ public sealed class FullAggregationScannerTests
     public void Scan_Utf8MultiBytePropertyName_RoundTripsAsColumnIdentifier(DataFormat format)
     {
         // Arrange
-        _ = format; // Use parameter to suppress xUnit1026
+        var path = CreateTempFile(format, """{"user":{"名前":"Alice"}}""");
 
         // Act
+        var result = FullAggregationScanner.Scan(path, format, ["user"]);
 
         // Assert
-        Assert.Fail("Skeleton test - replace with real assertions.");
+        result.IsSuccess.Should().BeTrue();
+        result.Value.schema.Columns.Select(c => c.Name).Should().Equal("名前");
+        JsonObjectCellExtractor.ExtractCell(result.Value.rows[0].Bytes.Span, Encoding.UTF8.GetBytes("名前"))
+            .Should().Be("Alice");
+    }
+
+    [Fact]
+    public void Scan_JsonLinesWithEmptyLineInMiddle_PreservesLineBasedRecordPosition()
+    {
+        // Arrange
+        var path = CreateTempFile(DataFormat.JsonLines, """{"score":1}""", "", """{"score":3}""");
+
+        // Act
+        var result = FullAggregationScanner.Scan(path, DataFormat.JsonLines, ["score"]);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.rows.Should().HaveCount(2);
+        result.Value.rows[0].HashValue.Should().Be("1");
+        result.Value.rows[1].HashValue.Should().Be("3");
+    }
+
+    [Theory]
+    [InlineData(DataFormat.JsonLines)]
+    [InlineData(DataFormat.JsonArray)]
+    public void Scan_EmptyKeyPath_TreatsEachRecordAsRowWithTopLevelKeysAsColumns(DataFormat format)
+    {
+        // Arrange
+        var path = CreateTempFile(
+            format,
+            """{"name":"Alice","age":30}""",
+            """{"name":"Bob","age":25}""");
+
+        // Act
+        var result = FullAggregationScanner.Scan(path, format, []);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.rows.Should().HaveCount(2);
+        result.Value.rows[0].HashValue.Should().Be(Pos(format, 0));
+        result.Value.rows[1].HashValue.Should().Be(Pos(format, 1));
+        result.Value.schema.Columns.Select(c => c.Name).Should().Equal("name", "age");
+        GetProperty(result.Value.rows[0].Bytes, "name").GetString().Should().Be("Alice");
+        GetProperty(result.Value.rows[1].Bytes, "name").GetString().Should().Be("Bob");
+    }
+
+    [Fact]
+    public void Scan_JsonLinesFileWithUtf8Bom_SkipsBomAndParsesFirstLine()
+    {
+        // Arrange
+        var path = Path.ChangeExtension(Path.GetTempFileName(), ".jsonl");
+        byte[] bom = [0xEF, 0xBB, 0xBF];
+        var content = Encoding.UTF8.GetBytes("""{"score":88}""");
+        File.WriteAllBytes(path, [.. bom, .. content]);
+        _tempFiles.Add(path);
+
+        // Act
+        var result = FullAggregationScanner.Scan(path, DataFormat.JsonLines, ["score"]);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.rows.Should().HaveCount(1);
+        result.Value.rows[0].HashValue.Should().Be("1");
+        GetProperty(result.Value.rows[0].Bytes, "score").GetInt32().Should().Be(88);
     }
 }

--- a/tests/DataMorph.Tests/Engine/IO/DrillDown/FullAggregationScannerTests.cs
+++ b/tests/DataMorph.Tests/Engine/IO/DrillDown/FullAggregationScannerTests.cs
@@ -1,0 +1,269 @@
+using DataMorph.Engine.Types;
+
+namespace DataMorph.Tests.Engine.IO.DrillDown;
+
+public sealed class FullAggregationScannerTests
+{
+    [Theory]
+    [InlineData(DataFormat.JsonLines)]
+    [InlineData(DataFormat.JsonArray)]
+    public void Scan_ObjectLeafInAllRecords_ReturnsOneRowPerRecord(DataFormat format)
+    {
+        // Arrange
+        _ = format; // Use parameter to suppress xUnit1026
+
+        // Act
+
+        // Assert
+        Assert.Fail("Skeleton test - replace with real assertions.");
+    }
+
+    [Theory]
+    [InlineData(DataFormat.JsonLines)]
+    [InlineData(DataFormat.JsonArray)]
+    public void Scan_ArrayOfObjectLeafInAllRecords_ReturnsOneRowPerElement(DataFormat format)
+    {
+        // Arrange
+        _ = format; // Use parameter to suppress xUnit1026
+
+        // Act
+
+        // Assert
+        Assert.Fail("Skeleton test - replace with real assertions.");
+    }
+
+    [Theory]
+    [InlineData(DataFormat.JsonLines)]
+    [InlineData(DataFormat.JsonArray)]
+    public void Scan_ArrayOfPrimitiveLeafInAllRecords_ReturnsRowsWithValueColumn(DataFormat format)
+    {
+        // Arrange
+        _ = format; // Use parameter to suppress xUnit1026
+
+        // Act
+
+        // Assert
+        Assert.Fail("Skeleton test - replace with real assertions.");
+    }
+
+    [Theory]
+    [InlineData(DataFormat.JsonLines)]
+    [InlineData(DataFormat.JsonArray)]
+    public void Scan_PrimitiveLeaf_ReturnsOneRowPerRecordWithKeyNamedColumn(DataFormat format)
+    {
+        // Arrange
+        _ = format; // Use parameter to suppress xUnit1026
+
+        // Act
+
+        // Assert
+        Assert.Fail("Skeleton test - replace with real assertions.");
+    }
+
+    [Theory]
+    [InlineData(DataFormat.JsonLines)]
+    [InlineData(DataFormat.JsonArray)]
+    public void Scan_IndexSegmentInPath_ProducesSameOutputAsParentArray(DataFormat format)
+    {
+        // Arrange
+        _ = format; // Use parameter to suppress xUnit1026
+
+        // Act
+
+        // Assert
+        Assert.Fail("Skeleton test - replace with real assertions.");
+    }
+
+    [Theory]
+    [InlineData(DataFormat.JsonLines)]
+    [InlineData(DataFormat.JsonArray)]
+    public void Scan_TwoIndexSegmentsInPath_HashHasTwoColonSeparators(DataFormat format)
+    {
+        // Arrange
+        _ = format; // Use parameter to suppress xUnit1026
+
+        // Act
+
+        // Assert
+        Assert.Fail("Skeleton test - replace with real assertions.");
+    }
+
+    [Theory]
+    [InlineData(DataFormat.JsonLines)]
+    [InlineData(DataFormat.JsonArray)]
+    public void Scan_KeyMissingInSomeRecords_SkipsThoseRecordsSilently(DataFormat format)
+    {
+        // Arrange
+        _ = format; // Use parameter to suppress xUnit1026
+
+        // Act
+
+        // Assert
+        Assert.Fail("Skeleton test - replace with real assertions.");
+    }
+
+    [Theory]
+    [InlineData(DataFormat.JsonLines)]
+    [InlineData(DataFormat.JsonArray)]
+    public void Scan_KeySegmentFollowedByNonObjectToken_SkipsRecordSilently(DataFormat format)
+    {
+        // Arrange
+        _ = format; // Use parameter to suppress xUnit1026
+
+        // Act
+
+        // Assert
+        Assert.Fail("Skeleton test - replace with real assertions.");
+    }
+
+    [Theory]
+    [InlineData(DataFormat.JsonLines)]
+    [InlineData(DataFormat.JsonArray)]
+    public void Scan_IndexSegmentFollowedByNonArrayToken_SkipsRecordSilently(DataFormat format)
+    {
+        // Arrange
+        _ = format; // Use parameter to suppress xUnit1026
+
+        // Act
+
+        // Assert
+        Assert.Fail("Skeleton test - replace with real assertions.");
+    }
+
+    [Theory]
+    [InlineData(DataFormat.JsonLines)]
+    [InlineData(DataFormat.JsonArray)]
+    public void Scan_NoRecordsMatch_ReturnsFailureWithNoMatchingRecordsMessage(DataFormat format)
+    {
+        // Arrange
+        _ = format; // Use parameter to suppress xUnit1026
+
+        // Act
+
+        // Assert
+        Assert.Fail("Skeleton test - replace with real assertions.");
+    }
+
+    [Fact]
+    public void Scan_JsonObjectFormat_ReturnsFailure()
+    {
+        // Arrange
+
+        // Act
+
+        // Assert
+        Assert.Fail("Skeleton test - replace with real assertions.");
+    }
+
+    [Theory]
+    [InlineData(DataFormat.JsonLines)]
+    [InlineData(DataFormat.JsonArray)]
+    public void Scan_AllMatchedLeafObjectsEmpty_ReturnsFailureWithNoKeysMessage(DataFormat format)
+    {
+        // Arrange
+        _ = format; // Use parameter to suppress xUnit1026
+
+        // Act
+
+        // Assert
+        Assert.Fail("Skeleton test - replace with real assertions.");
+    }
+
+    [Theory]
+    [InlineData(DataFormat.JsonLines)]
+    [InlineData(DataFormat.JsonArray)]
+    public void Scan_VaryingKeysAcrossRecords_BuildsUnionSchemaWithNullableForMissingKeys(DataFormat format)
+    {
+        // Arrange
+        _ = format; // Use parameter to suppress xUnit1026
+
+        // Act
+
+        // Assert
+        Assert.Fail("Skeleton test - replace with real assertions.");
+    }
+
+    [Theory]
+    [InlineData(DataFormat.JsonLines)]
+    [InlineData(DataFormat.JsonArray)]
+    public void Scan_CancellationRequestedMidScan_ThrowsOperationCanceledException(DataFormat format)
+    {
+        // Arrange
+        _ = format; // Use parameter to suppress xUnit1026
+
+        // Act
+
+        // Assert
+        Assert.Fail("Skeleton test - replace with real assertions.");
+    }
+
+    [Theory]
+    [InlineData(DataFormat.JsonLines)]
+    [InlineData(DataFormat.JsonArray)]
+    public void Scan_NestedObjectOrArrayCellValue_RendersAsEllipsisPlaceholder(DataFormat format)
+    {
+        // Arrange
+        _ = format; // Use parameter to suppress xUnit1026
+
+        // Act
+
+        // Assert
+        Assert.Fail("Skeleton test - replace with real assertions.");
+    }
+
+    [Theory]
+    [InlineData(DataFormat.JsonLines)]
+    [InlineData(DataFormat.JsonArray)]
+    public void Scan_LeafValueIsNull_EmitsOneNullRow(DataFormat format)
+    {
+        // Arrange
+        _ = format; // Use parameter to suppress xUnit1026
+
+        // Act
+
+        // Assert
+        Assert.Fail("Skeleton test - replace with real assertions.");
+    }
+
+    [Theory]
+    [InlineData(DataFormat.JsonLines)]
+    [InlineData(DataFormat.JsonArray)]
+    public void Scan_EmptyArrayAtLeafPosition_ContributesZeroRowsForThatRecord(DataFormat format)
+    {
+        // Arrange
+        _ = format; // Use parameter to suppress xUnit1026
+
+        // Act
+
+        // Assert
+        Assert.Fail("Skeleton test - replace with real assertions.");
+    }
+
+    [Theory]
+    [InlineData(DataFormat.JsonLines)]
+    [InlineData(DataFormat.JsonArray)]
+    public void Scan_MixedArrayOfObjectAndPrimitiveElements_ProducesCorrespondingRowTypes(DataFormat format)
+    {
+        // Arrange
+        _ = format; // Use parameter to suppress xUnit1026
+
+        // Act
+
+        // Assert
+        Assert.Fail("Skeleton test - replace with real assertions.");
+    }
+
+    [Theory]
+    [InlineData(DataFormat.JsonLines)]
+    [InlineData(DataFormat.JsonArray)]
+    public void Scan_Utf8MultiBytePropertyName_RoundTripsAsColumnIdentifier(DataFormat format)
+    {
+        // Arrange
+        _ = format; // Use parameter to suppress xUnit1026
+
+        // Act
+
+        // Assert
+        Assert.Fail("Skeleton test - replace with real assertions.");
+    }
+}

--- a/tests/DataMorph.Tests/Engine/IO/DrillDown/FullAggregationScannerTests.cs
+++ b/tests/DataMorph.Tests/Engine/IO/DrillDown/FullAggregationScannerTests.cs
@@ -45,6 +45,17 @@ public sealed class FullAggregationScannerTests : IDisposable
         return doc.RootElement.GetProperty(propertyName).Clone();
     }
 
+    /// <summary>
+    /// Builds a KeyPath from conventional segment labels for test scenarios: a segment matching the
+    /// "[n]" index-label form is tagged as Index, every other segment as Key. This is test shorthand
+    /// only — production BuildKeyPath tags segments by parent node type, never by label text, so a
+    /// literal "[0]" object key is correctly tagged as Key there (see the regression test below).
+    /// </summary>
+    private static IReadOnlyList<KeyPathSegment> KeyPath(params string[] segments)
+        => [.. segments.Select(static s => new KeyPathSegment(
+            s,
+            s.StartsWith('[') ? KeyPathSegmentKind.Index : KeyPathSegmentKind.Key))];
+
     [Theory]
     [InlineData(DataFormat.JsonLines)]
     [InlineData(DataFormat.JsonArray)]
@@ -57,7 +68,7 @@ public sealed class FullAggregationScannerTests : IDisposable
             """{"user":{"name":"Bob","age":25}}""");
 
         // Act
-        var result = FullAggregationScanner.Scan(path, format, ["user"]);
+        var result = FullAggregationScanner.Scan(path, format, KeyPath("user"));
 
         // Assert
         result.IsSuccess.Should().BeTrue();
@@ -81,7 +92,7 @@ public sealed class FullAggregationScannerTests : IDisposable
             """{"orders":[{"id":"B1","qty":1}]}""");
 
         // Act
-        var result = FullAggregationScanner.Scan(path, format, ["orders"]);
+        var result = FullAggregationScanner.Scan(path, format, KeyPath("orders"));
 
         // Assert
         result.IsSuccess.Should().BeTrue();
@@ -104,7 +115,7 @@ public sealed class FullAggregationScannerTests : IDisposable
             """{"tags":["dev"]}""");
 
         // Act
-        var result = FullAggregationScanner.Scan(path, format, ["tags"]);
+        var result = FullAggregationScanner.Scan(path, format, KeyPath("tags"));
 
         // Assert
         result.IsSuccess.Should().BeTrue();
@@ -128,7 +139,7 @@ public sealed class FullAggregationScannerTests : IDisposable
             """{"score":72}""");
 
         // Act
-        var result = FullAggregationScanner.Scan(path, format, ["score"]);
+        var result = FullAggregationScanner.Scan(path, format, KeyPath("score"));
 
         // Assert
         result.IsSuccess.Should().BeTrue();
@@ -149,8 +160,8 @@ public sealed class FullAggregationScannerTests : IDisposable
         var path = CreateTempFile(format, """{"orders":[{"id":"A1"},{"id":"A2"}]}""");
 
         // Act
-        var resultWithoutIndex = FullAggregationScanner.Scan(path, format, ["orders"]);
-        var resultWithIndex = FullAggregationScanner.Scan(path, format, ["orders", "[0]"]);
+        var resultWithoutIndex = FullAggregationScanner.Scan(path, format, KeyPath("orders"));
+        var resultWithIndex = FullAggregationScanner.Scan(path, format, KeyPath("orders", "[0]"));
 
         // Assert
         resultWithoutIndex.IsSuccess.Should().BeTrue();
@@ -172,7 +183,7 @@ public sealed class FullAggregationScannerTests : IDisposable
             """{"orders":[{"tags":["urgent","gift"]},{"tags":["normal"]}]}""");
 
         // Act
-        var result = FullAggregationScanner.Scan(path, format, ["orders", "[0]", "tags"]);
+        var result = FullAggregationScanner.Scan(path, format, KeyPath("orders", "[0]", "tags"));
 
         // Assert
         result.IsSuccess.Should().BeTrue();
@@ -195,7 +206,7 @@ public sealed class FullAggregationScannerTests : IDisposable
             """{"other":"x"}""");
 
         // Act
-        var result = FullAggregationScanner.Scan(path, format, ["user"]);
+        var result = FullAggregationScanner.Scan(path, format, KeyPath("user"));
 
         // Assert
         result.IsSuccess.Should().BeTrue();
@@ -216,7 +227,7 @@ public sealed class FullAggregationScannerTests : IDisposable
             """{"user":{"name":"Bob"}}""");
 
         // Act
-        var result = FullAggregationScanner.Scan(path, format, ["user", "name"]);
+        var result = FullAggregationScanner.Scan(path, format, KeyPath("user", "name"));
 
         // Assert
         result.IsSuccess.Should().BeTrue();
@@ -237,7 +248,7 @@ public sealed class FullAggregationScannerTests : IDisposable
             """{"tags":["x","y"]}""");
 
         // Act
-        var result = FullAggregationScanner.Scan(path, format, ["tags", "[0]"]);
+        var result = FullAggregationScanner.Scan(path, format, KeyPath("tags", "[0]"));
 
         // Assert
         result.IsSuccess.Should().BeTrue();
@@ -257,7 +268,7 @@ public sealed class FullAggregationScannerTests : IDisposable
         var path = CreateTempFile(format, """{"user":{"name":"Alice"}}""");
 
         // Act
-        var result = FullAggregationScanner.Scan(path, format, ["missing"]);
+        var result = FullAggregationScanner.Scan(path, format, KeyPath("missing"));
 
         // Assert
         result.IsFailure.Should().BeTrue();
@@ -271,7 +282,7 @@ public sealed class FullAggregationScannerTests : IDisposable
         var path = Path.Combine(Path.GetTempPath(), "does-not-need-to-exist.json");
 
         // Act
-        var result = FullAggregationScanner.Scan(path, DataFormat.JsonObject, ["user"]);
+        var result = FullAggregationScanner.Scan(path, DataFormat.JsonObject, KeyPath("user"));
 
         // Assert
         result.IsFailure.Should().BeTrue();
@@ -290,7 +301,7 @@ public sealed class FullAggregationScannerTests : IDisposable
             """{"user":{}}""");
 
         // Act
-        var result = FullAggregationScanner.Scan(path, format, ["user"]);
+        var result = FullAggregationScanner.Scan(path, format, KeyPath("user"));
 
         // Assert
         result.IsFailure.Should().BeTrue();
@@ -309,7 +320,7 @@ public sealed class FullAggregationScannerTests : IDisposable
             """{"user":{"name":"Bob"}}""");
 
         // Act
-        var result = FullAggregationScanner.Scan(path, format, ["user"]);
+        var result = FullAggregationScanner.Scan(path, format, KeyPath("user"));
 
         // Assert
         result.IsSuccess.Should().BeTrue();
@@ -331,7 +342,7 @@ public sealed class FullAggregationScannerTests : IDisposable
         cts.Cancel();
 
         // Act
-        var act = () => FullAggregationScanner.Scan(path, format, ["user"], cts.Token);
+        var act = () => FullAggregationScanner.Scan(path, format, KeyPath("user"), cts.Token);
 
         // Assert
         act.Should().Throw<OperationCanceledException>();
@@ -348,7 +359,7 @@ public sealed class FullAggregationScannerTests : IDisposable
             """{"user":{"name":"Alice","address":{"city":"Tokyo"},"tags":["dev","ops"]}}""");
 
         // Act
-        var result = FullAggregationScanner.Scan(path, format, ["user"]);
+        var result = FullAggregationScanner.Scan(path, format, KeyPath("user"));
 
         // Assert
         result.IsSuccess.Should().BeTrue();
@@ -366,7 +377,7 @@ public sealed class FullAggregationScannerTests : IDisposable
         var path = CreateTempFile(format, """{"score":null}""");
 
         // Act
-        var result = FullAggregationScanner.Scan(path, format, ["score"]);
+        var result = FullAggregationScanner.Scan(path, format, KeyPath("score"));
 
         // Assert
         result.IsSuccess.Should().BeTrue();
@@ -386,7 +397,7 @@ public sealed class FullAggregationScannerTests : IDisposable
             """{"tags":["x"]}""");
 
         // Act
-        var result = FullAggregationScanner.Scan(path, format, ["tags"]);
+        var result = FullAggregationScanner.Scan(path, format, KeyPath("tags"));
 
         // Assert
         result.IsSuccess.Should().BeTrue();
@@ -404,7 +415,7 @@ public sealed class FullAggregationScannerTests : IDisposable
         var path = CreateTempFile(format, """{"items":[{"id":"A1"},"loose-string"]}""");
 
         // Act
-        var result = FullAggregationScanner.Scan(path, format, ["items"]);
+        var result = FullAggregationScanner.Scan(path, format, KeyPath("items"));
 
         // Assert
         result.IsSuccess.Should().BeTrue();
@@ -423,7 +434,7 @@ public sealed class FullAggregationScannerTests : IDisposable
         var path = CreateTempFile(format, """{"user":{"名前":"Alice"}}""");
 
         // Act
-        var result = FullAggregationScanner.Scan(path, format, ["user"]);
+        var result = FullAggregationScanner.Scan(path, format, KeyPath("user"));
 
         // Assert
         result.IsSuccess.Should().BeTrue();
@@ -439,7 +450,7 @@ public sealed class FullAggregationScannerTests : IDisposable
         var path = CreateTempFile(DataFormat.JsonLines, """{"score":1}""", "", """{"score":3}""");
 
         // Act
-        var result = FullAggregationScanner.Scan(path, DataFormat.JsonLines, ["score"]);
+        var result = FullAggregationScanner.Scan(path, DataFormat.JsonLines, KeyPath("score"));
 
         // Assert
         result.IsSuccess.Should().BeTrue();
@@ -483,7 +494,7 @@ public sealed class FullAggregationScannerTests : IDisposable
         _tempFiles.Add(path);
 
         // Act
-        var result = FullAggregationScanner.Scan(path, DataFormat.JsonLines, ["score"]);
+        var result = FullAggregationScanner.Scan(path, DataFormat.JsonLines, KeyPath("score"));
 
         // Assert
         result.IsSuccess.Should().BeTrue();

--- a/tests/DataMorph.Tests/Engine/IO/DrillDown/KeyPathTraverserTests.cs
+++ b/tests/DataMorph.Tests/Engine/IO/DrillDown/KeyPathTraverserTests.cs
@@ -1,0 +1,327 @@
+using System.Text;
+using System.Text.Json;
+using AwesomeAssertions;
+using DataMorph.Engine.IO.DrillDown;
+using DataMorph.Engine.Types;
+
+namespace DataMorph.Tests.Engine.IO.DrillDown;
+
+public sealed class KeyPathTraverserTests
+{
+    private static KeyPathSegment Key(string value) => new(value, KeyPathSegmentKind.Key);
+
+    private static KeyPathSegment Index(string value) => new(value, KeyPathSegmentKind.Index);
+
+    private static JsonRawBytes Bytes(string json) => Encoding.UTF8.GetBytes(json);
+
+    private static JsonElement GetProperty(JsonRawBytes bytes, string propertyName)
+    {
+        using var doc = JsonDocument.Parse(bytes);
+        return doc.RootElement.GetProperty(propertyName).Clone();
+    }
+
+    private static TraverseResult Traverse(
+        JsonRawBytes recordBytes, IReadOnlyList<KeyPathSegment> keyPath, string posHash = "1")
+    {
+        var colName = KeyPathTraverser.LastKeySegment(keyPath);
+        var colNameUtf8 = Encoding.UTF8.GetBytes(colName);
+        List<FocusedTableRow> rows = [];
+        List<string> keyOrder = [];
+        var keySet = new HashSet<string>(StringComparer.Ordinal);
+        var columnTypes = new Dictionary<string, ColumnType>(StringComparer.Ordinal);
+        var keyObservedCount = new Dictionary<string, int>(StringComparer.Ordinal);
+
+        KeyPathTraverser.ExtractRows(
+            recordBytes, keyPath, posHash, colName, colNameUtf8,
+            rows, keyOrder, keySet, columnTypes, keyObservedCount);
+
+        return new TraverseResult(rows, keyOrder, columnTypes, keyObservedCount);
+    }
+
+    private readonly record struct TraverseResult(
+        List<FocusedTableRow> Rows,
+        List<string> KeyOrder,
+        Dictionary<string, ColumnType> ColumnTypes,
+        Dictionary<string, int> KeyObservedCount);
+
+    [Fact]
+    public void ExtractRows_KeyThenIndexThenKeySegments_ReachesNestedLeaves()
+    {
+        // Arrange
+        var bytes = Bytes("""{"orders":[{"id":"A1"},{"id":"A2"}]}""");
+        IReadOnlyList<KeyPathSegment> keyPath = [Key("orders"), Index("[0]"), Key("id")];
+
+        // Act
+        var result = Traverse(bytes, keyPath);
+
+        // Assert
+        result.Rows.Should().HaveCount(2);
+        result.Rows.Select(r => r.HashValue).Should().Equal("1:0", "1:1");
+        result.Rows.Select(r => GetProperty(r.Bytes, "id").GetString()).Should().Equal("A1", "A2");
+        result.KeyOrder.Should().Equal("id");
+    }
+
+    [Fact]
+    public void ExtractRows_IndexSegmentLabelDoesNotMatchPosition_AggregatesAllElements()
+    {
+        // Arrange
+        var bytes = Bytes("""{"orders":[{"id":"A1"},{"id":"A2"}]}""");
+        IReadOnlyList<KeyPathSegment> keyPath = [Key("orders"), Index("[99]"), Key("id")];
+
+        // Act
+        var result = Traverse(bytes, keyPath);
+
+        // Assert
+        result.Rows.Should().HaveCount(2);
+        result.Rows.Select(r => r.HashValue).Should().Equal("1:0", "1:1");
+        result.Rows.Select(r => GetProperty(r.Bytes, "id").GetString()).Should().Equal("A1", "A2");
+    }
+
+    [Fact]
+    public void ExtractRows_KeySegmentAbsentInObject_SkipsRecordSilently()
+    {
+        // Arrange
+        var bytes = Bytes("""{"other":"x"}""");
+        IReadOnlyList<KeyPathSegment> keyPath = [Key("user")];
+
+        // Act
+        var result = Traverse(bytes, keyPath);
+
+        // Assert
+        result.Rows.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ExtractRows_KeySegmentWhenCurrentValueIsNotObject_SkipsRecordSilently()
+    {
+        // Arrange
+        var bytes = Bytes("""{"user":"just a string"}""");
+        IReadOnlyList<KeyPathSegment> keyPath = [Key("user"), Key("name")];
+
+        // Act
+        var result = Traverse(bytes, keyPath);
+
+        // Assert
+        result.Rows.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ExtractRows_IndexSegmentWhenCurrentValueIsNotArray_SkipsRecordSilently()
+    {
+        // Arrange
+        var bytes = Bytes("""{"tags":"not an array"}""");
+        IReadOnlyList<KeyPathSegment> keyPath = [Key("tags"), Index("[0]")];
+
+        // Act
+        var result = Traverse(bytes, keyPath);
+
+        // Assert
+        result.Rows.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ExtractRows_LeafIsObject_AddsRowAndScansSchema()
+    {
+        // Arrange
+        var bytes = Bytes("""{"user":{"name":"Alice","age":30}}""");
+        IReadOnlyList<KeyPathSegment> keyPath = [Key("user")];
+
+        // Act
+        var result = Traverse(bytes, keyPath);
+
+        // Assert
+        result.Rows.Should().HaveCount(1);
+        result.Rows[0].HashValue.Should().Be("1");
+        GetProperty(result.Rows[0].Bytes, "name").GetString().Should().Be("Alice");
+        GetProperty(result.Rows[0].Bytes, "age").GetInt32().Should().Be(30);
+        result.KeyOrder.Should().Equal("name", "age");
+    }
+
+    [Fact]
+    public void ExtractRows_LeafIsArray_CollectsRowPerArrayElement()
+    {
+        // Arrange
+        var bytes = Bytes("""{"orders":[{"id":"A1"},{"id":"A2"}]}""");
+        IReadOnlyList<KeyPathSegment> keyPath = [Key("orders")];
+
+        // Act
+        var result = Traverse(bytes, keyPath);
+
+        // Assert
+        result.Rows.Should().HaveCount(2);
+        result.Rows.Select(r => r.HashValue).Should().Equal("1:0", "1:1");
+        result.Rows.Select(r => GetProperty(r.Bytes, "id").GetString()).Should().Equal("A1", "A2");
+    }
+
+    [Fact]
+    public void ExtractRows_LeafIsEmptyArray_ProducesNoRows()
+    {
+        // Arrange
+        var bytes = Bytes("""{"tags":[]}""");
+        IReadOnlyList<KeyPathSegment> keyPath = [Key("tags")];
+
+        // Act
+        var result = Traverse(bytes, keyPath);
+
+        // Assert
+        result.Rows.Should().BeEmpty();
+        result.KeyOrder.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ExtractRows_LeafIsPrimitiveString_SynthesizesObjectUsingColName()
+    {
+        // Arrange
+        var bytes = Bytes("""{"grade":"A+"}""");
+        IReadOnlyList<KeyPathSegment> keyPath = [Key("grade")];
+
+        // Act
+        var result = Traverse(bytes, keyPath);
+
+        // Assert
+        result.Rows.Should().HaveCount(1);
+        result.Rows[0].HashValue.Should().Be("1");
+        GetProperty(result.Rows[0].Bytes, "grade").GetString().Should().Be("A+");
+        result.KeyOrder.Should().Equal("grade");
+    }
+
+    [Fact]
+    public void ExtractRows_LeafIsPrimitiveNull_SynthesizesObjectWithNullValue()
+    {
+        // Arrange
+        var bytes = Bytes("""{"score":null}""");
+        IReadOnlyList<KeyPathSegment> keyPath = [Key("score")];
+
+        // Act
+        var result = Traverse(bytes, keyPath);
+
+        // Assert
+        result.Rows.Should().HaveCount(1);
+        GetProperty(result.Rows[0].Bytes, "score").ValueKind.Should().Be(JsonValueKind.Null);
+        result.KeyOrder.Should().Equal("score");
+    }
+
+    [Fact]
+    public void ExtractRows_KeySegmentArrayLeafObjectElement_AddsRowAndScansElementSchema()
+    {
+        // Arrange
+        var bytes = Bytes("""{"items":[{"id":"A1","qty":2},{"id":"A2"}]}""");
+        IReadOnlyList<KeyPathSegment> keyPath = [Key("items")];
+
+        // Act
+        var result = Traverse(bytes, keyPath);
+
+        // Assert
+        result.Rows.Should().HaveCount(2);
+        result.KeyOrder.Should().Equal("id", "qty");
+        result.KeyObservedCount["id"].Should().Be(2);
+        result.KeyObservedCount["qty"].Should().Be(1);
+        result.Rows.Select(r => GetProperty(r.Bytes, "id").GetString()).Should().Equal("A1", "A2");
+    }
+
+    [Fact]
+    public void ExtractRows_KeySegmentArrayLeafPrimitiveElement_SynthesizesValueColumn()
+    {
+        // Arrange
+        var bytes = Bytes("""{"tags":["dev","ops"]}""");
+        IReadOnlyList<KeyPathSegment> keyPath = [Key("tags")];
+
+        // Act
+        var result = Traverse(bytes, keyPath);
+
+        // Assert
+        result.Rows.Should().HaveCount(2);
+        result.Rows.Select(r => r.HashValue).Should().Equal("1:0", "1:1");
+        result.Rows.Select(r => GetProperty(r.Bytes, "value").GetString()).Should().Equal("dev", "ops");
+        result.KeyOrder.Should().Equal("value");
+    }
+
+    [Fact]
+    public void ExtractRows_KeySegmentArrayLeafMixedElements_ProducesRowPerElementKind()
+    {
+        // Arrange
+        var bytes = Bytes("""{"items":[{"id":"A1"},"loose-string"]}""");
+        IReadOnlyList<KeyPathSegment> keyPath = [Key("items")];
+
+        // Act
+        var result = Traverse(bytes, keyPath);
+
+        // Assert
+        result.Rows.Should().HaveCount(2);
+        GetProperty(result.Rows[0].Bytes, "id").GetString().Should().Be("A1");
+        GetProperty(result.Rows[1].Bytes, "value").GetString().Should().Be("loose-string");
+        result.KeyOrder.Should().Contain(["id", "value"]);
+    }
+
+    [Fact]
+    public void ExtractRows_PathEndingInIndexSegment_ProducesSameRowsAsPathWithoutIt()
+    {
+        // Arrange
+        var bytes = Bytes("""{"tags":["dev","ops"]}""");
+        IReadOnlyList<KeyPathSegment> pathWithoutIndex = [Key("tags")];
+        IReadOnlyList<KeyPathSegment> pathWithIndex = [Key("tags"), Index("[0]")];
+
+        // Act
+        var resultWithoutIndex = Traverse(bytes, pathWithoutIndex);
+        var resultWithIndex = Traverse(bytes, pathWithIndex);
+
+        // Assert
+        resultWithoutIndex.Rows.Select(r => r.HashValue)
+            .Should().Equal(resultWithIndex.Rows.Select(r => r.HashValue));
+        resultWithoutIndex.Rows.Select(r => GetProperty(r.Bytes, "value").GetString())
+            .Should().Equal(resultWithIndex.Rows.Select(r => GetProperty(r.Bytes, "value").GetString()));
+        resultWithoutIndex.KeyOrder.Should().Equal(resultWithIndex.KeyOrder);
+    }
+
+    [Fact]
+    public void LastKeySegment_PathEndingInKeySegment_ReturnsThatSegmentValue()
+    {
+        // Arrange
+        IReadOnlyList<KeyPathSegment> keyPath = [Key("user"), Key("name")];
+
+        // Act
+        var result = KeyPathTraverser.LastKeySegment(keyPath);
+
+        // Assert
+        result.Should().Be("name");
+    }
+
+    [Fact]
+    public void LastKeySegment_PathEndingInIndexSegment_ReturnsPrecedingKeySegment()
+    {
+        // Arrange
+        IReadOnlyList<KeyPathSegment> keyPath = [Key("tags"), Index("[0]")];
+
+        // Act
+        var result = KeyPathTraverser.LastKeySegment(keyPath);
+
+        // Assert
+        result.Should().Be("tags");
+    }
+
+    [Fact]
+    public void LastKeySegment_PathOfOnlyIndexSegments_ReturnsValueFallback()
+    {
+        // Arrange
+        IReadOnlyList<KeyPathSegment> keyPath = [Index("[0]"), Index("[1]")];
+
+        // Act
+        var result = KeyPathTraverser.LastKeySegment(keyPath);
+
+        // Assert
+        result.Should().Be("value");
+    }
+
+    [Fact]
+    public void LastKeySegment_EmptyPath_ReturnsValueFallback()
+    {
+        // Arrange
+        IReadOnlyList<KeyPathSegment> keyPath = [];
+
+        // Act
+        var result = KeyPathTraverser.LastKeySegment(keyPath);
+
+        // Assert
+        result.Should().Be("value");
+    }
+}


### PR DESCRIPTION
## Summary
- Implement Full Aggregation DrillDown for JSON Lines and JSON Array formats, converting Tree view into Table view with schema discovery across the whole file
- Introduce `KeyPathSegment`/`KeyPathSegmentKind` to unambiguously distinguish object keys from array indices when traversing a drill-down path, fixing a bug where object keys literally starting with `[` (e.g. `"[0]"`) collided with the array-index marker
- Extract `SchemaScanner` from `DrillDownSchemaExtractor` and `FileChunkReader` from `FullAggregationScanner` to keep each file within size/complexity guidelines
- Add dedicated unit test coverage for `KeyPathTraverser`, `FileChunkReader`, `BuildKeyPath`, and `JsonTreeNodeHelper` parent/key wiring

## Test plan
- [x] `dotnet format --verify-no-changes` — no diff
- [x] `dotnet build` — 0 Warning / 0 Error
- [x] `dotnet test` — 1447/1447 passed

Closes #53