### PR TITLE
feat: implement breadcrumb navigation for current path display

### DIFF
--- a/docs/design_breadcrumb_navigation.md
+++ b/docs/design_breadcrumb_navigation.md
@@ -20,14 +20,13 @@ Displays the current location in the JSON hierarchy as a breadcrumb bar at the t
 | `CsvTable` | ❌ | No hierarchical structure |
 
 **Out of scope (deferred):**
-- Clicking a **FocusedTable** breadcrumb segment to jump back into Tree mode at that ancestor
-  level. This needs a "return to Tree and restore selection at an arbitrary ancestor" mechanism,
-  which `docs/design_drilldown_command_phase2.md` already deferred under "Back / Undo navigation
-  (Backspace to return to Tree)". Building that is a separate, non-trivial feature and should be
-  tracked as its own follow-up rather than bundled here.
-- Exhaustive mouse-support verification across terminal emulators. Click handling is implemented
-  on a best-effort basis using Terminal.Gui's standard mouse API; not every terminal/driver
-  combination will be tested.
+- Clicking a breadcrumb segment to navigate (jump the Tree selection to that ancestor, or jump a
+  **FocusedTable** breadcrumb back into Tree mode at that ancestor level). This is a TUI app
+  primarily driven by keyboard (vim-key tree navigation); the click use case is unclear and a
+  click affordance is easy to miss in a terminal. Omitted from this issue entirely — track as its
+  own follow-up if there's real demand for it. This also removes the need for
+  `KeyPathFormatter.Format` to report per-segment column ranges and for `BreadcrumbBar` to expose
+  a `SegmentActivated` event; `BreadcrumbBar` is display-only.
 
 ---
 
@@ -147,17 +146,15 @@ when converting Tree → Table"). See 3.5 for why the two DrillDown variants nee
 ### 3.5 Rendering: `BreadcrumbBar` + index-collapsing rule
 
 New `src/App/Views/BreadcrumbBar.cs`, a small `View` (single row, `Y=1` — see 3.6 for exact
-placement) that renders a formatted path string and exposes:
+placement) that renders a formatted path string. Display-only, no click handling (see Scope):
 
 ```csharp
 internal void SetPath(IReadOnlyList<KeyPathSegment> path, bool collapseIndices);
-internal event Action<int>? SegmentActivated; // clicked segment's 0-based index
 ```
 
 Formatting is delegated to a new static `src/App/KeyPathFormatter.cs`
 (`Format(IReadOnlyList<KeyPathSegment> path, bool collapseIndices)` → e.g. `"root → data →
-orders[*]"`), which also returns the column range of each rendered segment so `BreadcrumbBar` can
-map a mouse click's X position back to a segment index.
+orders[*]"`).
 
 **`collapseIndices` decision:** per `docs/design_drilldown_command_phase2.md` §1.3, discarding the
 specific array index and expanding every element (`orders` and `orders[0]` produce identical
@@ -224,33 +221,19 @@ Terminal.Gui `Adornments` (Padding/Border/Margin) were considered and rejected: 
 single view's own bounds, not a sibling relationship ("bar above container"), so a container +
 `Pos.Bottom` is the correct fit here.
 
-### 3.7 Parent-level navigation (Tree modes only, in scope)
-
-Clicking a breadcrumb segment (or a to-be-decided keyboard shortcut) while in a Tree mode moves
-the tree's selection to that ancestor node and scrolls it into view. The ancestor node is already
-materialized in memory (it's on the `ParentNode` chain of the currently selected node), so no
-re-scan is needed — this is a pure selection/scroll operation.
-
-**Open item for implementation:** the exact Terminal.Gui v2 API to select-and-scroll-to an
-already-known node (e.g. `TreeView.GoTo(object)`, or manually setting `SelectedObject` plus a
-scroll/`EnsureVisible` call) is not yet confirmed. To be verified during Step 1/2 implementation
-rather than guessed here.
-
 ---
 
 ## 4. Testing
 
 - `KeyPathBuilderTests.cs` (moved from `AppKeyHandlerTests.cs`, renamed type only).
 - `KeyPathFormatterTests.cs` (new): empty path → `"root"`; key-only path; path containing an
-  `Index` segment with `collapseIndices: true` vs `false`; segment-range output used for click
-  mapping.
+  `Index` segment with `collapseIndices: true` vs `false`.
 - `ViewManagerTests.cs`: extend to cover the Phase 1 vs Phase 2 `collapseIndices` distinction from
   3.4/3.5 directly — a `SingleDrillDownRequest` result with an `Index` segment in its `KeyPath`
   must render the literal index (`collapseIndices: false`), while a
   `FullAggregationDrillDownRequest` result with an `Index` segment must render `[*]`
   (`collapseIndices: true`). This is the regression test for Finding 1 of the design review.
-- `BreadcrumbBarTests.cs` (new): `SetPath` updates displayed text; a simulated click within a
-  segment's column range raises `SegmentActivated` with the correct index.
+- `BreadcrumbBarTests.cs` (new): `SetPath` updates displayed text.
 - `AppStateTests.cs`: extend for `CurrentKeyPath` default (`[]`) — likely a small addition to an
   existing test file rather than a new one.
 - Extend existing `JsonLinesTreeViewTests` / `JsonArrayTreeViewTests` / `JsonObjectTreeViewTests`

--- a/docs/design_breadcrumb_navigation.md
+++ b/docs/design_breadcrumb_navigation.md
@@ -115,9 +115,11 @@ must also accept `onSelectionChanged` and forward it to `base(...)` for the para
 so it needs no intermediate change.
 
 `ViewManager.SwitchToJsonLinesTree/JsonArrayTree/JsonObjectTree` pass a call to
-`UpdateBreadcrumb(path, collapseIndices: false)` (3.5) as `onPathChanged`, and invoke it once
-immediately after the view is built so the breadcrumb reflects the initial selection instead of
-staying blank until the first cursor move.
+`UpdateBreadcrumb(path, collapseIndices: false)` (3.5) as `onPathChanged`, and call
+`UpdateBreadcrumb([], collapseIndices: false)` once immediately after the view is built. A freshly
+built `TreeView` has no `SelectedObject` yet, so this always renders `"root"` — it exists only so
+the breadcrumb reads "root" from the first frame instead of showing whatever path was left over
+from the previously displayed mode.
 
 ### 3.4 Static path for FocusedTable
 
@@ -153,8 +155,8 @@ internal void SetPath(IReadOnlyList<KeyPathSegment> path, bool collapseIndices);
 ```
 
 Formatting is delegated to a new static `src/App/KeyPathFormatter.cs`
-(`Format(IReadOnlyList<KeyPathSegment> path, bool collapseIndices)` → e.g. `"root → data →
-orders[*]"`).
+(`Format(IReadOnlyList<KeyPathSegment> path, bool collapseIndices)` → e.g. `"data >
+orders[*]"`; an empty path renders as `"root"`).
 
 **`collapseIndices` decision:** per `docs/design_drilldown_command_phase2.md` §1.3, discarding the
 specific array index and expanding every element (`orders` and `orders[0]` produce identical
@@ -164,7 +166,7 @@ such thing: `ModeController.DrillDown` calls `DrillDownSchemaExtractor.ExtractFr
 against the one concrete node the user selected, with no index-discarding and no file-wide
 expansion. `ViewMode.FocusedTable` is a single mode shared by both, so `_state.CurrentMode ==
 ViewMode.FocusedTable` cannot distinguish them — deriving `collapseIndices` from `CurrentMode`
-alone would render a Phase 1 result such as `list[2].orders` as `list[*] → orders`, falsely
+alone would render a Phase 1 result such as `list[2].orders` as `list[*] > orders`, falsely
 implying the table aggregates every element of `list` when it is actually scoped to element 2
 only.
 

--- a/docs/design_breadcrumb_navigation.md
+++ b/docs/design_breadcrumb_navigation.md
@@ -1,0 +1,281 @@
+# Breadcrumb Navigation — Design Document
+
+## Terminology Note
+
+The source requirement refers to a "Morph Command" that converts Tree → Table. No such command
+exists in this codebase; the only Tree → Table conversion is the **DrillDown** command (`x` key,
+`SingleDrillDownRequest` / `FullAggregationDrillDownRequest`). This document treats every mention
+of "morph"/"Morph Command" in the requirement as DrillDown.
+
+## Scope
+
+Displays the current location in the JSON hierarchy as a breadcrumb bar at the top of the TUI
+(directly below the MenuBar), and keeps it updated as the user navigates.
+
+| Mode | In scope | Reason |
+|---|---|---|
+| `JsonLinesTree` / `JsonArrayTree` / `JsonObjectTree` | ✅ | Cursor position changes the path in real time |
+| `FocusedTable` (DrillDown result) | ✅ | The table is scoped to a KeyPath; that path is worth surfacing |
+| `JsonLinesTable` / `JsonArrayTable` (`t`-key toggle) | ❌ | Re-renders already-loaded rows with no scan and no scoped path (always root-equivalent); `JsonArrayTable` is currently a stub |
+| `CsvTable` | ❌ | No hierarchical structure |
+
+**Out of scope (deferred):**
+- Clicking a **FocusedTable** breadcrumb segment to jump back into Tree mode at that ancestor
+  level. This needs a "return to Tree and restore selection at an arbitrary ancestor" mechanism,
+  which `docs/design_drilldown_command_phase2.md` already deferred under "Back / Undo navigation
+  (Backspace to return to Tree)". Building that is a separate, non-trivial feature and should be
+  tracked as its own follow-up rather than bundled here.
+- Exhaustive mouse-support verification across terminal emulators. Click handling is implemented
+  on a best-effort basis using Terminal.Gui's standard mouse API; not every terminal/driver
+  combination will be tested.
+
+---
+
+## 1. Existing Infrastructure (Reused)
+
+- `KeyPathSegment` / `KeyPathSegmentKind` — `src/Engine/IO/DrillDown/KeyPathSegment.cs`. Tags a
+  segment as `Key` (object property) or `Index` (array element), avoiding ambiguity with literal
+  keys such as `"[0]"`.
+- `AppKeyHandler.BuildKeyPath(ITreeNode)` — `src/App/AppKeyHandler.cs:314`. Walks the
+  `ParentNode` chain of a selected tree node up to the root, producing an ordered
+  `IReadOnlyList<KeyPathSegment>`. Currently only called when DrillDown is triggered
+  (`HandleFullAggregationDrillDown`).
+- `FullAggregationDrillDownRequest.KeyPath` — already carries this list into the scanner.
+
+## 2. Gaps
+
+- `AppState` (`src/App/AppState.cs`) has no field for "the path currently on screen."
+- `DrillDownState` (`src/App/DrillDownState.cs`) holds only `Rows`/`Schema` — no KeyPath.
+- No tree view wires `TreeView.SelectionChanged`; cursor movement (both vim keys via
+  `AdjustSelection` and native arrow keys) is not observed anywhere today.
+- `MainWindow` only ever adds a `MenuBar` (row 0) and `StatusBar` (bottom); every
+  `ViewManager.SwitchTo*` method hardcodes its content view to `Y=1, Height=Dim.Fill()-1`
+  ("start below MenuBar, leave the bottom row for StatusBar"). There is no row reserved for a
+  breadcrumb bar and no shared container to place one without touching 6 call sites individually.
+
+## 3. Design
+
+### 3.1 State: `AppState.CurrentKeyPath`
+
+Add one field, parallel to the existing `CurrentFilePath`/`CurrentMode`:
+
+```csharp
+public IReadOnlyList<KeyPathSegment> CurrentKeyPath { get; set; } = [];
+```
+
+Only meaningful while `CurrentMode` is a Tree mode or `FocusedTable`. Updated in two places:
+
+- **Tree modes**: on every `SelectionChanged` (see 3.3).
+- **FocusedTable**: once, at the moment DrillDown is triggered (see 3.4).
+
+### 3.2 Extracting `KeyPathBuilder`
+
+`AppKeyHandler.BuildKeyPath` moves to a new static class `src/App/KeyPathBuilder.cs`
+(`KeyPathBuilder.Build(ITreeNode node)`), with `AppKeyHandler` updated to call it.
+
+Reason: the new call site for KeyPath-building is not `ViewManager` but the tree view `Create`
+factories (`JsonLinesTreeView.Create`, `JsonArrayTreeView.Create`, `JsonObjectTreeView.Create`,
+all in `App.Views`) — see 3.3, where the `onSelectionChanged` lambda calls
+`KeyPathBuilder.Build(node)` directly. A static call from `App.Views` into `AppKeyHandler`
+(`App`) is not itself a new layering violation — `MorphTreeView.cs` and `MorphTableView.cs`
+already call `AppKeyHandler.IsGlobalShortcut` the same way. The reason to extract is narrower:
+`AppKeyHandler` is a keyboard-shortcut handler, and `BuildKeyPath`/`KeyPathBuilder` is unrelated
+to that responsibility — carrying it along as a static utility on `AppKeyHandler` was already a
+minor responsibility leak before this feature, and this is a natural point to split it out rather
+than add a second unrelated caller to it. Existing tests in `AppKeyHandlerTests.cs`
+(`BuildKeyPath_WithRootSelection_ReturnsEmptyKeyPath`,
+`BuildKeyPath_WithNestedObjectArraySelection_ReturnsOrderedSegmentsWithIndex`) move to a new
+`KeyPathBuilderTests.cs` unchanged except for the type name.
+
+### 3.3 Live updates in Tree modes
+
+`MorphTreeView` (`src/App/Views/MorphTreeView.cs`) gains a constructor parameter
+`Action<ITreeNode?> onSelectionChanged`, wired once in the constructor:
+
+```csharp
+SelectionChanged += (_, _) => onSelectionChanged(SelectedObject is ITreeNode node ? node : null);
+```
+
+Both vim-key navigation (`AdjustSelection`, called directly from `MorphTreeView.OnKeyDown`) and
+native arrow-key navigation update `SelectedObject` internally, and both reliably raise
+`SelectionChanged` — so a single subscription covers every navigation path, with no need for a
+separate hook on `AdjustSelection`.
+
+`JsonLinesTreeView.Create`, `JsonArrayTreeView.Create`, `JsonObjectTreeView.Create` each gain an
+`onPathChanged` parameter (`Action<IReadOnlyList<KeyPathSegment>>`) and thread through:
+
+```csharp
+onSelectionChanged: node => onPathChanged(node is null ? [] : KeyPathBuilder.Build(node))
+```
+
+`JsonLinesTreeView` and `JsonArrayTreeView` do not extend `MorphTreeView` directly — both extend
+`RangeTreeViewBase` (`src/App/Views/RangeTreeViewBase.cs`), which itself extends `MorphTreeView`
+and currently forwards only `onTableModeToggle` to `base(...)`. `RangeTreeViewBase`'s constructor
+must also accept `onSelectionChanged` and forward it to `base(...)` for the parameter to reach
+`MorphTreeView` from these two view types. `JsonObjectTreeView` extends `MorphTreeView` directly,
+so it needs no intermediate change.
+
+`ViewManager.SwitchToJsonLinesTree/JsonArrayTree/JsonObjectTree` pass a call to
+`UpdateBreadcrumb(path, collapseIndices: false)` (3.5) as `onPathChanged`, and invoke it once
+immediately after the view is built so the breadcrumb reflects the initial selection instead of
+staying blank until the first cursor move.
+
+### 3.4 Static path for FocusedTable
+
+`SingleDrillDownRequest` gains a `KeyPath` field for symmetry with
+`FullAggregationDrillDownRequest`, computed the same way at trigger time:
+
+```csharp
+// AppKeyHandler.HandleSingleDrillDown
+var request = new SingleDrillDownRequest(
+    Format: format,
+    NodeBytes: arrayNode.RawJson,
+    KeyPath: KeyPathBuilder.Build(selectedNode));
+```
+
+`ViewManager.DrillDown` (Phase 1, `SingleDrillDownRequest`) calls
+`UpdateBreadcrumb(request.KeyPath, collapseIndices: false)`, and
+`FullAggregationDrillDownAsync` (Phase 2, `FullAggregationDrillDownRequest`) calls
+`UpdateBreadcrumb(request.KeyPath, collapseIndices: true)` — `request` (the method's own
+parameter) is captured by the `_uiThreadInvoke` callback, so no new field is needed on
+`DrillDownState` to carry `KeyPath` through — both right before
+`SwitchToFocusedTable` — so the path captured at the exact node the user triggered DrillDown from
+becomes the FocusedTable's breadcrumb and stays fixed for the session (matching "Store morph path
+when converting Tree → Table"). See 3.5 for why the two DrillDown variants need different
+`collapseIndices` values despite sharing one `ViewMode.FocusedTable`.
+
+### 3.5 Rendering: `BreadcrumbBar` + index-collapsing rule
+
+New `src/App/Views/BreadcrumbBar.cs`, a small `View` (single row, `Y=1` — see 3.6 for exact
+placement) that renders a formatted path string and exposes:
+
+```csharp
+internal void SetPath(IReadOnlyList<KeyPathSegment> path, bool collapseIndices);
+internal event Action<int>? SegmentActivated; // clicked segment's 0-based index
+```
+
+Formatting is delegated to a new static `src/App/KeyPathFormatter.cs`
+(`Format(IReadOnlyList<KeyPathSegment> path, bool collapseIndices)` → e.g. `"root → data →
+orders[*]"`), which also returns the column range of each rendered segment so `BreadcrumbBar` can
+map a mouse click's X position back to a segment index.
+
+**`collapseIndices` decision:** per `docs/design_drilldown_command_phase2.md` §1.3, discarding the
+specific array index and expanding every element (`orders` and `orders[0]` produce identical
+output) is a rule that applies **only to Phase 2 — `FullAggregationDrillDownRequest`** (JSON
+Lines / JSON Array, full-file scan). **Phase 1 — `SingleDrillDownRequest`** (JSON Object) does no
+such thing: `ModeController.DrillDown` calls `DrillDownSchemaExtractor.ExtractFromNode` once,
+against the one concrete node the user selected, with no index-discarding and no file-wide
+expansion. `ViewMode.FocusedTable` is a single mode shared by both, so `_state.CurrentMode ==
+ViewMode.FocusedTable` cannot distinguish them — deriving `collapseIndices` from `CurrentMode`
+alone would render a Phase 1 result such as `list[2].orders` as `list[*] → orders`, falsely
+implying the table aggregates every element of `list` when it is actually scoped to element 2
+only.
+
+So `collapseIndices` must instead be decided **at the point each request is built**, based on
+request type, not read back from `CurrentMode` later:
+
+- **Tree modes** (live navigation, 3.3): `collapseIndices = false` — the concrete index (e.g.
+  `[2]`) is shown; the cursor is genuinely on one specific element.
+- **`SingleDrillDownRequest` → FocusedTable** (3.4, Phase 1): `collapseIndices = false` — the
+  path is scoped to the one selected node, same as tree mode.
+- **`FullAggregationDrillDownRequest` → FocusedTable** (3.4, Phase 2): `collapseIndices = true` —
+  every `Index` segment renders as `[*]`, reflecting the actual expand-all scan semantics.
+
+`ViewManager.UpdateBreadcrumb` therefore takes `collapseIndices` as an explicit parameter rather
+than inferring it:
+
+```csharp
+internal void UpdateBreadcrumb(IReadOnlyList<KeyPathSegment> path, bool collapseIndices)
+{
+    _state.CurrentKeyPath = path;
+    _breadcrumbBar.SetPath(path, collapseIndices);
+}
+```
+
+Call sites: tree `onPathChanged` callbacks and `ViewManager.DrillDown` (Phase 1) pass `false`;
+`FullAggregationDrillDownAsync` (Phase 2) passes `true`. No new field on `AppState` or
+`DrillDownState` is needed to track "which DrillDown variant produced this FocusedTable" — the
+call site already knows, at the point it has the concrete request in hand. For the two
+out-of-scope table modes and `FileSelection`, the bar is cleared (`SetPath([], collapseIndices:
+false)` renders as just `"root"`, or the bar is blanked entirely — left as an implementation
+choice, not a behavior contract).
+
+### 3.6 Layout: shared `ContentContainer`
+
+Rather than editing the `Y=1, Height=Dim.Fill()-1` boilerplate at all 6 `SwitchTo*` call sites,
+`ViewManager` introduces one internal container view:
+
+```
+MainWindow (Window)
+├─ MenuBar                (Y = 0)
+├─ BreadcrumbBar           (Y = 1, Height = 1)
+├─ ContentContainer (View) (Y = Pos.Bottom(breadcrumbBar), Height = Dim.Fill() - 1)
+│   └─ <current content view>  (X=0, Y=0, Width=Dim.Fill(), Height=Dim.Fill())
+└─ StatusBar               (Y = Pos.AnchorEnd(1))
+```
+
+`BreadcrumbBar` and `ContentContainer` are created once in `ViewManager`'s constructor and added
+to `_container` (the `Window`) there. `SwapView` adds/removes the active content view into
+`ContentContainer` instead of `_container`, and every `SwitchTo*` method drops its `X/Y/Width/
+Height` assignment (now fixed and identical for all of them, set once on `ContentContainer`).
+This is a net simplification, not just a breadcrumb accommodation.
+
+Terminal.Gui `Adornments` (Padding/Border/Margin) were considered and rejected: they decorate a
+single view's own bounds, not a sibling relationship ("bar above container"), so a container +
+`Pos.Bottom` is the correct fit here.
+
+### 3.7 Parent-level navigation (Tree modes only, in scope)
+
+Clicking a breadcrumb segment (or a to-be-decided keyboard shortcut) while in a Tree mode moves
+the tree's selection to that ancestor node and scrolls it into view. The ancestor node is already
+materialized in memory (it's on the `ParentNode` chain of the currently selected node), so no
+re-scan is needed — this is a pure selection/scroll operation.
+
+**Open item for implementation:** the exact Terminal.Gui v2 API to select-and-scroll-to an
+already-known node (e.g. `TreeView.GoTo(object)`, or manually setting `SelectedObject` plus a
+scroll/`EnsureVisible` call) is not yet confirmed. To be verified during Step 1/2 implementation
+rather than guessed here.
+
+---
+
+## 4. Testing
+
+- `KeyPathBuilderTests.cs` (moved from `AppKeyHandlerTests.cs`, renamed type only).
+- `KeyPathFormatterTests.cs` (new): empty path → `"root"`; key-only path; path containing an
+  `Index` segment with `collapseIndices: true` vs `false`; segment-range output used for click
+  mapping.
+- `ViewManagerTests.cs`: extend to cover the Phase 1 vs Phase 2 `collapseIndices` distinction from
+  3.4/3.5 directly — a `SingleDrillDownRequest` result with an `Index` segment in its `KeyPath`
+  must render the literal index (`collapseIndices: false`), while a
+  `FullAggregationDrillDownRequest` result with an `Index` segment must render `[*]`
+  (`collapseIndices: true`). This is the regression test for Finding 1 of the design review.
+- `BreadcrumbBarTests.cs` (new): `SetPath` updates displayed text; a simulated click within a
+  segment's column range raises `SegmentActivated` with the correct index.
+- `AppStateTests.cs`: extend for `CurrentKeyPath` default (`[]`) — likely a small addition to an
+  existing test file rather than a new one.
+- Extend existing `JsonLinesTreeViewTests` / `JsonArrayTreeViewTests` / `JsonObjectTreeViewTests`
+  (and their `.Create` counterparts) to assert `onPathChanged` fires with the expected KeyPath on
+  simulated selection change.
+
+## 5. Files Touched
+
+**New:**
+- `src/App/KeyPathBuilder.cs`
+- `src/App/KeyPathFormatter.cs`
+- `src/App/Views/BreadcrumbBar.cs`
+- `tests/DataMorph.Tests/App/KeyPathBuilderTests.cs`
+- `tests/DataMorph.Tests/App/KeyPathFormatterTests.cs`
+- `tests/DataMorph.Tests/App/Views/BreadcrumbBarTests.cs`
+
+**Modified:**
+- `src/App/AppState.cs` — add `CurrentKeyPath`
+- `src/App/AppKeyHandler.cs` — remove `BuildKeyPath`, call `KeyPathBuilder.Build` instead
+- `src/App/DrillDownRequest.cs` — add `KeyPath` to `SingleDrillDownRequest`
+- `src/App/ViewManager.cs` — `ContentContainer` + `BreadcrumbBar` wiring, `UpdateBreadcrumb`,
+  simplified `SwitchTo*` layout code
+- `src/App/Views/MorphTreeView.cs` — `onSelectionChanged` constructor parameter
+- `src/App/Views/RangeTreeViewBase.cs` — forward `onSelectionChanged` to `base(...)` so it
+  reaches `MorphTreeView` from `JsonLinesTreeView`/`JsonArrayTreeView`
+- `src/App/Views/JsonLinesTreeView.cs`, `JsonArrayTreeView.cs`, `JsonObjectTreeView.cs` —
+  `onPathChanged` parameter threaded through `Create`
+- `tests/DataMorph.Tests/App/AppKeyHandlerTests.cs` — remove moved `BuildKeyPath` tests

--- a/docs/design_breadcrumb_navigation.md
+++ b/docs/design_breadcrumb_navigation.md
@@ -225,6 +225,73 @@ single view's own bounds, not a sibling relationship ("bar above container"), so
 
 ---
 
+## Architectural Decision Records (ADR)
+
+### ADR 1: No `"root"` Prefix on Non-Empty Breadcrumb Paths
+
+**Status:** Accepted
+
+**Context:** The source requirement's example (`root → data → orders[*]`) always prefixes
+`"root"`. An alternative considered during implementation was to always prefix every breadcrumb
+with `"root"` (e.g. `"root > data > orders[*]"`), including for a fully populated path — matching
+the requirement literally and making the hierarchy's starting point explicit at all times, similar
+to a filesystem's `/` or JSONPath's `$`.
+
+**Decision:** Do not prefix `"root"` onto non-empty paths. `KeyPathFormatter.Format` renders an
+empty path as `"root"` alone; a non-empty path renders as just its segments (e.g.
+`"data > orders[*]"`).
+
+**Rationale:**
+1. **Dropping the prefix doesn't make the location ambiguous.** Only one file is open at a time,
+   with one fixed hierarchy for the Tree/FocusedTable session — so seeing `"data > orders[*]"` on
+   screen can only ever mean "starting from this file's root, `data`, then `orders`." There is no
+   second document or alternate root the segments could be confused with. Prefixing every line
+   with `"root >"` would just repeat something already implied; the word only carries information
+   in the one state where the path is otherwise blank (empty path → `"root"` alone).
+2. **Singular/plural mismatch with Full Aggregation.** `FullAggregationDrillDownRequest`
+   (Phase 2) collapses every array index to `[*]`, which signals "every element, aggregated
+   across the whole file." `"root"` reads as one specific, singular location. Always prefixing
+   would render `"root > list[*] > orders"` — a literal singular anchor sitting next to an
+   aggregate/plural marker in the same string, which is misleading: the aggregation spans every
+   record in the file, not one root. Full Aggregation would need a collective word (e.g.
+   `"all"`/`"roots"`) to be accurate, not `"root"`.
+3. **Dropping the prefix sidesteps the mismatch entirely.** `"root"` only ever appears alone (for
+   an empty path); it never co-occurs with `[*]` in the same rendered string, so the
+   singular/plural conflict described above cannot occur, without needing any Phase-1-vs-Phase-2
+   branching in `KeyPathFormatter`.
+4. **Low cost.** Special-casing the prefix by DrillDown phase (e.g. `"root"` for Tree/Phase 1,
+   `"all"` for Phase 2) was considered and rejected for this issue on cost grounds — it would
+   require `KeyPathFormatter.Format` to take on Phase-awareness it doesn't otherwise need, plus
+   doc/test updates, for a distinction that doesn't fully solve the problem anyway (see
+   Consequences below).
+
+**Consequences:**
+- Investigating what "empty path" actually covers surfaced that `KeyPathBuilder.Build` only walks
+  `KeyName`, and the top-level line/element node for JSON Lines / JSON Array
+  (`JsonLinesRangeTreeNode.CreateLineNode` / `JsonArrayRangeTreeNode.CreateElementNode`) has
+  `KeyName = null` (only `RecordPosition` is set). Selecting the record/element itself — not just
+  having nothing selected — also yields an empty path and renders as `"root"`. So `"root"` covers
+  both "nothing selected" and "positioned on any record's own node," indistinguishable from any
+  other record. JSON Object is the exception: its top-level entries are real object keys, so
+  selecting one yields a non-empty path immediately. A future pass could surface `RecordPosition`
+  (e.g. `"Line 1"` / `"[5]"`) as the first breadcrumb segment instead of `"root"`. If picked up, it
+  opens the door to also making the breadcrumb always render as a full
+  `<record> > <level 2> > <level 3>...` chain (no bare `"root"` case at all), and to varying that
+  first segment by DrillDown kind — a single-node `SingleDrillDownRequest` names the one concrete
+  record, while a `FullAggregationDrillDownRequest` (scanning every record) would need a
+  collective label instead of one record's identity, since it aggregates across all of them
+  regardless of whether the path itself contains any array index to collapse to `[*]`.
+- This decision does not fully resolve Phase 1 vs. Phase 2 ambiguity: Full Aggregation DrillDown
+  also runs on paths with **zero array segments** (see
+  `docs/design_drilldown_command_phase2.md`'s "0 arrays in path" examples: `user`, `score`). In
+  that case `[*]` never appears, so a Phase 1 (single-node) and Phase 2 (full-file aggregate)
+  breadcrumb can render as the exact same string (e.g. both just `"user"`). Row count is not a
+  reliable substitute either, since a Phase 1 selection can itself contain an array and render
+  multiple rows. Accepted as a known limitation for this issue rather than solved, per the cost
+  tradeoff in Rationale point 4.
+
+---
+
 ## 4. Testing
 
 - `KeyPathBuilderTests.cs` (moved from `AppKeyHandlerTests.cs`, renamed type only).

--- a/src/App/AppKeyHandler.cs
+++ b/src/App/AppKeyHandler.cs
@@ -1,9 +1,7 @@
-using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using DataMorph.App.Views;
 using DataMorph.App.Views.Dialogs;
 using DataMorph.App.Views.JsonTreeNodes;
-using DataMorph.Engine.IO.DrillDown;
 using DataMorph.Engine.Types;
 using Terminal.Gui.App;
 using Terminal.Gui.Drivers;
@@ -253,7 +251,8 @@ internal sealed class AppKeyHandler : IDisposable
 
         var request = new SingleDrillDownRequest(
             Format: format,
-            NodeBytes: arrayNode.RawJson);
+            NodeBytes: arrayNode.RawJson,
+            KeyPath: KeyPathBuilder.Build(selectedNode));
 
         void onDrillDownConfirmed(string actionName) => _viewManager.DrillDown(request);
 
@@ -272,7 +271,7 @@ internal sealed class AppKeyHandler : IDisposable
     )]
     private bool HandleFullAggregationDrillDown(ITreeNode selectedNode, DataFormat format)
     {
-        var keyPath = BuildKeyPath(selectedNode);
+        var keyPath = KeyPathBuilder.Build(selectedNode);
         var request = new FullAggregationDrillDownRequest(
             Format: format,
             KeyPath: keyPath);
@@ -296,50 +295,6 @@ internal sealed class AppKeyHandler : IDisposable
         {
             _app.Invoke(() => _viewManager.ShowError(task.Exception.InnerException?.Message ?? task.Exception.Message));
         }
-    }
-
-    /// <summary>
-    /// Traverses the <c>ParentNode</c> chain from <paramref name="node"/> up to the root,
-    /// collecting <c>KeyName</c> segments in bottom-up order, then reverses to produce a
-    /// root-to-leaf KeyPath.
-    /// </summary>
-    /// <param name="node">The selected tree node to build the KeyPath from.</param>
-    /// <returns>An ordered list of path segments from root to <paramref name="node"/>.</returns>
-    [SuppressMessage(
-        "Performance",
-        "CA1859:Use concrete types when possible for improved performance",
-        Justification = "IReadOnlyList<KeyPathSegment> is the KeyPath contract shared with FullAggregationDrillDownRequest; " +
-            "the concrete List<KeyPathSegment> used to build it is an implementation detail that should not leak out."
-    )]
-    internal static IReadOnlyList<KeyPathSegment> BuildKeyPath(ITreeNode node)
-    {
-        List<KeyPathSegment> segments = [];
-        var current = node;
-
-        while (current is JsonObjectTreeNode or JsonArrayTreeNode or JsonValueTreeNode)
-        {
-            var (keyName, parent) = current switch
-            {
-                JsonObjectTreeNode obj => (obj.KeyName, obj.ParentNode),
-                JsonArrayTreeNode arr => (arr.KeyName, arr.ParentNode),
-                JsonValueTreeNode val => (val.KeyName, val.ParentNode),
-                _ => throw new UnreachableException(),
-            };
-
-            if (keyName is not null)
-            {
-                // An array element's parent is the JsonArrayTreeNode that labeled it "[n]"; every
-                // other node is an object property. Tagging by parent type — not by the label text —
-                // keeps a literal object key such as "[0]" from colliding with an index marker.
-                var kind = parent is JsonArrayTreeNode ? KeyPathSegmentKind.Index : KeyPathSegmentKind.Key;
-                segments.Add(new KeyPathSegment(keyName, kind));
-            }
-
-            current = parent;
-        }
-
-        segments.Reverse();
-        return segments;
     }
 
     /// <summary>

--- a/src/App/AppState.cs
+++ b/src/App/AppState.cs
@@ -1,4 +1,5 @@
 using DataMorph.Engine.IO;
+using DataMorph.Engine.IO.DrillDown;
 using DataMorph.Engine.Models;
 using DataMorph.Engine.Models.Actions;
 
@@ -20,6 +21,13 @@ internal sealed class AppState : IDisposable
     /// Gets or sets the current view mode.
     /// </summary>
     public ViewMode CurrentMode { get; set; } = ViewMode.FileSelection;
+
+    /// <summary>
+    /// Gets or sets the KeyPath of the location currently on screen.
+    /// Only meaningful while <see cref="CurrentMode"/> is a Tree mode or FocusedTable — updated
+    /// on tree cursor movement and when DrillDown is triggered.
+    /// </summary>
+    public IReadOnlyList<KeyPathSegment> CurrentKeyPath { get; set; } = [];
 
     /// <summary>
     /// Gets or sets the table schema for the loaded file.

--- a/src/App/DrillDownRequest.cs
+++ b/src/App/DrillDownRequest.cs
@@ -10,9 +10,11 @@ internal abstract record DrillDownRequest(DataFormat Format);
 /// <summary>Single-node DrillDown: JSON Object format, operates on the selected node only.</summary>
 /// <param name="Format">Source file format.</param>
 /// <param name="NodeBytes">Raw bytes of the selected node's JSON value.</param>
+/// <param name="KeyPath">Ordered path segments from root to the selected node.</param>
 internal sealed record SingleDrillDownRequest(
     DataFormat Format,
-    JsonRawBytes NodeBytes)
+    JsonRawBytes NodeBytes,
+    IReadOnlyList<KeyPathSegment> KeyPath)
     : DrillDownRequest(Format);
 
 /// <summary>Full-aggregation DrillDown: JSON Lines / JSON Array format, scans the entire file.</summary>

--- a/src/App/KeyPathBuilder.cs
+++ b/src/App/KeyPathBuilder.cs
@@ -1,0 +1,59 @@
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using DataMorph.App.Views.JsonTreeNodes;
+using DataMorph.Engine.IO.DrillDown;
+using Terminal.Gui.Views;
+
+namespace DataMorph.App;
+
+/// <summary>
+/// Builds an ordered KeyPath from a selected tree node by walking its <c>ParentNode</c> chain
+/// up to the root. Extracted from <see cref="AppKeyHandler"/> so the tree-view <c>Create</c>
+/// factories can compute a path without depending on the keyboard-shortcut handler.
+/// </summary>
+internal static class KeyPathBuilder
+{
+    /// <summary>
+    /// Traverses the <c>ParentNode</c> chain from <paramref name="node"/> up to the root,
+    /// collecting <c>KeyName</c> segments in bottom-up order, then reverses to produce a
+    /// root-to-leaf KeyPath.
+    /// </summary>
+    /// <param name="node">The selected tree node to build the KeyPath from.</param>
+    /// <returns>An ordered list of path segments from root to <paramref name="node"/>.</returns>
+    [SuppressMessage(
+        "Performance",
+        "CA1859:Use concrete types when possible for improved performance",
+        Justification = "IReadOnlyList<KeyPathSegment> is the KeyPath contract shared with FullAggregationDrillDownRequest; " +
+            "the concrete List<KeyPathSegment> used to build it is an implementation detail that should not leak out."
+    )]
+    internal static IReadOnlyList<KeyPathSegment> Build(ITreeNode node)
+    {
+        List<KeyPathSegment> segments = [];
+        var current = node;
+
+        while (current is JsonObjectTreeNode or JsonArrayTreeNode or JsonValueTreeNode)
+        {
+            var (keyName, parent) = current switch
+            {
+                JsonObjectTreeNode obj => (obj.KeyName, obj.ParentNode),
+                JsonArrayTreeNode arr => (arr.KeyName, arr.ParentNode),
+                JsonValueTreeNode val => (val.KeyName, val.ParentNode),
+                _ => throw new UnreachableException(),
+            };
+
+            if (keyName is not null)
+            {
+                // An array element's parent is the JsonArrayTreeNode that labeled it "[n]"; every
+                // other node is an object property. Tagging by parent type — not by the label text —
+                // keeps a literal object key such as "[0]" from colliding with an index marker.
+                var kind = parent is JsonArrayTreeNode ? KeyPathSegmentKind.Index : KeyPathSegmentKind.Key;
+                segments.Add(new KeyPathSegment(keyName, kind));
+            }
+
+            current = parent;
+        }
+
+        segments.Reverse();
+        return segments;
+    }
+}

--- a/src/App/KeyPathFormatter.cs
+++ b/src/App/KeyPathFormatter.cs
@@ -1,0 +1,32 @@
+using DataMorph.Engine.IO.DrillDown;
+
+namespace DataMorph.App;
+
+/// <summary>
+/// Formats a KeyPath into the breadcrumb display string (e.g. <c>"root → data → orders[*]"</c>)
+/// and reports the column range of each rendered segment so <see cref="Views.BreadcrumbBar"/> can
+/// map a mouse click's X position back to a segment index.
+/// </summary>
+internal static class KeyPathFormatter
+{
+    /// <summary>
+    /// Renders <paramref name="path"/> as a single breadcrumb line, collapsing every
+    /// <see cref="KeyPathSegmentKind.Index"/> segment to <c>"[*]"</c> when
+    /// <paramref name="collapseIndices"/> is <c>true</c> (Full Aggregation DrillDown semantics),
+    /// or keeping the concrete index otherwise.
+    /// </summary>
+    /// <param name="path">The ordered path segments from root to the selected node.</param>
+    /// <param name="collapseIndices">
+    /// When <c>true</c>, every <see cref="KeyPathSegmentKind.Index"/> segment renders as <c>"[*]"</c>.
+    /// </param>
+    /// <returns>
+    /// The formatted breadcrumb text and, for each input segment in order, the column
+    /// <c>(start, length)</c> range it occupies within that text. An empty path yields <c>"root"</c>.
+    /// </returns>
+    internal static (string text, IReadOnlyList<(int start, int length)> segmentRanges) Format(
+        IReadOnlyList<KeyPathSegment> path,
+        bool collapseIndices)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/src/App/KeyPathFormatter.cs
+++ b/src/App/KeyPathFormatter.cs
@@ -1,12 +1,15 @@
+using System.Text;
 using DataMorph.Engine.IO.DrillDown;
 
 namespace DataMorph.App;
 
 /// <summary>
-/// Formats a KeyPath into the breadcrumb display string (e.g. <c>"root → data → orders[*]"</c>).
+/// Formats a KeyPath into the breadcrumb display string (e.g. <c>"data > orders[*]"</c>).
 /// </summary>
 internal static class KeyPathFormatter
 {
+    private const string Separator = " > ";
+
     /// <summary>
     /// Renders <paramref name="path"/> as a single breadcrumb line, collapsing every
     /// <see cref="KeyPathSegmentKind.Index"/> segment to <c>"[*]"</c> when
@@ -20,6 +23,28 @@ internal static class KeyPathFormatter
     /// <returns>The formatted breadcrumb text. An empty path yields <c>"root"</c>.</returns>
     internal static string Format(IReadOnlyList<KeyPathSegment> path, bool collapseIndices)
     {
-        throw new NotImplementedException();
+        if (path.Count == 0)
+        {
+            return "root";
+        }
+
+        var builder = new StringBuilder();
+        foreach (var segment in path)
+        {
+            if (segment.Kind == KeyPathSegmentKind.Index)
+            {
+                builder.Append(collapseIndices ? "[*]" : segment.Value);
+                continue;
+            }
+
+            if (builder.Length > 0)
+            {
+                builder.Append(Separator);
+            }
+
+            builder.Append(segment.Value);
+        }
+
+        return builder.ToString();
     }
 }

--- a/src/App/KeyPathFormatter.cs
+++ b/src/App/KeyPathFormatter.cs
@@ -3,9 +3,7 @@ using DataMorph.Engine.IO.DrillDown;
 namespace DataMorph.App;
 
 /// <summary>
-/// Formats a KeyPath into the breadcrumb display string (e.g. <c>"root → data → orders[*]"</c>)
-/// and reports the column range of each rendered segment so <see cref="Views.BreadcrumbBar"/> can
-/// map a mouse click's X position back to a segment index.
+/// Formats a KeyPath into the breadcrumb display string (e.g. <c>"root → data → orders[*]"</c>).
 /// </summary>
 internal static class KeyPathFormatter
 {
@@ -19,13 +17,8 @@ internal static class KeyPathFormatter
     /// <param name="collapseIndices">
     /// When <c>true</c>, every <see cref="KeyPathSegmentKind.Index"/> segment renders as <c>"[*]"</c>.
     /// </param>
-    /// <returns>
-    /// The formatted breadcrumb text and, for each input segment in order, the column
-    /// <c>(start, length)</c> range it occupies within that text. An empty path yields <c>"root"</c>.
-    /// </returns>
-    internal static (string text, IReadOnlyList<(int start, int length)> segmentRanges) Format(
-        IReadOnlyList<KeyPathSegment> path,
-        bool collapseIndices)
+    /// <returns>The formatted breadcrumb text. An empty path yields <c>"root"</c>.</returns>
+    internal static string Format(IReadOnlyList<KeyPathSegment> path, bool collapseIndices)
     {
         throw new NotImplementedException();
     }

--- a/src/App/ViewManager.cs
+++ b/src/App/ViewManager.cs
@@ -58,6 +58,7 @@ internal sealed class ViewManager : IDisposable
             Y = Pos.Bottom(_breadcrumbBar),
             Width = Dim.Fill(),
             Height = Dim.Fill() - 1, // Leave room for StatusBar at the bottom
+            CanFocus = true,
         };
         _container.Add(_breadcrumbBar, _contentContainer);
     }
@@ -138,8 +139,7 @@ internal sealed class ViewManager : IDisposable
     internal void UpdateBreadcrumb(IReadOnlyList<KeyPathSegment> path, bool collapseIndices)
     {
         _state.CurrentKeyPath = path;
-        // _breadcrumbBar.SetPath(path, collapseIndices) is deferred to Step 2, pending
-        // KeyPathFormatter/BreadcrumbBar rendering logic.
+        _breadcrumbBar.SetPath(path, collapseIndices);
     }
 
     /// <summary>
@@ -192,6 +192,7 @@ internal sealed class ViewManager : IDisposable
     internal void SwitchToFileSelection()
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
+        _state.CurrentKeyPath = [];
         SwapView(Views.FileSelectionView.Create());
         RefreshStatusBarHints();
     }
@@ -212,6 +213,7 @@ internal sealed class ViewManager : IDisposable
         ObjectDisposedException.ThrowIf(_disposed, this);
         ArgumentNullException.ThrowIfNull(indexer);
         ArgumentNullException.ThrowIfNull(schema);
+        _state.CurrentKeyPath = [];
 
         ITableSource rawSource = new Views.VirtualTableSource(indexer, schema);
         var source = _state.ActionStack.Count > 0
@@ -271,6 +273,7 @@ internal sealed class ViewManager : IDisposable
             () => _ = ToggleJsonLinesModeAsync(),
             path => UpdateBreadcrumb(path, collapseIndices: false),
             _uiThreadInvoke);
+        UpdateBreadcrumb([], collapseIndices: false);
         SwapView(view);
         RefreshStatusBarHints();
     }
@@ -294,6 +297,7 @@ internal sealed class ViewManager : IDisposable
             () => _ = ToggleJsonArrayModeAsync(),
             path => UpdateBreadcrumb(path, collapseIndices: false),
             _uiThreadInvoke);
+        UpdateBreadcrumb([], collapseIndices: false);
         SwapView(view);
         RefreshStatusBarHints();
     }
@@ -319,6 +323,7 @@ internal sealed class ViewManager : IDisposable
             entries,
             static () => { },
             path => UpdateBreadcrumb(path, collapseIndices: false));
+        UpdateBreadcrumb([], collapseIndices: false);
         SwapView(view);
         RefreshStatusBarHints();
     }
@@ -340,6 +345,7 @@ internal sealed class ViewManager : IDisposable
         ObjectDisposedException.ThrowIf(_disposed, this);
         ArgumentNullException.ThrowIfNull(indexer);
         ArgumentNullException.ThrowIfNull(schema);
+        _state.CurrentKeyPath = [];
 
         var cache = new RowByteCache(indexer);
         var source = new Views.JsonLinesTableSource(cache, schema);

--- a/src/App/ViewManager.cs
+++ b/src/App/ViewManager.cs
@@ -143,6 +143,18 @@ internal sealed class ViewManager : IDisposable
     }
 
     /// <summary>
+    /// Blanks the breadcrumb bar and resets <see cref="AppState.CurrentKeyPath"/> for modes with no
+    /// JSON hierarchy (<see cref="ViewMode.CsvTable"/>, <see cref="ViewMode.JsonLinesTable"/>,
+    /// <see cref="ViewMode.FileSelection"/>). Unlike <see cref="UpdateBreadcrumb"/> with an empty
+    /// path, this does not render <c>"root"</c>.
+    /// </summary>
+    internal void ClearBreadcrumb()
+    {
+        _state.CurrentKeyPath = [];
+        _breadcrumbBar.Clear();
+    }
+
+    /// <summary>
     /// Toggles between JSON Lines Tree and Table view modes.
     /// </summary>
     /// <returns>A task representing the asynchronous operation.</returns>
@@ -192,7 +204,7 @@ internal sealed class ViewManager : IDisposable
     internal void SwitchToFileSelection()
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
-        _state.CurrentKeyPath = [];
+        ClearBreadcrumb();
         SwapView(Views.FileSelectionView.Create());
         RefreshStatusBarHints();
     }
@@ -213,7 +225,7 @@ internal sealed class ViewManager : IDisposable
         ObjectDisposedException.ThrowIf(_disposed, this);
         ArgumentNullException.ThrowIfNull(indexer);
         ArgumentNullException.ThrowIfNull(schema);
-        _state.CurrentKeyPath = [];
+        ClearBreadcrumb();
 
         ITableSource rawSource = new Views.VirtualTableSource(indexer, schema);
         var source = _state.ActionStack.Count > 0
@@ -345,7 +357,7 @@ internal sealed class ViewManager : IDisposable
         ObjectDisposedException.ThrowIf(_disposed, this);
         ArgumentNullException.ThrowIfNull(indexer);
         ArgumentNullException.ThrowIfNull(schema);
-        _state.CurrentKeyPath = [];
+        ClearBreadcrumb();
 
         var cache = new RowByteCache(indexer);
         var source = new Views.JsonLinesTableSource(cache, schema);

--- a/src/App/ViewManager.cs
+++ b/src/App/ViewManager.cs
@@ -3,6 +3,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Text;
 using DataMorph.App.Views;
 using DataMorph.Engine.IO;
+using DataMorph.Engine.IO.DrillDown;
 using DataMorph.Engine.IO.JsonLines;
 using DataMorph.Engine.Models;
 using DataMorph.Engine.Models.Actions;
@@ -24,6 +25,18 @@ internal sealed class ViewManager : IDisposable
     private readonly AppState _state;
     private readonly ModeController _modeController;
     private readonly Action<Action> _uiThreadInvoke;
+    [SuppressMessage(
+        "Reliability",
+        "CA2213:Disposable fields should be disposed",
+        Justification = "BreadcrumbBar is added to the Window (_container) and is disposed automatically when the Window is disposed."
+    )]
+    private readonly BreadcrumbBar _breadcrumbBar;
+    [SuppressMessage(
+        "Reliability",
+        "CA2213:Disposable fields should be disposed",
+        Justification = "ContentContainer is added to the Window (_container) and is disposed automatically when the Window is disposed."
+    )]
+    private readonly View _contentContainer;
     private View? _currentView;
     private Label? _itemCountLabel;
     private bool _disposed;
@@ -38,6 +51,15 @@ internal sealed class ViewManager : IDisposable
         _state = state;
         _modeController = modeController;
         _uiThreadInvoke = uiThreadInvoke;
+        _breadcrumbBar = new BreadcrumbBar();
+        _contentContainer = new View
+        {
+            X = 0,
+            Y = Pos.Bottom(_breadcrumbBar),
+            Width = Dim.Fill(),
+            Height = Dim.Fill() - 1, // Leave room for StatusBar at the bottom
+        };
+        _container.Add(_breadcrumbBar, _contentContainer);
     }
 
     /// <summary>
@@ -104,6 +126,20 @@ internal sealed class ViewManager : IDisposable
             };
             _container.Add(_itemCountLabel);
         }
+    }
+
+    /// <summary>
+    /// Updates the breadcrumb bar to reflect the current location and stores it on <see cref="AppState"/>.
+    /// </summary>
+    /// <param name="path">The ordered path segments from root to the current location.</param>
+    /// <param name="collapseIndices">
+    /// When <c>true</c>, array indices render as <c>"[*]"</c> (Full Aggregation DrillDown).
+    /// </param>
+    internal void UpdateBreadcrumb(IReadOnlyList<KeyPathSegment> path, bool collapseIndices)
+    {
+        _state.CurrentKeyPath = path;
+        // _breadcrumbBar.SetPath(path, collapseIndices) is deferred to Step 2, pending
+        // KeyPathFormatter/BreadcrumbBar rendering logic.
     }
 
     /// <summary>
@@ -200,10 +236,6 @@ internal sealed class ViewManager : IDisposable
 
         var view = new Views.CsvTableView
         {
-            X = 0,
-            Y = 1, // Start below MenuBar
-            Width = Dim.Fill(),
-            Height = Dim.Fill() - 1, // Leave room for StatusBar at the bottom
             Table = source,
             Style = new TableStyle { AlwaysShowHeaders = true },
             OnMorphAction = HandleMorphAction,
@@ -234,11 +266,11 @@ internal sealed class ViewManager : IDisposable
         ObjectDisposedException.ThrowIf(_disposed, this);
         ArgumentNullException.ThrowIfNull(indexer);
 
-        var view = Views.JsonLinesTreeView.Create(indexer, () => _ = ToggleJsonLinesModeAsync(), _uiThreadInvoke);
-        view.X = 0;
-        view.Y = 1; // Start below MenuBar
-        view.Width = Dim.Fill();
-        view.Height = Dim.Fill() - 1; // Leave room for StatusBar at the bottom
+        var view = Views.JsonLinesTreeView.Create(
+            indexer,
+            () => _ = ToggleJsonLinesModeAsync(),
+            path => UpdateBreadcrumb(path, collapseIndices: false),
+            _uiThreadInvoke);
         SwapView(view);
         RefreshStatusBarHints();
     }
@@ -257,11 +289,11 @@ internal sealed class ViewManager : IDisposable
         ObjectDisposedException.ThrowIf(_disposed, this);
         ArgumentNullException.ThrowIfNull(indexer);
 
-        var view = Views.JsonArrayTreeView.Create(indexer, () => _ = ToggleJsonArrayModeAsync(), _uiThreadInvoke);
-        view.X = 0;
-        view.Y = 1; // Start below MenuBar
-        view.Width = Dim.Fill();
-        view.Height = Dim.Fill() - 1; // Leave room for StatusBar at the bottom
+        var view = Views.JsonArrayTreeView.Create(
+            indexer,
+            () => _ = ToggleJsonArrayModeAsync(),
+            path => UpdateBreadcrumb(path, collapseIndices: false),
+            _uiThreadInvoke);
         SwapView(view);
         RefreshStatusBarHints();
     }
@@ -283,11 +315,10 @@ internal sealed class ViewManager : IDisposable
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
         ArgumentNullException.ThrowIfNull(entries);
-        var view = Views.JsonObjectTreeView.Create(entries, static () => { });
-        view.X = 0;
-        view.Y = 1;
-        view.Width = Dim.Fill();
-        view.Height = Dim.Fill() - 1;
+        var view = Views.JsonObjectTreeView.Create(
+            entries,
+            static () => { },
+            path => UpdateBreadcrumb(path, collapseIndices: false));
         SwapView(view);
         RefreshStatusBarHints();
     }
@@ -337,10 +368,6 @@ internal sealed class ViewManager : IDisposable
 
         var view = new Views.JsonLinesTableView
         {
-            X = 0,
-            Y = 1, // Start below MenuBar
-            Width = Dim.Fill(),
-            Height = Dim.Fill() - 1, // Leave room for StatusBar at the bottom
             Table = tableSource,
             Style = new TableStyle { AlwaysShowHeaders = true },
             OnMorphAction = HandleMorphAction,
@@ -443,13 +470,18 @@ internal sealed class ViewManager : IDisposable
     {
         if (_currentView is not null)
         {
-            _container.Remove(_currentView);
+            _contentContainer.Remove(_currentView);
             _currentView.Dispose();
         }
 
+        newView.X = 0;
+        newView.Y = 0;
+        newView.Width = Dim.Fill();
+        newView.Height = Dim.Fill();
+
         _currentView = newView;
-        _container.Add(_currentView);
-        _container.SetNeedsDraw();
+        _contentContainer.Add(_currentView);
+        _contentContainer.SetNeedsDraw();
     }
 
     private void RemoveItemCountLabel()
@@ -501,6 +533,7 @@ internal sealed class ViewManager : IDisposable
                     "ModeController.DrillDown must set DrillDown state on success.");
             }
 
+            UpdateBreadcrumb(request.KeyPath, collapseIndices: false);
             SwitchToFocusedTable(drillDown);
         });
     }
@@ -528,6 +561,7 @@ internal sealed class ViewManager : IDisposable
 
             _state.DrillDown = result.Value;
             _state.CurrentMode = ViewMode.FocusedTable;
+            UpdateBreadcrumb(request.KeyPath, collapseIndices: true);
             SwitchToFocusedTable(result.Value);
         });
     }
@@ -542,10 +576,6 @@ internal sealed class ViewManager : IDisposable
         var source = new Views.FocusedTableSource(drillDown);
         var view = new Views.FocusedTableView
         {
-            X = 0,
-            Y = 1,
-            Width = Dim.Fill(),
-            Height = Dim.Fill() - 1,
             Table = source,
             Style = new TableStyle { AlwaysShowHeaders = true },
         };

--- a/src/App/Views/BreadcrumbBar.cs
+++ b/src/App/Views/BreadcrumbBar.cs
@@ -1,0 +1,43 @@
+using DataMorph.Engine.IO.DrillDown;
+using Terminal.Gui.ViewBase;
+
+namespace DataMorph.App.Views;
+
+/// <summary>
+/// A single-row bar directly below the <c>MenuBar</c> that renders the current JSON hierarchy
+/// location as a breadcrumb. <see cref="SetPath"/> updates the displayed text and the clickable
+/// segment ranges; clicking a segment raises <see cref="SegmentActivated"/>.
+/// </summary>
+internal sealed class BreadcrumbBar : View
+{
+    /// <summary>
+    /// Raised with the 0-based index of the segment the user activated (clicked or otherwise
+    /// selected). Subscribers move the tree selection to the corresponding ancestor node.
+    /// Invoked from the mouse click handler, which is implemented in Step 2.
+    /// </summary>
+#pragma warning disable CS0067
+    internal event Action<int>? SegmentActivated;
+#pragma warning restore CS0067
+
+    internal BreadcrumbBar()
+    {
+        X = 0;
+        Y = 1; // Directly below the MenuBar (row 0)
+        Width = Dim.Fill();
+        Height = 1;
+    }
+
+    /// <summary>
+    /// Renders <paramref name="path"/> as the breadcrumb text, collapsing array indices to
+    /// <c>"[*]"</c> when <paramref name="collapseIndices"/> is <c>true</c>, and records each
+    /// segment's column range so a later click can be mapped back to a segment index.
+    /// </summary>
+    /// <param name="path">The ordered path segments from root to the current location.</param>
+    /// <param name="collapseIndices">
+    /// When <c>true</c>, array-element indices render as <c>"[*]"</c> (Full Aggregation DrillDown).
+    /// </param>
+    internal void SetPath(IReadOnlyList<KeyPathSegment> path, bool collapseIndices)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/src/App/Views/BreadcrumbBar.cs
+++ b/src/App/Views/BreadcrumbBar.cs
@@ -27,6 +27,6 @@ internal sealed class BreadcrumbBar : View
     /// </param>
     internal void SetPath(IReadOnlyList<KeyPathSegment> path, bool collapseIndices)
     {
-        throw new NotImplementedException();
+        Text = KeyPathFormatter.Format(path, collapseIndices);
     }
 }

--- a/src/App/Views/BreadcrumbBar.cs
+++ b/src/App/Views/BreadcrumbBar.cs
@@ -29,4 +29,13 @@ internal sealed class BreadcrumbBar : View
     {
         Text = KeyPathFormatter.Format(path, collapseIndices);
     }
+
+    /// <summary>
+    /// Blanks the breadcrumb text for views with no JSON hierarchy (e.g. <c>CsvTable</c>).
+    /// Unlike <see cref="SetPath"/> with an empty path, this does not render <c>"root"</c>.
+    /// </summary>
+    internal void Clear()
+    {
+        Text = string.Empty;
+    }
 }

--- a/src/App/Views/BreadcrumbBar.cs
+++ b/src/App/Views/BreadcrumbBar.cs
@@ -5,20 +5,10 @@ namespace DataMorph.App.Views;
 
 /// <summary>
 /// A single-row bar directly below the <c>MenuBar</c> that renders the current JSON hierarchy
-/// location as a breadcrumb. <see cref="SetPath"/> updates the displayed text and the clickable
-/// segment ranges; clicking a segment raises <see cref="SegmentActivated"/>.
+/// location as a breadcrumb. Display-only; <see cref="SetPath"/> updates the displayed text.
 /// </summary>
 internal sealed class BreadcrumbBar : View
 {
-    /// <summary>
-    /// Raised with the 0-based index of the segment the user activated (clicked or otherwise
-    /// selected). Subscribers move the tree selection to the corresponding ancestor node.
-    /// Invoked from the mouse click handler, which is implemented in Step 2.
-    /// </summary>
-#pragma warning disable CS0067
-    internal event Action<int>? SegmentActivated;
-#pragma warning restore CS0067
-
     internal BreadcrumbBar()
     {
         X = 0;
@@ -29,8 +19,7 @@ internal sealed class BreadcrumbBar : View
 
     /// <summary>
     /// Renders <paramref name="path"/> as the breadcrumb text, collapsing array indices to
-    /// <c>"[*]"</c> when <paramref name="collapseIndices"/> is <c>true</c>, and records each
-    /// segment's column range so a later click can be mapped back to a segment index.
+    /// <c>"[*]"</c> when <paramref name="collapseIndices"/> is <c>true</c>.
     /// </summary>
     /// <param name="path">The ordered path segments from root to the current location.</param>
     /// <param name="collapseIndices">

--- a/src/App/Views/JsonArrayTreeView.cs
+++ b/src/App/Views/JsonArrayTreeView.cs
@@ -1,6 +1,8 @@
 using DataMorph.App.Views.JsonRangeTreeNodes;
 using DataMorph.Engine.IO;
+using DataMorph.Engine.IO.DrillDown;
 using DataMorph.Engine.IO.JsonArray;
+using Terminal.Gui.Views;
 
 namespace DataMorph.App.Views;
 
@@ -17,9 +19,10 @@ internal sealed class JsonArrayTreeView : RangeTreeViewBase
         IRowIndexer indexer,
         ElementReader reader,
         Action onTableModeToggle,
+        Action<ITreeNode?> onSelectionChanged,
         Action<Action> uiThreadInvoke,
         long nodeGroupSize)
-        : base(indexer, onTableModeToggle, uiThreadInvoke, nodeGroupSize)
+        : base(indexer, onTableModeToggle, onSelectionChanged, uiThreadInvoke, nodeGroupSize)
     {
         _reader = reader;
     }
@@ -29,20 +32,28 @@ internal sealed class JsonArrayTreeView : RangeTreeViewBase
     /// </summary>
     /// <param name="indexer">The row indexer for the JSON Array file.</param>
     /// <param name="onTableModeToggle">Callback invoked when the user presses 't'.</param>
+    /// <param name="onPathChanged">Callback invoked with the current selection's KeyPath whenever the cursor moves.</param>
     /// <param name="uiThreadInvoke">Marshals actions to the UI thread for thread-safe <c>AddObject</c> calls.</param>
     /// <returns>A new <see cref="JsonArrayTreeView"/> instance populated with element or range nodes.</returns>
     internal static JsonArrayTreeView Create(
         IRowIndexer indexer,
         Action onTableModeToggle,
+        Action<IReadOnlyList<KeyPathSegment>> onPathChanged,
         Action<Action> uiThreadInvoke)
     {
         ArgumentNullException.ThrowIfNull(indexer);
         ArgumentNullException.ThrowIfNull(onTableModeToggle);
+        ArgumentNullException.ThrowIfNull(onPathChanged);
         ArgumentNullException.ThrowIfNull(uiThreadInvoke);
 
         var nodeGroupSize = RangePartitionPolicy.GetNodeGroupSize(indexer.FileSize);
         var view = new JsonArrayTreeView(
-            indexer, new ElementReader(indexer.FilePath), onTableModeToggle, uiThreadInvoke, nodeGroupSize);
+            indexer,
+            new ElementReader(indexer.FilePath),
+            onTableModeToggle,
+            node => onPathChanged(node is null ? [] : KeyPathBuilder.Build(node)),
+            uiThreadInvoke,
+            nodeGroupSize);
 
         if (indexer.IsIndexingCompleted)
         {

--- a/src/App/Views/JsonLinesTreeView.cs
+++ b/src/App/Views/JsonLinesTreeView.cs
@@ -1,6 +1,8 @@
 using DataMorph.App.Views.JsonRangeTreeNodes;
 using DataMorph.Engine.IO;
+using DataMorph.Engine.IO.DrillDown;
 using DataMorph.Engine.IO.JsonLines;
+using Terminal.Gui.Views;
 
 namespace DataMorph.App.Views;
 
@@ -17,9 +19,10 @@ internal sealed class JsonLinesTreeView : RangeTreeViewBase
         IRowIndexer indexer,
         RowReader reader,
         Action onTableModeToggle,
+        Action<ITreeNode?> onSelectionChanged,
         Action<Action> uiThreadInvoke,
         long nodeGroupSize)
-        : base(indexer, onTableModeToggle, uiThreadInvoke, nodeGroupSize)
+        : base(indexer, onTableModeToggle, onSelectionChanged, uiThreadInvoke, nodeGroupSize)
     {
         _reader = reader;
     }
@@ -29,20 +32,28 @@ internal sealed class JsonLinesTreeView : RangeTreeViewBase
     /// </summary>
     /// <param name="indexer">The row indexer for the JSON Lines file.</param>
     /// <param name="onTableModeToggle">Callback invoked when the user presses 't'.</param>
+    /// <param name="onPathChanged">Callback invoked with the current selection's KeyPath whenever the cursor moves.</param>
     /// <param name="uiThreadInvoke">Marshals actions to the UI thread for thread-safe <c>AddObject</c> calls.</param>
     /// <returns>A new <see cref="JsonLinesTreeView"/> instance populated with line or range nodes.</returns>
     internal static JsonLinesTreeView Create(
         IRowIndexer indexer,
         Action onTableModeToggle,
+        Action<IReadOnlyList<KeyPathSegment>> onPathChanged,
         Action<Action> uiThreadInvoke)
     {
         ArgumentNullException.ThrowIfNull(indexer);
         ArgumentNullException.ThrowIfNull(onTableModeToggle);
+        ArgumentNullException.ThrowIfNull(onPathChanged);
         ArgumentNullException.ThrowIfNull(uiThreadInvoke);
 
         var nodeGroupSize = RangePartitionPolicy.GetNodeGroupSize(indexer.FileSize);
         var view = new JsonLinesTreeView(
-            indexer, new RowReader(indexer.FilePath), onTableModeToggle, uiThreadInvoke, nodeGroupSize);
+            indexer,
+            new RowReader(indexer.FilePath),
+            onTableModeToggle,
+            node => onPathChanged(node is null ? [] : KeyPathBuilder.Build(node)),
+            uiThreadInvoke,
+            nodeGroupSize);
 
         if (indexer.IsIndexingCompleted)
         {

--- a/src/App/Views/JsonObjectTreeView.cs
+++ b/src/App/Views/JsonObjectTreeView.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using DataMorph.App.Views.JsonTreeNodes;
+using DataMorph.Engine.IO.DrillDown;
 using Terminal.Gui.Views;
 
 namespace DataMorph.App.Views;
@@ -10,8 +11,8 @@ namespace DataMorph.App.Views;
 /// </summary>
 internal sealed class JsonObjectTreeView : MorphTreeView
 {
-    private JsonObjectTreeView(Action onTableModeToggle)
-        : base(onTableModeToggle) { }
+    private JsonObjectTreeView(Action onTableModeToggle, Action<ITreeNode?> onSelectionChanged)
+        : base(onTableModeToggle, onSelectionChanged) { }
 
     /// <summary>
     /// Creates a new <see cref="JsonObjectTreeView"/> populated with root-level key nodes.
@@ -23,14 +24,19 @@ internal sealed class JsonObjectTreeView : MorphTreeView
     /// Callback invoked when the user presses 't' to toggle between tree and table mode.
     /// JSON Object does not support table mode, so callers pass a no-op.
     /// </param>
+    /// <param name="onPathChanged">Callback invoked with the current selection's KeyPath whenever the cursor moves.</param>
     /// <returns>A populated <see cref="JsonObjectTreeView"/>.</returns>
     internal static JsonObjectTreeView Create(
         IReadOnlyList<(string key, JsonRawBytes value)> entries,
-        Action onTableModeToggle)
+        Action onTableModeToggle,
+        Action<IReadOnlyList<KeyPathSegment>> onPathChanged)
     {
         ArgumentNullException.ThrowIfNull(entries);
         ArgumentNullException.ThrowIfNull(onTableModeToggle);
-        var view = new JsonObjectTreeView(onTableModeToggle);
+        ArgumentNullException.ThrowIfNull(onPathChanged);
+        var view = new JsonObjectTreeView(
+            onTableModeToggle,
+            node => onPathChanged(node is null ? [] : KeyPathBuilder.Build(node)));
         foreach (var (key, valueBytes) in entries)
         {
             view.AddObject(CreateKeyNode(key, valueBytes));

--- a/src/App/Views/MorphTreeView.cs
+++ b/src/App/Views/MorphTreeView.cs
@@ -13,12 +13,18 @@ internal abstract class MorphTreeView : TreeView
 {
     private readonly VimKeyTranslator _vimKeys = new();
     private readonly Action _onTableModeToggle;
+    private readonly Action<ITreeNode?> _onSelectionChanged;
 
-    protected MorphTreeView(Action onTableModeToggle)
+    protected MorphTreeView(Action onTableModeToggle, Action<ITreeNode?> onSelectionChanged)
     {
         ArgumentNullException.ThrowIfNull(onTableModeToggle);
+        ArgumentNullException.ThrowIfNull(onSelectionChanged);
         _onTableModeToggle = onTableModeToggle;
+        _onSelectionChanged = onSelectionChanged;
         Accepted += OnAccepted;
+        // A single subscription covers both vim-key (AdjustSelection) and native arrow-key
+        // navigation, since both update SelectedObject and raise SelectionChanged.
+        SelectionChanged += (_, _) => _onSelectionChanged(SelectedObject is ITreeNode node ? node : null);
     }
 
     private void OnAccepted(object? sender, CommandEventArgs e)

--- a/src/App/Views/RangeTreeViewBase.cs
+++ b/src/App/Views/RangeTreeViewBase.cs
@@ -21,9 +21,10 @@ internal abstract class RangeTreeViewBase : MorphTreeView
     protected RangeTreeViewBase(
         IRowIndexer indexer,
         Action onTableModeToggle,
+        Action<ITreeNode?> onSelectionChanged,
         Action<Action> uiThreadInvoke,
         long nodeGroupSize)
-        : base(onTableModeToggle)
+        : base(onTableModeToggle, onSelectionChanged)
     {
         Indexer = indexer;
         _uiThreadInvoke = uiThreadInvoke;

--- a/tests/DataMorph.Tests/App/AppKeyHandlerTests.cs
+++ b/tests/DataMorph.Tests/App/AppKeyHandlerTests.cs
@@ -2,7 +2,6 @@ using AwesomeAssertions;
 using DataMorph.App;
 using DataMorph.App.Views;
 using DataMorph.App.Views.JsonTreeNodes;
-using DataMorph.Engine.IO.DrillDown;
 using Terminal.Gui.App;
 using Terminal.Gui.Drivers;
 using Terminal.Gui.Input;
@@ -204,37 +203,6 @@ public sealed class AppKeyHandlerTests
     }
 
     // MessageBox.Query display is not unit-testable; requires TUI event loop integration testing.
-
-    // BuildKeyPath is exposed as internal static (same pattern as IsGlobalShortcut) so its tests call it directly. HandleSingleDrillDown and HandleActionMenu are tested indirectly through the real ActionMenuDialog; the DrillDown path is driven by an app.Iteration Enter-key press.
-    [Fact]
-    public void BuildKeyPath_WithRootSelection_ReturnsEmptyKeyPath()
-    {
-        // Arrange
-        ITreeNode rootNode = new JsonValueTreeNode("root");
-
-        // Act
-        var keyPath = AppKeyHandler.BuildKeyPath(rootNode);
-
-        // Assert
-        keyPath.Should().BeEmpty();
-    }
-
-    [Fact]
-    public void BuildKeyPath_WithNestedObjectArraySelection_ReturnsOrderedSegmentsWithIndex()
-    {
-        // Arrange
-        var root = new JsonObjectTreeNode("{}"u8.ToArray());
-        var ordersArray = new JsonArrayTreeNode("[]"u8.ToArray()) { KeyName = "orders", ParentNode = root };
-        var element0 = new JsonObjectTreeNode("{}"u8.ToArray()) { KeyName = "[0]", ParentNode = ordersArray };
-
-        // Act
-        var keyPath = AppKeyHandler.BuildKeyPath(element0);
-
-        // Assert
-        keyPath.Should().Equal(
-            new KeyPathSegment("orders", KeyPathSegmentKind.Key),
-            new KeyPathSegment("[0]", KeyPathSegmentKind.Index));
-    }
 
     [Fact]
     public void HandleActionMenu_WithJsonObjectFormatAndArrayNode_DispatchesSingleDrillDown()

--- a/tests/DataMorph.Tests/App/AppStateTests.cs
+++ b/tests/DataMorph.Tests/App/AppStateTests.cs
@@ -107,10 +107,12 @@ public sealed class AppStateTests
     public void CurrentKeyPath_Default_IsEmpty()
     {
         // Arrange
+        using var state = new AppState();
 
         // Act
+        var result = state.CurrentKeyPath;
 
         // Assert
-        Assert.Fail("Not implemented");
+        result.Should().BeEmpty();
     }
 }

--- a/tests/DataMorph.Tests/App/AppStateTests.cs
+++ b/tests/DataMorph.Tests/App/AppStateTests.cs
@@ -102,4 +102,15 @@ public sealed class AppStateTests
         originalList.Should().HaveCount(1);
         state.ActionStack.Should().BeEmpty();
     }
+
+    [Fact]
+    public void CurrentKeyPath_Default_IsEmpty()
+    {
+        // Arrange
+
+        // Act
+
+        // Assert
+        Assert.Fail("Not implemented");
+    }
 }

--- a/tests/DataMorph.Tests/App/KeyPathBuilderTests.cs
+++ b/tests/DataMorph.Tests/App/KeyPathBuilderTests.cs
@@ -1,0 +1,40 @@
+using AwesomeAssertions;
+using DataMorph.App;
+using DataMorph.App.Views.JsonTreeNodes;
+using DataMorph.Engine.IO.DrillDown;
+using Terminal.Gui.Views;
+
+namespace DataMorph.Tests.App;
+
+public sealed class KeyPathBuilderTests
+{
+    [Fact]
+    public void Build_WithRootSelection_ReturnsEmptyKeyPath()
+    {
+        // Arrange
+        ITreeNode rootNode = new JsonValueTreeNode("root");
+
+        // Act
+        var keyPath = KeyPathBuilder.Build(rootNode);
+
+        // Assert
+        keyPath.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Build_WithNestedObjectArraySelection_ReturnsOrderedSegmentsWithIndex()
+    {
+        // Arrange
+        var root = new JsonObjectTreeNode("{}"u8.ToArray());
+        var ordersArray = new JsonArrayTreeNode("[]"u8.ToArray()) { KeyName = "orders", ParentNode = root };
+        var element0 = new JsonObjectTreeNode("{}"u8.ToArray()) { KeyName = "[0]", ParentNode = ordersArray };
+
+        // Act
+        var keyPath = KeyPathBuilder.Build(element0);
+
+        // Assert
+        keyPath.Should().Equal(
+            new KeyPathSegment("orders", KeyPathSegmentKind.Key),
+            new KeyPathSegment("[0]", KeyPathSegmentKind.Index));
+    }
+}

--- a/tests/DataMorph.Tests/App/KeyPathFormatterTests.cs
+++ b/tests/DataMorph.Tests/App/KeyPathFormatterTests.cs
@@ -1,0 +1,59 @@
+namespace DataMorph.Tests.App;
+
+public sealed class KeyPathFormatterTests
+{
+    [Fact]
+    public void Format_WithEmptyPath_ReturnsRoot()
+    {
+        // Arrange — an empty path represents the root location
+
+        // Act
+
+        // Assert
+        Assert.Fail("Not implemented");
+    }
+
+    [Fact]
+    public void Format_WithKeyOnlyPath_ReturnsJoinedKeys()
+    {
+        // Arrange — object-property segments joined by the breadcrumb separator
+
+        // Act
+
+        // Assert
+        Assert.Fail("Not implemented");
+    }
+
+    [Fact]
+    public void Format_WithIndexSegment_AndCollapseIndicesTrue_ReturnsStarMarker()
+    {
+        // Arrange — Full Aggregation DrillDown collapses every index to [*]
+
+        // Act
+
+        // Assert
+        Assert.Fail("Not implemented");
+    }
+
+    [Fact]
+    public void Format_WithIndexSegment_AndCollapseIndicesFalse_ReturnsLiteralIndex()
+    {
+        // Arrange — tree navigation and Single DrillDown keep the concrete index
+
+        // Act
+
+        // Assert
+        Assert.Fail("Not implemented");
+    }
+
+    [Fact]
+    public void Format_ReturnsSegmentRangesForClickMapping()
+    {
+        // Arrange — each segment's (start, length) range maps a click X back to a segment index
+
+        // Act
+
+        // Assert
+        Assert.Fail("Not implemented");
+    }
+}

--- a/tests/DataMorph.Tests/App/KeyPathFormatterTests.cs
+++ b/tests/DataMorph.Tests/App/KeyPathFormatterTests.cs
@@ -45,15 +45,4 @@ public sealed class KeyPathFormatterTests
         // Assert
         Assert.Fail("Not implemented");
     }
-
-    [Fact]
-    public void Format_ReturnsSegmentRangesForClickMapping()
-    {
-        // Arrange — each segment's (start, length) range maps a click X back to a segment index
-
-        // Act
-
-        // Assert
-        Assert.Fail("Not implemented");
-    }
 }

--- a/tests/DataMorph.Tests/App/KeyPathFormatterTests.cs
+++ b/tests/DataMorph.Tests/App/KeyPathFormatterTests.cs
@@ -1,3 +1,7 @@
+using AwesomeAssertions;
+using DataMorph.App;
+using DataMorph.Engine.IO.DrillDown;
+
 namespace DataMorph.Tests.App;
 
 public sealed class KeyPathFormatterTests
@@ -6,43 +10,63 @@ public sealed class KeyPathFormatterTests
     public void Format_WithEmptyPath_ReturnsRoot()
     {
         // Arrange — an empty path represents the root location
+        IReadOnlyList<KeyPathSegment> path = [];
 
         // Act
+        var result = KeyPathFormatter.Format(path, collapseIndices: false);
 
         // Assert
-        Assert.Fail("Not implemented");
+        result.Should().Be("root");
     }
 
     [Fact]
     public void Format_WithKeyOnlyPath_ReturnsJoinedKeys()
     {
         // Arrange — object-property segments joined by the breadcrumb separator
+        IReadOnlyList<KeyPathSegment> path =
+        [
+            new KeyPathSegment("k1", KeyPathSegmentKind.Key),
+            new KeyPathSegment("k2", KeyPathSegmentKind.Key),
+        ];
 
         // Act
+        var result = KeyPathFormatter.Format(path, collapseIndices: false);
 
         // Assert
-        Assert.Fail("Not implemented");
+        result.Should().Be("k1 > k2");
     }
 
     [Fact]
     public void Format_WithIndexSegment_AndCollapseIndicesTrue_ReturnsStarMarker()
     {
         // Arrange — Full Aggregation DrillDown collapses every index to [*]
+        IReadOnlyList<KeyPathSegment> path =
+        [
+            new KeyPathSegment("items", KeyPathSegmentKind.Key),
+            new KeyPathSegment("[2]", KeyPathSegmentKind.Index),
+        ];
 
         // Act
+        var result = KeyPathFormatter.Format(path, collapseIndices: true);
 
         // Assert
-        Assert.Fail("Not implemented");
+        result.Should().Be("items[*]");
     }
 
     [Fact]
     public void Format_WithIndexSegment_AndCollapseIndicesFalse_ReturnsLiteralIndex()
     {
         // Arrange — tree navigation and Single DrillDown keep the concrete index
+        IReadOnlyList<KeyPathSegment> path =
+        [
+            new KeyPathSegment("items", KeyPathSegmentKind.Key),
+            new KeyPathSegment("[2]", KeyPathSegmentKind.Index),
+        ];
 
         // Act
+        var result = KeyPathFormatter.Format(path, collapseIndices: false);
 
         // Assert
-        Assert.Fail("Not implemented");
+        result.Should().Be("items[2]");
     }
 }

--- a/tests/DataMorph.Tests/App/ModeControllerTests.cs
+++ b/tests/DataMorph.Tests/App/ModeControllerTests.cs
@@ -152,7 +152,8 @@ public sealed class ModeControllerTests : IDisposable
         JsonRawBytes nodeBytes = Encoding.UTF8.GetBytes($"[{children}]");
         var request = new SingleDrillDownRequest(
             Format: DataMorph.Engine.Types.DataFormat.JsonObject,
-            NodeBytes: nodeBytes);
+            NodeBytes: nodeBytes,
+            KeyPath: []);
         using var state = new AppState();
         var controller = new ModeController(state);
         var expectedHashValues = Enumerable.Range(0, childCount).Select(i => $"[{i}]");

--- a/tests/DataMorph.Tests/App/ViewManagerTests.cs
+++ b/tests/DataMorph.Tests/App/ViewManagerTests.cs
@@ -683,6 +683,7 @@ public sealed class ViewManagerTests : IDisposable
 
         // Assert
         state.CurrentKeyPath.Should().BeEmpty();
+        window.SubViews.OfType<BreadcrumbBar>().Single().Text.Should().BeEmpty();
     }
 
     [Fact]
@@ -710,6 +711,7 @@ public sealed class ViewManagerTests : IDisposable
 
         // Assert
         state.CurrentKeyPath.Should().BeEmpty();
+        window.SubViews.OfType<BreadcrumbBar>().Single().Text.Should().BeEmpty();
     }
 
     [Fact]
@@ -730,6 +732,7 @@ public sealed class ViewManagerTests : IDisposable
 
         // Assert
         state.CurrentKeyPath.Should().BeEmpty();
+        window.SubViews.OfType<BreadcrumbBar>().Single().Text.Should().BeEmpty();
     }
 
     [Fact]

--- a/tests/DataMorph.Tests/App/ViewManagerTests.cs
+++ b/tests/DataMorph.Tests/App/ViewManagerTests.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using AwesomeAssertions;
 using DataMorph.App;
 using DataMorph.App.Views;
@@ -658,26 +659,127 @@ public sealed class ViewManagerTests : IDisposable
     }
 
     [Fact]
+    public void SwitchToCsvTable_WithStaleKeyPath_ResetsCurrentKeyPath()
+    {
+        // Arrange — a leftover KeyPath from a prior Tree/FocusedTable session must not leak into CsvTable
+        var filePath = CreateTempFile(".csv", "col1\nvalue1\n");
+        using var app = CreateTestApp();
+        using var state = new AppState
+        {
+            CurrentFilePath = filePath,
+            CurrentKeyPath = [new KeyPathSegment("stale", KeyPathSegmentKind.Key)],
+        };
+        using var window = new Window();
+        var modeController = new ModeController(state);
+        using var viewManager = new ViewManager(window, state, modeController, action => action());
+        var schema = new TableSchema
+        {
+            SourceFormat = DataFormat.Csv,
+            Columns = [new ColumnSchema { Name = "col1", Type = ColumnType.Text }]
+        };
+
+        // Act
+        viewManager.SwitchToCsvTable(new MockRowIndexer(filePath), schema);
+
+        // Assert
+        state.CurrentKeyPath.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void SwitchToJsonLinesTableView_WithStaleKeyPath_ResetsCurrentKeyPath()
+    {
+        // Arrange — a leftover KeyPath from a prior Tree/FocusedTable session must not leak into JsonLinesTable
+        var filePath = CreateTempFile(".jsonl", "{\"col1\": \"value\"}\n");
+        using var app = CreateTestApp();
+        using var state = new AppState
+        {
+            CurrentFilePath = filePath,
+            CurrentKeyPath = [new KeyPathSegment("stale", KeyPathSegmentKind.Key)],
+        };
+        using var window = new Window();
+        var modeController = new ModeController(state);
+        using var viewManager = new ViewManager(window, state, modeController, action => action());
+        var schema = new TableSchema
+        {
+            SourceFormat = DataFormat.JsonLines,
+            Columns = [new ColumnSchema { Name = "col1", Type = ColumnType.Text }]
+        };
+
+        // Act
+        viewManager.SwitchToJsonLinesTableView(new MockRowIndexer(filePath), schema);
+
+        // Assert
+        state.CurrentKeyPath.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void SwitchToFileSelection_WithStaleKeyPath_ResetsCurrentKeyPath()
+    {
+        // Arrange — a leftover KeyPath from a prior Tree/FocusedTable session must not leak into FileSelection
+        using var app = CreateTestApp();
+        using var state = new AppState
+        {
+            CurrentKeyPath = [new KeyPathSegment("stale", KeyPathSegmentKind.Key)],
+        };
+        using var window = new Window();
+        var modeController = new ModeController(state);
+        using var viewManager = new ViewManager(window, state, modeController, action => action());
+
+        // Act
+        viewManager.SwitchToFileSelection();
+
+        // Assert
+        state.CurrentKeyPath.Should().BeEmpty();
+    }
+
+    [Fact]
     public void DrillDown_WithIndexSegmentInKeyPath_RendersLiteralIndexInBreadcrumb()
     {
         // Arrange — SingleDrillDownRequest (Phase 1) must not collapse array indices
+        using var app = CreateTestApp();
+        using var state = new AppState();
+        using var window = new Window();
+        var modeController = new ModeController(state);
+        using var viewManager = new ViewManager(window, state, modeController, action => action());
+
+        var request = new SingleDrillDownRequest(
+            DataFormat.JsonObject,
+            Encoding.UTF8.GetBytes("[{\"a\":1}]"),
+            [
+                new KeyPathSegment("list", KeyPathSegmentKind.Key),
+                new KeyPathSegment("[0]", KeyPathSegmentKind.Index),
+            ]);
 
         // Act
+        viewManager.DrillDown(request);
 
         // Assert
-        Assert.Fail("Not implemented");
+        window.SubViews.OfType<BreadcrumbBar>().Single().Text.Should().Be("list[0]");
     }
 
     [Fact]
     public async Task FullAggregationDrillDownAsync_WithIndexSegmentInKeyPath_RendersCollapsedIndexInBreadcrumb()
     {
         // Arrange — FullAggregationDrillDownRequest (Phase 2) collapses array indices to [*]
+        var filePath = CreateTempFile(".jsonl", "{\"list\":[{\"a\":1}]}\n");
+        using var app = CreateTestApp();
+        using var state = new AppState { CurrentFilePath = filePath };
+        using var window = new Window();
+        var modeController = new ModeController(state);
+        using var viewManager = new ViewManager(window, state, modeController, action => action());
+
+        var request = new FullAggregationDrillDownRequest(
+            DataFormat.JsonLines,
+            [
+                new KeyPathSegment("list", KeyPathSegmentKind.Key),
+                new KeyPathSegment("[0]", KeyPathSegmentKind.Index),
+            ]);
 
         // Act
-        await Task.CompletedTask;
+        await viewManager.FullAggregationDrillDownAsync(request);
 
         // Assert
-        Assert.Fail("Not implemented");
+        window.SubViews.OfType<BreadcrumbBar>().Single().Text.Should().Be("list[*]");
     }
 
     /// <summary>

--- a/tests/DataMorph.Tests/App/ViewManagerTests.cs
+++ b/tests/DataMorph.Tests/App/ViewManagerTests.cs
@@ -657,6 +657,29 @@ public sealed class ViewManagerTests : IDisposable
         state.CurrentMode.Should().Be(ViewMode.FileSelection);
     }
 
+    [Fact]
+    public void DrillDown_WithIndexSegmentInKeyPath_RendersLiteralIndexInBreadcrumb()
+    {
+        // Arrange — SingleDrillDownRequest (Phase 1) must not collapse array indices
+
+        // Act
+
+        // Assert
+        Assert.Fail("Not implemented");
+    }
+
+    [Fact]
+    public async Task FullAggregationDrillDownAsync_WithIndexSegmentInKeyPath_RendersCollapsedIndexInBreadcrumb()
+    {
+        // Arrange — FullAggregationDrillDownRequest (Phase 2) collapses array indices to [*]
+
+        // Act
+        await Task.CompletedTask;
+
+        // Assert
+        Assert.Fail("Not implemented");
+    }
+
     /// <summary>
     /// Mock IRowIndexer for testing.
     /// </summary>

--- a/tests/DataMorph.Tests/App/Views/BreadcrumbBarTests.cs
+++ b/tests/DataMorph.Tests/App/Views/BreadcrumbBarTests.cs
@@ -12,15 +12,4 @@ public sealed class BreadcrumbBarTests
         // Assert
         Assert.Fail("Not implemented");
     }
-
-    [Fact]
-    public void SegmentActivated_WhenClickWithinSegmentRange_RaisesWithCorrectIndex()
-    {
-        // Arrange — a click whose X falls within a segment's column range
-
-        // Act
-
-        // Assert
-        Assert.Fail("Not implemented");
-    }
 }

--- a/tests/DataMorph.Tests/App/Views/BreadcrumbBarTests.cs
+++ b/tests/DataMorph.Tests/App/Views/BreadcrumbBarTests.cs
@@ -1,3 +1,7 @@
+using AwesomeAssertions;
+using DataMorph.App.Views;
+using DataMorph.Engine.IO.DrillDown;
+
 namespace DataMorph.Tests.App.Views;
 
 public sealed class BreadcrumbBarTests
@@ -6,10 +10,17 @@ public sealed class BreadcrumbBarTests
     public void SetPath_WithPath_UpdatesDisplayedText()
     {
         // Arrange
+        using var bar = new BreadcrumbBar();
+        IReadOnlyList<KeyPathSegment> path =
+        [
+            new KeyPathSegment("data", KeyPathSegmentKind.Key),
+            new KeyPathSegment("[0]", KeyPathSegmentKind.Index),
+        ];
 
         // Act
+        bar.SetPath(path, collapseIndices: false);
 
         // Assert
-        Assert.Fail("Not implemented");
+        bar.Text.Should().Be("data[0]");
     }
 }

--- a/tests/DataMorph.Tests/App/Views/BreadcrumbBarTests.cs
+++ b/tests/DataMorph.Tests/App/Views/BreadcrumbBarTests.cs
@@ -1,0 +1,26 @@
+namespace DataMorph.Tests.App.Views;
+
+public sealed class BreadcrumbBarTests
+{
+    [Fact]
+    public void SetPath_WithPath_UpdatesDisplayedText()
+    {
+        // Arrange
+
+        // Act
+
+        // Assert
+        Assert.Fail("Not implemented");
+    }
+
+    [Fact]
+    public void SegmentActivated_WhenClickWithinSegmentRange_RaisesWithCorrectIndex()
+    {
+        // Arrange — a click whose X falls within a segment's column range
+
+        // Act
+
+        // Assert
+        Assert.Fail("Not implemented");
+    }
+}

--- a/tests/DataMorph.Tests/App/Views/JsonArrayTreeViewTests.Create.cs
+++ b/tests/DataMorph.Tests/App/Views/JsonArrayTreeViewTests.Create.cs
@@ -1,6 +1,7 @@
 using AwesomeAssertions;
 using DataMorph.App.Views;
 using DataMorph.App.Views.JsonRangeTreeNodes;
+using DataMorph.Engine.IO.DrillDown;
 using DataMorph.Engine.IO.JsonArray;
 
 namespace DataMorph.Tests.App.Views;
@@ -66,6 +67,30 @@ public sealed partial class JsonArrayTreeViewTests
 
         // Assert
         act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void Create_OnSelectionChanged_InvokesOnPathChangedWithExpectedKeyPath()
+    {
+        // Arrange
+        var filePath = CreateTempFile("[{\"a\":1}]");
+        using var app = CreateTestApp();
+        var indexer = new RowIndexer(filePath);
+        indexer.BuildIndex();
+        List<IReadOnlyList<KeyPathSegment>> observedPaths = [];
+        using var view = JsonArrayTreeView.Create(
+            indexer, () => { }, path => observedPaths.Add(path), SynchronousUiThreadInvoke);
+        var objects = view.Objects;
+        objects.Should().NotBeNull();
+        var elementNode = objects.First();
+        var childNode = elementNode.Children.First();
+
+        // Act
+        view.SelectedObject = childNode;
+
+        // Assert
+        observedPaths.Should().ContainSingle();
+        observedPaths[0].Should().Equal(new KeyPathSegment("a", KeyPathSegmentKind.Key));
     }
 
     [Fact]

--- a/tests/DataMorph.Tests/App/Views/JsonArrayTreeViewTests.Create.cs
+++ b/tests/DataMorph.Tests/App/Views/JsonArrayTreeViewTests.Create.cs
@@ -14,7 +14,7 @@ public sealed partial class JsonArrayTreeViewTests
         using var app = CreateTestApp();
 
         // Act
-        var act = () => JsonArrayTreeView.Create(null!, () => { }, SynchronousUiThreadInvoke);
+        var act = () => JsonArrayTreeView.Create(null!, () => { }, _ => { }, SynchronousUiThreadInvoke);
 
         // Assert
         act.Should().Throw<ArgumentNullException>();
@@ -30,7 +30,7 @@ public sealed partial class JsonArrayTreeViewTests
         indexer.BuildIndex();
 
         // Act
-        var act = () => JsonArrayTreeView.Create(indexer, null!, SynchronousUiThreadInvoke);
+        var act = () => JsonArrayTreeView.Create(indexer, null!, _ => { }, SynchronousUiThreadInvoke);
 
         // Assert
         act.Should().Throw<ArgumentNullException>();
@@ -46,7 +46,23 @@ public sealed partial class JsonArrayTreeViewTests
         indexer.BuildIndex();
 
         // Act
-        var act = () => JsonArrayTreeView.Create(indexer, () => { }, null!);
+        var act = () => JsonArrayTreeView.Create(indexer, () => { }, _ => { }, null!);
+
+        // Assert
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void Create_WithNullOnPathChanged_ThrowsArgumentNullException()
+    {
+        // Arrange
+        var filePath = CreateTempFile("[1]");
+        using var app = CreateTestApp();
+        var indexer = new RowIndexer(filePath);
+        indexer.BuildIndex();
+
+        // Act
+        var act = () => JsonArrayTreeView.Create(indexer, () => { }, null!, SynchronousUiThreadInvoke);
 
         // Assert
         act.Should().Throw<ArgumentNullException>();
@@ -62,7 +78,7 @@ public sealed partial class JsonArrayTreeViewTests
         indexer.BuildIndex();
 
         // Act
-        using var view = JsonArrayTreeView.Create(indexer, () => { }, SynchronousUiThreadInvoke);
+        using var view = JsonArrayTreeView.Create(indexer, () => { }, _ => { }, SynchronousUiThreadInvoke);
 
         // Assert
         var objects = view.Objects;
@@ -84,7 +100,7 @@ public sealed partial class JsonArrayTreeViewTests
         indexer.BuildIndex();
 
         // Act
-        using var view = JsonArrayTreeView.Create(indexer, () => { }, SynchronousUiThreadInvoke);
+        using var view = JsonArrayTreeView.Create(indexer, () => { }, _ => { }, SynchronousUiThreadInvoke);
 
         // Assert
         var objects = view.Objects;
@@ -106,7 +122,7 @@ public sealed partial class JsonArrayTreeViewTests
         indexer.BuildIndex();
 
         // Act
-        using var view = JsonArrayTreeView.Create(indexer, () => { }, SynchronousUiThreadInvoke);
+        using var view = JsonArrayTreeView.Create(indexer, () => { }, _ => { }, SynchronousUiThreadInvoke);
 
         // Assert
         var objects = view.Objects;
@@ -128,7 +144,7 @@ public sealed partial class JsonArrayTreeViewTests
         indexer.BuildIndex();
 
         // Act
-        using var view = JsonArrayTreeView.Create(indexer, () => { }, SynchronousUiThreadInvoke);
+        using var view = JsonArrayTreeView.Create(indexer, () => { }, _ => { }, SynchronousUiThreadInvoke);
 
         // Assert
         var objects = view.Objects;
@@ -150,7 +166,7 @@ public sealed partial class JsonArrayTreeViewTests
         indexer.BuildIndex();
 
         // Act
-        using var view = JsonArrayTreeView.Create(indexer, () => { }, SynchronousUiThreadInvoke);
+        using var view = JsonArrayTreeView.Create(indexer, () => { }, _ => { }, SynchronousUiThreadInvoke);
 
         // Assert
         var objects = view.Objects;
@@ -170,7 +186,7 @@ public sealed partial class JsonArrayTreeViewTests
         var stubIndexer = new StubRowIndexer(realIndexer, 3);
 
         // Act
-        using var view = JsonArrayTreeView.Create(stubIndexer, () => { }, SynchronousUiThreadInvoke);
+        using var view = JsonArrayTreeView.Create(stubIndexer, () => { }, _ => { }, SynchronousUiThreadInvoke);
 
         // Assert — only 2 nodes added (Empty for index 2 is skipped)
         var objects = view.Objects;
@@ -190,7 +206,7 @@ public sealed partial class JsonArrayTreeViewTests
         indexer.BuildIndex();
 
         // Act
-        using var view = JsonArrayTreeView.Create(indexer, () => { }, SynchronousUiThreadInvoke);
+        using var view = JsonArrayTreeView.Create(indexer, () => { }, _ => { }, SynchronousUiThreadInvoke);
 
         // Assert — DelegateTreeBuilder prevents eager loading via AddObject()
         var objects = view.Objects;
@@ -210,7 +226,7 @@ public sealed partial class JsonArrayTreeViewTests
         indexer.BuildIndex();
 
         // Act
-        using var view = JsonArrayTreeView.Create(indexer, () => { }, SynchronousUiThreadInvoke);
+        using var view = JsonArrayTreeView.Create(indexer, () => { }, _ => { }, SynchronousUiThreadInvoke);
 
         // Assert — IsIndexingCompleted is true, TotalRows=2500, range nodes
         var objects = view.Objects;
@@ -232,7 +248,7 @@ public sealed partial class JsonArrayTreeViewTests
         var stubIndexer = new StubRowIndexer(realIndexer, 5000, fakeIsCompleted: true, fakeFileSize: 200_000_000);
 
         // Act
-        using var view = JsonArrayTreeView.Create(stubIndexer, () => { }, SynchronousUiThreadInvoke);
+        using var view = JsonArrayTreeView.Create(stubIndexer, () => { }, _ => { }, SynchronousUiThreadInvoke);
 
         // Assert — 3 range nodes: [0-1999], [2000-3999], [4000-4999]
         var objects = view.Objects;
@@ -256,7 +272,7 @@ public sealed partial class JsonArrayTreeViewTests
         var stubIndexer = new StubRowIndexer(realIndexer, 0, fakeIsCompleted: false);
 
         // Act
-        using var view = JsonArrayTreeView.Create(stubIndexer, () => { }, SynchronousUiThreadInvoke);
+        using var view = JsonArrayTreeView.Create(stubIndexer, () => { }, _ => { }, SynchronousUiThreadInvoke);
 
         // Assert — no nodes yet (TotalRows = 0)
         var objectsEmpty = view.Objects;
@@ -287,7 +303,7 @@ public sealed partial class JsonArrayTreeViewTests
 
         // Act — Create enters the in-progress branch (first check = false),
         // subscribes to events, then TOCTOU check finds completed → manual _completedHandler
-        using var view = JsonArrayTreeView.Create(stubIndexer, () => { }, SynchronousUiThreadInvoke);
+        using var view = JsonArrayTreeView.Create(stubIndexer, () => { }, _ => { }, SynchronousUiThreadInvoke);
 
         // Assert — TOCTOU path uses AddNodesBatch which creates 1 range node (count=3)
         var objects = view.Objects;
@@ -309,7 +325,7 @@ public sealed partial class JsonArrayTreeViewTests
         var stubIndexer = new StubRowIndexer(realIndexer, 0, fakeIsCompleted: false);
 
         // Act
-        using var view = JsonArrayTreeView.Create(stubIndexer, () => { }, SynchronousUiThreadInvoke);
+        using var view = JsonArrayTreeView.Create(stubIndexer, () => { }, _ => { }, SynchronousUiThreadInvoke);
 
         // Simulate progressive loading — 3500 elements indexed so far
         stubIndexer.UpdateTotalRows(3500);
@@ -345,7 +361,7 @@ public sealed partial class JsonArrayTreeViewTests
         var stubIndexer = new StubRowIndexer(realIndexer, 0, fakeIsCompleted: false);
 
         // Act
-        using var view = JsonArrayTreeView.Create(stubIndexer, () => { }, SynchronousUiThreadInvoke);
+        using var view = JsonArrayTreeView.Create(stubIndexer, () => { }, _ => { }, SynchronousUiThreadInvoke);
 
         // Assert — successive progress fires advance the count without duplicating
         stubIndexer.UpdateTotalRows(3000);
@@ -376,7 +392,7 @@ public sealed partial class JsonArrayTreeViewTests
         var stubIndexer = new StubRowIndexer(realIndexer, 0, fakeIsCompleted: false);
 
         // Act
-        using var view = JsonArrayTreeView.Create(stubIndexer, () => { }, SynchronousUiThreadInvoke);
+        using var view = JsonArrayTreeView.Create(stubIndexer, () => { }, _ => { }, SynchronousUiThreadInvoke);
 
         stubIndexer.UpdateTotalRows(3500);
         stubIndexer.RaiseProgressChanged(0, stubIndexer.FileSize);
@@ -403,7 +419,7 @@ public sealed partial class JsonArrayTreeViewTests
         var realIndexer = new RowIndexer(filePath);
         realIndexer.BuildIndex();
         var stubIndexer = new StubRowIndexer(realIndexer, 0, fakeIsCompleted: false);
-        using var view = JsonArrayTreeView.Create(stubIndexer, () => { }, SynchronousUiThreadInvoke);
+        using var view = JsonArrayTreeView.Create(stubIndexer, () => { }, _ => { }, SynchronousUiThreadInvoke);
 
         stubIndexer.UpdateTotalRows(3000);
         stubIndexer.RaiseProgressChanged(0, stubIndexer.FileSize);
@@ -434,7 +450,7 @@ public sealed partial class JsonArrayTreeViewTests
         var stubIndexer = new StubRowIndexer(realIndexer, 0, fakeIsCompleted: false);
 
         // Act
-        using var view = JsonArrayTreeView.Create(stubIndexer, () => { }, SynchronousUiThreadInvoke);
+        using var view = JsonArrayTreeView.Create(stubIndexer, () => { }, _ => { }, SynchronousUiThreadInvoke);
 
         stubIndexer.UpdateTotalRows(3000);
         stubIndexer.RaiseProgressChanged(0, stubIndexer.FileSize);

--- a/tests/DataMorph.Tests/App/Views/JsonArrayTreeViewTests.cs
+++ b/tests/DataMorph.Tests/App/Views/JsonArrayTreeViewTests.cs
@@ -55,7 +55,7 @@ public sealed partial class JsonArrayTreeViewTests : IDisposable
         using var app = CreateTestApp();
         var indexer = new RowIndexer(filePath);
         indexer.BuildIndex();
-        using var view = JsonArrayTreeView.Create(indexer, () => { }, SynchronousUiThreadInvoke);
+        using var view = JsonArrayTreeView.Create(indexer, () => { }, _ => { }, SynchronousUiThreadInvoke);
         var objects = view.Objects;
         objects.Should().NotBeNull();
         var elementNode = objects.First();
@@ -77,7 +77,7 @@ public sealed partial class JsonArrayTreeViewTests : IDisposable
         var realIndexer = new RowIndexer(filePath);
         realIndexer.BuildIndex();
         var stubIndexer = new StubRowIndexer(realIndexer, 0, fakeIsCompleted: false);
-        using var view = JsonArrayTreeView.Create(stubIndexer, () => { }, SynchronousUiThreadInvoke);
+        using var view = JsonArrayTreeView.Create(stubIndexer, () => { }, _ => { }, SynchronousUiThreadInvoke);
 
         // Act — simulate progress, then dispose
         stubIndexer.UpdateTotalRows(3000);
@@ -102,7 +102,7 @@ public sealed partial class JsonArrayTreeViewTests : IDisposable
         using var app = CreateTestApp();
         var indexer = new RowIndexer(filePath);
         indexer.BuildIndex();
-        using var view = JsonArrayTreeView.Create(indexer, () => { }, SynchronousUiThreadInvoke);
+        using var view = JsonArrayTreeView.Create(indexer, () => { }, _ => { }, SynchronousUiThreadInvoke);
 
         // Act & Assert — Dispose on fast-path view should not throw
         var act = () => view.Dispose();

--- a/tests/DataMorph.Tests/App/Views/JsonLinesTreeViewTests.Create.cs
+++ b/tests/DataMorph.Tests/App/Views/JsonLinesTreeViewTests.Create.cs
@@ -14,7 +14,7 @@ public sealed partial class JsonLinesTreeViewTests
         using var app = CreateTestApp();
 
         // Act
-        var act = () => JsonLinesTreeView.Create(null!, () => { }, SynchronousUiThreadInvoke);
+        var act = () => JsonLinesTreeView.Create(null!, () => { }, _ => { }, SynchronousUiThreadInvoke);
 
         // Assert
         act.Should().Throw<ArgumentNullException>();
@@ -30,7 +30,7 @@ public sealed partial class JsonLinesTreeViewTests
         indexer.BuildIndex();
 
         // Act
-        var act = () => JsonLinesTreeView.Create(indexer, null!, SynchronousUiThreadInvoke);
+        var act = () => JsonLinesTreeView.Create(indexer, null!, _ => { }, SynchronousUiThreadInvoke);
 
         // Assert
         act.Should().Throw<ArgumentNullException>();
@@ -46,7 +46,23 @@ public sealed partial class JsonLinesTreeViewTests
         indexer.BuildIndex();
 
         // Act
-        var act = () => JsonLinesTreeView.Create(indexer, () => { }, null!);
+        var act = () => JsonLinesTreeView.Create(indexer, () => { }, _ => { }, null!);
+
+        // Assert
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void Create_WithNullOnPathChanged_ThrowsArgumentNullException()
+    {
+        // Arrange
+        using var app = CreateTestApp();
+        var filePath = CreateTempFile("{\"a\":1}");
+        var indexer = new RowIndexer(filePath);
+        indexer.BuildIndex();
+
+        // Act
+        var act = () => JsonLinesTreeView.Create(indexer, () => { }, null!, SynchronousUiThreadInvoke);
 
         // Assert
         act.Should().Throw<ArgumentNullException>();
@@ -62,7 +78,7 @@ public sealed partial class JsonLinesTreeViewTests
         indexer.BuildIndex();
 
         // Act
-        using var view = JsonLinesTreeView.Create(indexer, () => { }, SynchronousUiThreadInvoke);
+        using var view = JsonLinesTreeView.Create(indexer, () => { }, _ => { }, SynchronousUiThreadInvoke);
 
         // Assert
         var objects = view.Objects;
@@ -84,7 +100,7 @@ public sealed partial class JsonLinesTreeViewTests
         indexer.BuildIndex();
 
         // Act
-        using var view = JsonLinesTreeView.Create(indexer, () => { }, SynchronousUiThreadInvoke);
+        using var view = JsonLinesTreeView.Create(indexer, () => { }, _ => { }, SynchronousUiThreadInvoke);
 
         // Assert
         var objects = view.Objects;
@@ -106,7 +122,7 @@ public sealed partial class JsonLinesTreeViewTests
         indexer.BuildIndex();
 
         // Act
-        using var view = JsonLinesTreeView.Create(indexer, () => { }, SynchronousUiThreadInvoke);
+        using var view = JsonLinesTreeView.Create(indexer, () => { }, _ => { }, SynchronousUiThreadInvoke);
 
         // Assert
         var objects = view.Objects;
@@ -128,7 +144,7 @@ public sealed partial class JsonLinesTreeViewTests
         indexer.BuildIndex();
 
         // Act
-        using var view = JsonLinesTreeView.Create(indexer, () => { }, SynchronousUiThreadInvoke);
+        using var view = JsonLinesTreeView.Create(indexer, () => { }, _ => { }, SynchronousUiThreadInvoke);
 
         // Assert
         var objects = view.Objects;
@@ -151,7 +167,7 @@ public sealed partial class JsonLinesTreeViewTests
         var stubIndexer = new StubRowIndexer(realIndexer, 0);
 
         // Act
-        using var view = JsonLinesTreeView.Create(stubIndexer, () => { }, SynchronousUiThreadInvoke);
+        using var view = JsonLinesTreeView.Create(stubIndexer, () => { }, _ => { }, SynchronousUiThreadInvoke);
 
         // Assert
         var objects = view.Objects;
@@ -171,7 +187,7 @@ public sealed partial class JsonLinesTreeViewTests
         var stubIndexer = new StubRowIndexer(realIndexer, 3);
 
         // Act
-        using var view = JsonLinesTreeView.Create(stubIndexer, () => { }, SynchronousUiThreadInvoke);
+        using var view = JsonLinesTreeView.Create(stubIndexer, () => { }, _ => { }, SynchronousUiThreadInvoke);
 
         // Assert — only 2 nodes added (Empty for index 2 is skipped)
         var objects = view.Objects;
@@ -191,7 +207,7 @@ public sealed partial class JsonLinesTreeViewTests
         indexer.BuildIndex();
 
         // Act
-        using var view = JsonLinesTreeView.Create(indexer, () => { }, SynchronousUiThreadInvoke);
+        using var view = JsonLinesTreeView.Create(indexer, () => { }, _ => { }, SynchronousUiThreadInvoke);
 
         // Assert — IsIndexingCompleted is true, TotalRows=2500, range nodes
         var objects = view.Objects;
@@ -213,7 +229,7 @@ public sealed partial class JsonLinesTreeViewTests
         var stubIndexer = new StubRowIndexer(realIndexer, 5000, fakeIsCompleted: true, fakeFileSize: 200_000_000);
 
         // Act
-        using var view = JsonLinesTreeView.Create(stubIndexer, () => { }, SynchronousUiThreadInvoke);
+        using var view = JsonLinesTreeView.Create(stubIndexer, () => { }, _ => { }, SynchronousUiThreadInvoke);
 
         // Assert — 3 range nodes: [1-2000], [2001-4000], [4001-5000]
         var objects = view.Objects;
@@ -237,7 +253,7 @@ public sealed partial class JsonLinesTreeViewTests
         var stubIndexer = new StubRowIndexer(realIndexer, 0, fakeIsCompleted: false);
 
         // Act
-        using var view = JsonLinesTreeView.Create(stubIndexer, () => { }, SynchronousUiThreadInvoke);
+        using var view = JsonLinesTreeView.Create(stubIndexer, () => { }, _ => { }, SynchronousUiThreadInvoke);
 
         // Assert — no nodes yet (TotalRows = 0)
         var objectsEmpty = view.Objects;
@@ -268,7 +284,7 @@ public sealed partial class JsonLinesTreeViewTests
         indexer.BuildIndex();
 
         // Act
-        using var view = JsonLinesTreeView.Create(indexer, () => { }, SynchronousUiThreadInvoke);
+        using var view = JsonLinesTreeView.Create(indexer, () => { }, _ => { }, SynchronousUiThreadInvoke);
 
         // Assert — DelegateTreeBuilder prevents eager loading via AddObject()
         var objects = view.Objects;
@@ -290,7 +306,7 @@ public sealed partial class JsonLinesTreeViewTests
 
         // Act — Create enters the in-progress branch (first check = false),
         // subscribes to events, then TOCTOU check finds completed → manual _completedHandler
-        using var view = JsonLinesTreeView.Create(stubIndexer, () => { }, SynchronousUiThreadInvoke);
+        using var view = JsonLinesTreeView.Create(stubIndexer, () => { }, _ => { }, SynchronousUiThreadInvoke);
 
         // Assert — TOCTOU path uses AddNodesBatch which creates 1 range node (count=3)
         // because totalRows=3 < nodeGroupSize=1000 → remainder node only
@@ -313,7 +329,7 @@ public sealed partial class JsonLinesTreeViewTests
         var stubIndexer = new StubRowIndexer(realIndexer, 0, fakeIsCompleted: false);
 
         // Act
-        using var view = JsonLinesTreeView.Create(stubIndexer, () => { }, SynchronousUiThreadInvoke);
+        using var view = JsonLinesTreeView.Create(stubIndexer, () => { }, _ => { }, SynchronousUiThreadInvoke);
 
         // Simulate progressive loading — 3500 rows indexed so far
         stubIndexer.UpdateTotalRows(3500);
@@ -349,7 +365,7 @@ public sealed partial class JsonLinesTreeViewTests
         var stubIndexer = new StubRowIndexer(realIndexer, 0, fakeIsCompleted: false);
 
         // Act
-        using var view = JsonLinesTreeView.Create(stubIndexer, () => { }, SynchronousUiThreadInvoke);
+        using var view = JsonLinesTreeView.Create(stubIndexer, () => { }, _ => { }, SynchronousUiThreadInvoke);
 
         // Assert — successive progress fires advance the count without duplicating
         stubIndexer.UpdateTotalRows(3000);
@@ -380,7 +396,7 @@ public sealed partial class JsonLinesTreeViewTests
         var stubIndexer = new StubRowIndexer(realIndexer, 0, fakeIsCompleted: false);
 
         // Act
-        using var view = JsonLinesTreeView.Create(stubIndexer, () => { }, SynchronousUiThreadInvoke);
+        using var view = JsonLinesTreeView.Create(stubIndexer, () => { }, _ => { }, SynchronousUiThreadInvoke);
 
         stubIndexer.UpdateTotalRows(3500);
         stubIndexer.RaiseProgressChanged(0, stubIndexer.FileSize);
@@ -407,7 +423,7 @@ public sealed partial class JsonLinesTreeViewTests
         var realIndexer = new RowIndexer(filePath);
         realIndexer.BuildIndex();
         var stubIndexer = new StubRowIndexer(realIndexer, 0, fakeIsCompleted: false);
-        using var view = JsonLinesTreeView.Create(stubIndexer, () => { }, SynchronousUiThreadInvoke);
+        using var view = JsonLinesTreeView.Create(stubIndexer, () => { }, _ => { }, SynchronousUiThreadInvoke);
 
         stubIndexer.UpdateTotalRows(3000);
         stubIndexer.RaiseProgressChanged(0, stubIndexer.FileSize);
@@ -438,7 +454,7 @@ public sealed partial class JsonLinesTreeViewTests
         var stubIndexer = new StubRowIndexer(realIndexer, 0, fakeIsCompleted: false);
 
         // Act
-        using var view = JsonLinesTreeView.Create(stubIndexer, () => { }, SynchronousUiThreadInvoke);
+        using var view = JsonLinesTreeView.Create(stubIndexer, () => { }, _ => { }, SynchronousUiThreadInvoke);
 
         stubIndexer.UpdateTotalRows(3000);
         stubIndexer.RaiseProgressChanged(0, stubIndexer.FileSize);

--- a/tests/DataMorph.Tests/App/Views/JsonLinesTreeViewTests.Create.cs
+++ b/tests/DataMorph.Tests/App/Views/JsonLinesTreeViewTests.Create.cs
@@ -1,6 +1,7 @@
 using AwesomeAssertions;
 using DataMorph.App.Views;
 using DataMorph.App.Views.JsonRangeTreeNodes;
+using DataMorph.Engine.IO.DrillDown;
 using DataMorph.Engine.IO.JsonLines;
 
 namespace DataMorph.Tests.App.Views;
@@ -66,6 +67,30 @@ public sealed partial class JsonLinesTreeViewTests
 
         // Assert
         act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void Create_OnSelectionChanged_InvokesOnPathChangedWithExpectedKeyPath()
+    {
+        // Arrange
+        var filePath = CreateTempFile("{\"a\":1}");
+        using var app = CreateTestApp();
+        var indexer = new RowIndexer(filePath);
+        indexer.BuildIndex();
+        List<IReadOnlyList<KeyPathSegment>> observedPaths = [];
+        using var view = JsonLinesTreeView.Create(
+            indexer, () => { }, path => observedPaths.Add(path), SynchronousUiThreadInvoke);
+        var objects = view.Objects;
+        objects.Should().NotBeNull();
+        var lineNode = objects.First();
+        var childNode = lineNode.Children.First();
+
+        // Act
+        view.SelectedObject = childNode;
+
+        // Assert
+        observedPaths.Should().ContainSingle();
+        observedPaths[0].Should().Equal(new KeyPathSegment("a", KeyPathSegmentKind.Key));
     }
 
     [Fact]

--- a/tests/DataMorph.Tests/App/Views/JsonLinesTreeViewTests.cs
+++ b/tests/DataMorph.Tests/App/Views/JsonLinesTreeViewTests.cs
@@ -56,7 +56,7 @@ public sealed partial class JsonLinesTreeViewTests : IDisposable
         using var app = CreateTestApp();
         var indexer = new RowIndexer(filePath);
         indexer.BuildIndex();
-        using var view = JsonLinesTreeView.Create(indexer, () => { }, SynchronousUiThreadInvoke);
+        using var view = JsonLinesTreeView.Create(indexer, () => { }, _ => { }, SynchronousUiThreadInvoke);
         var objects = view.Objects;
         objects.Should().NotBeNull();
         var lineNode = objects.First();
@@ -78,7 +78,7 @@ public sealed partial class JsonLinesTreeViewTests : IDisposable
         var realIndexer = new RowIndexer(filePath);
         realIndexer.BuildIndex();
         var stubIndexer = new StubRowIndexer(realIndexer, 0, fakeIsCompleted: false);
-        using var view = JsonLinesTreeView.Create(stubIndexer, () => { }, SynchronousUiThreadInvoke);
+        using var view = JsonLinesTreeView.Create(stubIndexer, () => { }, _ => { }, SynchronousUiThreadInvoke);
 
         // Act — simulate progress, then dispose
         stubIndexer.UpdateTotalRows(3000);
@@ -103,7 +103,7 @@ public sealed partial class JsonLinesTreeViewTests : IDisposable
         using var app = CreateTestApp();
         var indexer = new RowIndexer(filePath);
         indexer.BuildIndex();
-        using var view = JsonLinesTreeView.Create(indexer, () => { }, SynchronousUiThreadInvoke);
+        using var view = JsonLinesTreeView.Create(indexer, () => { }, _ => { }, SynchronousUiThreadInvoke);
 
         // Act & Assert — Dispose on fast-path view should not throw
         var act = () => view.Dispose();

--- a/tests/DataMorph.Tests/App/Views/JsonObjectTreeViewTests.cs
+++ b/tests/DataMorph.Tests/App/Views/JsonObjectTreeViewTests.cs
@@ -111,7 +111,7 @@ public sealed class JsonObjectTreeViewTests : IDisposable
         IReadOnlyList<(string key, JsonRawBytes value)> nullEntries = null!;
 
         // Act
-        var act = () => JsonObjectTreeView.Create(nullEntries, () => { });
+        var act = () => JsonObjectTreeView.Create(nullEntries, () => { }, _ => { });
 
         // Assert
         act.Should().Throw<ArgumentNullException>();
@@ -124,7 +124,20 @@ public sealed class JsonObjectTreeViewTests : IDisposable
         IReadOnlyList<(string key, JsonRawBytes value)> entries = [];
 
         // Act
-        var act = () => JsonObjectTreeView.Create(entries, null!);
+        var act = () => JsonObjectTreeView.Create(entries, null!, _ => { });
+
+        // Assert
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void Create_WithNullOnPathChanged_ThrowsArgumentNullException()
+    {
+        // Arrange
+        IReadOnlyList<(string key, JsonRawBytes value)> entries = [];
+
+        // Act
+        var act = () => JsonObjectTreeView.Create(entries, () => { }, null!);
 
         // Assert
         act.Should().Throw<ArgumentNullException>();
@@ -137,7 +150,7 @@ public sealed class JsonObjectTreeViewTests : IDisposable
         IReadOnlyList<(string key, JsonRawBytes value)> entries = [];
 
         // Act
-        using var view = JsonObjectTreeView.Create(entries, () => { });
+        using var view = JsonObjectTreeView.Create(entries, () => { }, _ => { });
 
         // Assert
         view.Objects.Should().BeEmpty();
@@ -155,7 +168,7 @@ public sealed class JsonObjectTreeViewTests : IDisposable
         ];
 
         // Act
-        using var view = JsonObjectTreeView.Create(entries, () => { });
+        using var view = JsonObjectTreeView.Create(entries, () => { }, _ => { });
 
         // Assert
         view.Objects.Should().HaveCount(3);

--- a/tests/DataMorph.Tests/App/Views/JsonObjectTreeViewTests.cs
+++ b/tests/DataMorph.Tests/App/Views/JsonObjectTreeViewTests.cs
@@ -2,6 +2,7 @@ using System.Text;
 using AwesomeAssertions;
 using DataMorph.App.Views;
 using DataMorph.App.Views.JsonTreeNodes;
+using DataMorph.Engine.IO.DrillDown;
 using Terminal.Gui.App;
 using Terminal.Gui.Drivers;
 
@@ -154,6 +155,25 @@ public sealed class JsonObjectTreeViewTests : IDisposable
 
         // Assert
         view.Objects.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Create_OnSelectionChanged_InvokesOnPathChangedWithExpectedKeyPath()
+    {
+        // Arrange
+        IReadOnlyList<(string key, JsonRawBytes value)> entries = [("data", ToBytes("{\"a\":1}"))];
+        List<IReadOnlyList<KeyPathSegment>> observedPaths = [];
+        using var view = JsonObjectTreeView.Create(entries, () => { }, path => observedPaths.Add(path));
+        var objects = view.Objects;
+        objects.Should().NotBeNull();
+        var node = objects.First();
+
+        // Act
+        view.SelectedObject = node;
+
+        // Assert
+        observedPaths.Should().ContainSingle();
+        observedPaths[0].Should().Equal(new KeyPathSegment("data", KeyPathSegmentKind.Key));
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Add `BreadcrumbBar` showing the current JSON hierarchy location below the MenuBar, live-updating in Tree modes and static in FocusedTable (DrillDown result)
- New `KeyPathBuilder`/`KeyPathFormatter` (`" > "`-separated, `[*]` for Full Aggregation DrillDown, no `"root"` prefix on non-empty paths — see ADR 1 in the design doc)
- Blank breadcrumb (not `"root"`) for modes with no JSON hierarchy: CSV table, JSON Lines/Array table view, file selection

## Out of scope (deferred, documented in `docs/design_breadcrumb_navigation.md`)
- Click/keyboard navigation to jump the Tree selection to an ancestor breadcrumb segment — unclear use case in a keyboard-driven TUI; tracked as a future issue if there's real demand

## Test plan
- [x] `dotnet format --verify-no-changes`
- [x] `dotnet build` (0 Warning / 0 Error)
- [x] `dotnet test` (1464 passed / 0 failed)
- [x] Manual verification: Tree navigation updates breadcrumb live; DrillDown (Phase 1 and Full Aggregation) shows static path with correct index collapsing; switching to CSV/JSON Lines table/file selection blanks the breadcrumb instead of showing a misleading path

Closes #54