### PR TITLE
feat: DrillDown Backspace navigation

### DIFF
--- a/docs/design_drilldown_backspace_navigation.md
+++ b/docs/design_drilldown_backspace_navigation.md
@@ -47,20 +47,52 @@ load and never cleared while that file stays open. `JsonObjectTree`, however, is
 `JsonObjectTree` would require re-running `TopLevelScanner.Scan` against the file (an extra async
 file read) purely to reconstruct a view the app already built once this session.
 
-`AppState` gains one field, cached the same way `RowIndexer` is:
+### 3.1 Element Type: `JsonObjectEntry`, Not a Bare `ValueTuple`
+
+`TopLevelScanner.Scan`'s existing return type, `IReadOnlyList<(string key, JsonRawBytes value)>`,
+is a reasonable shape for a value passed once from a scan to its single caller
+(`SwitchToJsonObjectTree`). Caching it on `AppState`, however, promotes it to a long-lived,
+app-wide domain concept — the same promotion `RowIndexer` already went through — and an unnamed,
+transient tuple shape is not an appropriate type for that role.
+
+**Decision:** introduce a dedicated `readonly record struct JsonObjectEntry(string Key, JsonRawBytes Value)`
+in `Engine.IO.JsonObject` (alongside `TopLevelScanner`, same layer) and use it everywhere this shape
+flows, not just on `AppState`:
+
+```csharp
+/// <summary>A single top-level key/value pair from a JSON Object file, as scanned by <see cref="TopLevelScanner"/>.</summary>
+public readonly record struct JsonObjectEntry(string Key, JsonRawBytes Value);
+```
+
+`record struct` (not a `class`), and `readonly`, briefly: (1) `JsonObjectEntry` is a `struct`, not a
+`class`, keeping the same inline-storage characteristics the existing `ValueTuple` shape already
+has — making it a `class` instead would move each cached entry to the heap individually, adding
+GC-tracked allocations that don't exist today; (2) per the project's immutability standard
+(`.claude/rules/csharp-standards.md`: "Mutable fields and mutable properties require
+justification"), state living on `AppState` should be immutable by default, and there is no
+justification for mutability here.
+
+- `TopLevelScanner.Scan` returns `IReadOnlyList<JsonObjectEntry>` instead of the bare tuple.
+- `JsonObjectTreeView` and `ViewManager.SwitchToJsonObjectTree` take `IReadOnlyList<JsonObjectEntry>`.
+- `AppState.JsonObjectEntries` is `IReadOnlyList<JsonObjectEntry>?`, cached the same way `RowIndexer` is:
 
 ```csharp
 /// <summary>
 /// Gets or sets the cached top-level entries for JSON Object tree reconstruction.
 /// Set once at file load for <see cref="DataFormat.JsonObject"/> files; null for all other formats.
 /// </summary>
-public IReadOnlyList<(string key, JsonRawBytes value)>? JsonObjectEntries { get; set; }
+public IReadOnlyList<JsonObjectEntry>? JsonObjectEntries { get; set; }
 ```
 
 `FileDialogHandler.HandleFileSelectedAsync` resets it to `null` in the existing "Reset state for
 new file" block (alongside `_state.DrillDown = null;`), and sets it in the existing
 `DataFormat.JsonObject` branch right where `_state.CurrentMode = ViewMode.JsonObjectTree;` is set
 today.
+
+Changing the existing `Scan` signature (rather than introducing the struct only for the new
+`AppState` field and converting at the boundary) keeps exactly one shape for this data instead of
+two, and avoids allocating a converted copy purely to satisfy a type mismatch. This widens the
+touched-file set beyond what Backspace navigation alone would require (see §8).
 
 **Alternative considered and rejected:** re-run `TopLevelScanner.Scan` on `Backspace` instead of
 caching, avoiding the extra `AppState` field entirely. Rejected — caching costs one small in-memory
@@ -259,22 +291,38 @@ to a tree node, storing it here would have no consumer).
 - `AppStateTests.cs` — extend for `JsonObjectEntries` default (`null`).
 - `FileDialogHandlerTests.cs` — extend: `JsonObjectEntries` is populated for `DataFormat.JsonObject`
   and reset to `null` for every other format.
+- `TopLevelScannerTests.cs` / `TopLevelScannerTests.Scan.cs` — update existing assertions from
+  tuple construction/comparison to `JsonObjectEntry` construction/comparison; no new test cases,
+  same coverage against the new element type.
+- `JsonObjectTreeViewTests.cs` — same signature-only update (tuple → `JsonObjectEntry`).
 
 ## 8. Files Touched
 
-**Modified (no new files):**
-- `src/App/AppState.cs` — add `JsonObjectEntries`
+**Modified:**
+- `src/App/AppState.cs` — add `JsonObjectEntries` (`IReadOnlyList<JsonObjectEntry>?`)
 - `src/App/DrillDownState.cs` — add `PreviousMode`
 - `src/App/ModeController.cs` — capture `PreviousMode` in `DrillDown` and
   `FullAggregationDrillDownAsync`
-- `src/App/ViewManager.cs` — add `ReturnFromDrillDown()`, `Backspace` status bar hint
+- `src/App/ViewManager.cs` — add `ReturnFromDrillDown()`, `Backspace` status bar hint,
+  `SwitchToJsonObjectTree` parameter type → `IReadOnlyList<JsonObjectEntry>`
 - `src/App/AppKeyHandler.cs` — add `HandleDrillDownBack()`, wire `Backspace` into
   `OnGlobalKeyDown` and `IsGlobalShortcut`
 - `src/App/FileDialogHandler.cs` — reset/populate `JsonObjectEntries`
 - `src/App/Views/Dialogs/HelpDialog.cs` — add `Backspace` line to help text
+- `src/App/Views/JsonObjectTreeView.cs` — parameter type → `IReadOnlyList<JsonObjectEntry>`
+- `src/Engine/IO/JsonObject/TopLevelScanner.cs` — element type swapped throughout, not just the
+  `Scan` return type: `List<(string key, JsonRawBytes value)> result` → `List<JsonObjectEntry>`,
+  threaded through `ProcessToken`/`RecordEntry`, and both tuple-literal construction sites
+  (`result.Add((key, mem))`, `result[idx] = (key, mem)`) → `new JsonObjectEntry(key, mem)`
 - `tests/DataMorph.Tests/App/ModeControllerTests.cs`
 - `tests/DataMorph.Tests/App/ViewManagerTests.cs`
 - `tests/DataMorph.Tests/App/AppKeyHandlerTests.cs`
 - `tests/DataMorph.Tests/App/AppStateTests.cs`
 - `tests/DataMorph.Tests/App/FileDialogHandlerTests.cs`
 - `tests/DataMorph.Tests/App/Views/Dialogs/HelpDialogTests.cs`
+- `tests/DataMorph.Tests/App/Views/JsonObjectTreeViewTests.cs`
+- `tests/DataMorph.Tests/Engine/IO/JsonObject/TopLevelScannerTests.cs`
+- `tests/DataMorph.Tests/Engine/IO/JsonObject/TopLevelScannerTests.Scan.cs`
+
+**New:**
+- `src/Engine/IO/JsonObject/JsonObjectEntry.cs` — `readonly record struct JsonObjectEntry(string Key, JsonRawBytes Value)`

--- a/docs/design_drilldown_backspace_navigation.md
+++ b/docs/design_drilldown_backspace_navigation.md
@@ -1,0 +1,280 @@
+# DrillDown Backspace Navigation — Design Document
+
+## Scope
+
+After a DrillDown (Single or Full Aggregation) switches the app to `ViewMode.FocusedTable`, there
+is currently no way back to the tree view that triggered it short of reopening the file. This adds
+`Backspace` in `FocusedTable` mode to return to the originating tree mode.
+
+**In scope:** single-level back navigation — `FocusedTable` → the one tree mode (`JsonLinesTree`,
+`JsonArrayTree`, or `JsonObjectTree`) it was entered from.
+
+**Out of scope:**
+- Multi-level DrillDown history/stack (explicitly excluded by the issue).
+- Restoring the exact tree cursor position / scroll offset / expanded-node state the user left
+  behind (see Design §2 and ADR 2 for why).
+
+## 1. Existing Infrastructure (Reused)
+
+- `AppState.CurrentMode` / `ViewMode` — `src/App/AppState.cs`, `src/App/ViewMode.cs`. DrillDown
+  entry points already read `_state.CurrentMode` immediately before overwriting it with
+  `ViewMode.FocusedTable` (`ModeController.DrillDown`, `ViewManager.FullAggregationDrillDownAsync`).
+- `AppState.RowIndexer` — already persisted across mode switches (this is what lets `t` toggle
+  JSON Lines Tree ⇄ Table without re-scanning). Reusable as-is for returning to `JsonLinesTree` /
+  `JsonArrayTree`.
+- `ViewManager.SwitchToJsonLinesTree(indexer)` / `SwitchToJsonArrayTree(indexer)` /
+  `SwitchToJsonObjectTree(entries)` — each rebuilds the tree view from scratch and resets the
+  breadcrumb to `[]` (root). Reused unchanged as the "go back" mechanism.
+
+## 2. Gap: Tree Views Are Always Rebuilt From Scratch
+
+Every `SwitchTo*Tree` method calls `UpdateBreadcrumb([], collapseIndices: false)` and constructs a
+brand-new `TreeView`, discarding whatever selection/expansion state the previous instance had (this
+is also true today for the `t`-key Table→Tree toggle — going back to Tree already resets to root).
+There is no existing "select node by KeyPath" capability anywhere in the tree view layer.
+
+Given that, returning from `FocusedTable` via `Backspace` lands on the tree at its root, same as
+every other tree (re)construction path in the app today. See ADR 2.
+
+## 3. Gap: `JsonObjectTree` Has No Persisted Backing Data
+
+`JsonLinesTree`/`JsonArrayTree` can be rebuilt from `AppState.RowIndexer`, which is cached at file
+load and never cleared while that file stays open. `JsonObjectTree`, however, is built from
+`entries` (`IReadOnlyList<(string key, JsonRawBytes value)>`) returned by
+`Engine.IO.JsonObject.TopLevelScanner.Scan` — computed once in
+`FileDialogHandler.HandleFileSelectedAsync` and passed directly to
+`ViewManager.SwitchToJsonObjectTree`, never stored anywhere. Without caching it, returning to
+`JsonObjectTree` would require re-running `TopLevelScanner.Scan` against the file (an extra async
+file read) purely to reconstruct a view the app already built once this session.
+
+`AppState` gains one field, cached the same way `RowIndexer` is:
+
+```csharp
+/// <summary>
+/// Gets or sets the cached top-level entries for JSON Object tree reconstruction.
+/// Set once at file load for <see cref="DataFormat.JsonObject"/> files; null for all other formats.
+/// </summary>
+public IReadOnlyList<(string key, JsonRawBytes value)>? JsonObjectEntries { get; set; }
+```
+
+`FileDialogHandler.HandleFileSelectedAsync` resets it to `null` in the existing "Reset state for
+new file" block (alongside `_state.DrillDown = null;`), and sets it in the existing
+`DataFormat.JsonObject` branch right where `_state.CurrentMode = ViewMode.JsonObjectTree;` is set
+today.
+
+**Alternative considered and rejected:** re-run `TopLevelScanner.Scan` on `Backspace` instead of
+caching, avoiding the extra `AppState` field entirely. Rejected — caching costs one small in-memory
+list for the lifetime of an already-open file (the same tradeoff `RowIndexer` already makes), while
+re-scanning would add file I/O latency and async error handling to `Backspace` that every other
+`ReturnFromDrillDown` branch doesn't need (`JsonLinesTree`/`JsonArrayTree` are synchronous, reusing
+the already-cached `RowIndexer`). Caching keeps all three `PreviousMode` branches symmetric.
+
+## 4. Design: `DrillDownState.PreviousMode`
+
+`DrillDownState` gains one field recording which tree mode was active immediately before the
+switch to `FocusedTable`:
+
+```csharp
+internal sealed record DrillDownState(
+    IReadOnlyList<FocusedTableRow> Rows,
+    TableSchema Schema,
+    ViewMode PreviousMode);
+```
+
+Populated at both DrillDown entry points, reading `_state.CurrentMode` before it is overwritten:
+
+- `ModeController.DrillDown(SingleDrillDownRequest)` — capture `_state.CurrentMode` right before
+  constructing `DrillDownState` / setting `CurrentMode = ViewMode.FocusedTable`.
+- `ModeController.FullAggregationDrillDownAsync(FullAggregationDrillDownRequest)` — capture
+  alongside the existing `filePath`/`ct` capture-before-`Task.Run` (same rationale already
+  documented inline: reading `_state` off the calling thread, not the thread-pool thread).
+  `CurrentMode` isn't set to `FocusedTable` inside this method today — that happens in
+  `ViewManager.FullAggregationDrillDownAsync` after the await — so it must be captured here, before
+  the background scan starts, while it's still the tree mode.
+
+`PreviousMode` lives and dies with the `DrillDownState` it's attached to, so it can never get out
+of sync with the DrillDown session it describes (see ADR 1).
+
+## 5. Design: Returning From `FocusedTable`
+
+New `ViewManager.ReturnFromDrillDown()`:
+
+```csharp
+internal void ReturnFromDrillDown()
+{
+    ObjectDisposedException.ThrowIf(_disposed, this);
+
+    if (_state.DrillDown is not { } drillDown)
+    {
+        return;
+    }
+
+    _state.DrillDown = null;
+
+    switch (drillDown.PreviousMode)
+    {
+        case ViewMode.JsonLinesTree when _state.RowIndexer is not null:
+            _state.CurrentMode = ViewMode.JsonLinesTree;
+            SwitchToJsonLinesTree(_state.RowIndexer);
+            break;
+
+        case ViewMode.JsonArrayTree when _state.RowIndexer is not null:
+            _state.CurrentMode = ViewMode.JsonArrayTree;
+            SwitchToJsonArrayTree(_state.RowIndexer);
+            break;
+
+        case ViewMode.JsonObjectTree when _state.JsonObjectEntries is not null:
+            _state.CurrentMode = ViewMode.JsonObjectTree;
+            SwitchToJsonObjectTree(_state.JsonObjectEntries);
+            break;
+
+        default:
+            throw new UnreachableException(
+                "DrillDownState.PreviousMode must be a tree mode with its backing data still cached on AppState.");
+    }
+}
+```
+
+`AppKeyHandler` wires `Backspace` the same way as the existing single-key shortcuts:
+
+```csharp
+private bool HandleDrillDownBack()
+{
+    if (_state.CurrentMode != ViewMode.FocusedTable || _state.DrillDown is null)
+    {
+        return false;
+    }
+
+    _viewManager.ReturnFromDrillDown();
+    return true;
+}
+```
+
+- Added to the `baseKey switch` in `OnGlobalKeyDown` alongside `O`/`S`/`Q`/`T`/`X`/`C`.
+- Added to `IsGlobalShortcut`'s key set, matching every other single-key global shortcut (this is
+  what lets `MorphTreeView`/`MorphTableView.OnKeyDown` yield to the global handler for this key;
+  `FocusedTableView` — a bare `MorphTableView` subclass with no Backspace handling of its own —
+  already benefits from this without any change to it).
+- Returns `false` (unhandled) outside `FocusedTable`, following the same conditional-return pattern
+  `HandleViewToggle`/`HandleActionMenu` already use — no new precedent.
+
+## 6. Discoverability: Status Bar Hint + Help Dialog
+
+`Backspace` must be discoverable the same way every other single-key shortcut already is — via the
+contextual status bar hints and the `?` help overlay. Both are updated:
+
+**`ViewManager.RefreshStatusBarHints()`** — add one more contextual hint, alongside the existing
+`t:Tree/Table`/`x:Menu`/`c:Clear` conditions:
+
+```csharp
+if (_state.CurrentMode == ViewMode.FocusedTable)
+{
+    hints.Add("bs:Back");
+}
+```
+
+Shown only while in `FocusedTable` (i.e. only when the shortcut actually does something), matching
+how `t:Tree/Table` and `x:Menu` are already gated to the modes where they apply. `bs` (not a Unicode
+glyph) was chosen to match the short-letter style of every other hint (`o`, `s`, `t`, `x`, `c`) and
+avoid terminal font rendering risk; the Help dialog spells it out in full (below) so the
+abbreviation's meaning isn't left ambiguous anywhere in the UI.
+
+**`HelpDialog.GetHelpText()`** — add one line under "Global / File Operations", next to the other
+single-key bindings:
+
+```
+Backspace : Return from DrillDown to the originating tree view (FocusedTable only)
+```
+
+## Architectural Decision Records (ADR)
+
+### ADR 1: `PreviousMode` Lives on `DrillDownState`, Not a Separate `AppState` Field
+
+**Status:** Accepted
+
+**Context:** The issue's own suggestion is "a 'previous mode' reference alongside
+`AppState.DrillDown`." Two placements were possible: a standalone `AppState.PreviousMode` field set
+whenever entering `FocusedTable`, or a field on `DrillDownState` itself.
+
+**Decision:** Add `PreviousMode` to `DrillDownState`.
+
+**Rationale:**
+1. **Lifecycle correctness.** `DrillDownState` and "which mode to return to" are set at the exact
+   same moment (DrillDown entry) and cleared at the exact same moment (`ReturnFromDrillDown`, or
+   any future point that clears `_state.DrillDown`). A separate `AppState` field could be forgotten
+   in one of those two places and silently drift out of sync with `DrillDown`; a field on the
+   record itself cannot, by construction — there is no code path that sets/clears one without the
+   other.
+2. **Matches an existing project precedent.** `docs/design_breadcrumb_navigation.md` explicitly
+   rejected adding new `AppState`/`DrillDownState` fields for "which DrillDown variant produced
+   this" in favor of deriving it at the call site — the general bias here is toward attaching
+   session-scoped data to the session's own record rather than scattering parallel `AppState`
+   fields that must be manually kept in sync.
+
+### ADR 2: Return to Tree Root, Do Not Restore Cursor/Scroll Position
+
+**Status:** Accepted
+
+**Context:** The issue notes recording "the originating `ViewMode` **or** tree cursor position" as
+one way to close the gap. Restoring the exact cursor would mean, on `Backspace`: finding the tree
+node matching a stored `KeyPath` inside a freshly rebuilt tree, expanding every ancestor on the
+path to make it reachable, then setting `SelectedObject` and scrolling it into view.
+
+**Decision:** Restore only `PreviousMode` (which tree, not where in it). Every `SwitchTo*Tree` call
+rebuilds fresh at root, same as it does today for the `t`-key Table→Tree toggle.
+
+**Rationale:**
+1. **No existing capability to build on.** Nothing in the tree view layer today supports "select
+   node by `KeyPath`" — trees are only ever built forward (root outward), never resolved backward
+   (path to node). Building this is a nontrivial addition (path resolution + ancestor expansion +
+   scroll-into-view) that doesn't exist for *any* other navigation flow in the app, DrillDown
+   included on the way in.
+2. **Root-return still fully solves the stated problem.** The issue is "there is no way to go
+   back... the only way out is reopening the file." Landing on the correct tree, at its root, is a
+   complete fix for that — the user is no longer stuck in `FocusedTable`, and re-navigating to the
+   same node from a known-good tree is far cheaper than reopening the file from scratch.
+3. **Consistent with how "going back" already behaves elsewhere.** The `t`-key toggle back to Tree
+   mode already discards cursor state; a user returning via `Backspace` sees the same reset-to-root
+   behavior they'd already get from `t`, rather than two different "return to tree" behaviors in
+   the same app.
+
+**Consequences:** A future issue could add KeyPath-based node resolution and restore the exact
+cursor; this design does not block that. `DrillDownState.PreviousMode` alone is enough for this
+issue's scope, so no `PreviousKeyPath` field is added now (`AppState.CurrentKeyPath` was
+considered — it holds the KeyPath at DrillDown entry — but with no way to resolve a `KeyPath` back
+to a tree node, storing it here would have no consumer).
+
+## 7. Testing
+
+- `ModeControllerTests.cs` — extend `DrillDown` tests to assert `DrillDownState.PreviousMode`
+  equals `CurrentMode` as it was *before* the call; extend `FullAggregationDrillDownAsync` tests
+  the same way.
+- `ViewManagerTests.cs` — new tests for `ReturnFromDrillDown()`: one per `PreviousMode` case
+  (`JsonLinesTree`/`JsonArrayTree` via `RowIndexer`, `JsonObjectTree` via `JsonObjectEntries`),
+  asserting `CurrentMode` is restored and `DrillDown` is cleared; a no-op case when `DrillDown` is
+  already `null`.
+- `AppKeyHandlerTests.cs` — new tests for `Backspace`: handled + delegates to
+  `ReturnFromDrillDown()` when `CurrentMode == FocusedTable`; unhandled (`false`) otherwise. Extend
+  the existing `IsGlobalShortcut` theory data with `KeyCode.Backspace`.
+- `AppStateTests.cs` — extend for `JsonObjectEntries` default (`null`).
+- `FileDialogHandlerTests.cs` — extend: `JsonObjectEntries` is populated for `DataFormat.JsonObject`
+  and reset to `null` for every other format.
+
+## 8. Files Touched
+
+**Modified (no new files):**
+- `src/App/AppState.cs` — add `JsonObjectEntries`
+- `src/App/DrillDownState.cs` — add `PreviousMode`
+- `src/App/ModeController.cs` — capture `PreviousMode` in `DrillDown` and
+  `FullAggregationDrillDownAsync`
+- `src/App/ViewManager.cs` — add `ReturnFromDrillDown()`, `Backspace` status bar hint
+- `src/App/AppKeyHandler.cs` — add `HandleDrillDownBack()`, wire `Backspace` into
+  `OnGlobalKeyDown` and `IsGlobalShortcut`
+- `src/App/FileDialogHandler.cs` — reset/populate `JsonObjectEntries`
+- `src/App/Views/Dialogs/HelpDialog.cs` — add `Backspace` line to help text
+- `tests/DataMorph.Tests/App/ModeControllerTests.cs`
+- `tests/DataMorph.Tests/App/ViewManagerTests.cs`
+- `tests/DataMorph.Tests/App/AppKeyHandlerTests.cs`
+- `tests/DataMorph.Tests/App/AppStateTests.cs`
+- `tests/DataMorph.Tests/App/FileDialogHandlerTests.cs`
+- `tests/DataMorph.Tests/App/Views/Dialogs/HelpDialogTests.cs`

--- a/src/App/AppKeyHandler.cs
+++ b/src/App/AppKeyHandler.cs
@@ -38,7 +38,7 @@ internal sealed class AppKeyHandler : IDisposable
     internal static bool IsGlobalShortcut(KeyCode keyCode)
     {
         var baseKey = keyCode & ~(KeyCode.ShiftMask | KeyCode.CtrlMask | KeyCode.AltMask);
-        return baseKey is KeyCode.O or KeyCode.S or KeyCode.Q or KeyCode.T or KeyCode.X or KeyCode.C or (KeyCode)'?';
+        return baseKey is KeyCode.O or KeyCode.S or KeyCode.Q or KeyCode.T or KeyCode.X or KeyCode.C or KeyCode.Backspace or (KeyCode)'?';
     }
 
     internal AppKeyHandler(
@@ -330,8 +330,16 @@ internal sealed class AppKeyHandler : IDisposable
     /// Handles back navigation from DrillDown (FocusedTable) via the Backspace key.
     /// </summary>
     /// <returns><c>true</c> if the key was handled; <c>false</c> otherwise.</returns>
-    private bool HandleDrillDownBack() =>
-        throw new NotImplementedException();
+    private bool HandleDrillDownBack()
+    {
+        if (_state.CurrentMode != ViewMode.FocusedTable || _state.DrillDown is null)
+        {
+            return false;
+        }
+
+        _viewManager.ReturnFromDrillDown();
+        return true;
+    }
 
     private void OnGlobalKeyDown(object? sender, Key key)
     {
@@ -354,7 +362,7 @@ internal sealed class AppKeyHandler : IDisposable
             current = current.SuperView;
         }
 
-        // Shortcuts like o, s, q, t, x should not have Ctrl or Alt modifiers.
+        // Shortcuts like o, s, q, t, x, Backspace should not have Ctrl or Alt modifiers.
         if ((key.KeyCode & (KeyCode.CtrlMask | KeyCode.AltMask)) != 0)
         {
             return;
@@ -369,6 +377,7 @@ internal sealed class AppKeyHandler : IDisposable
             KeyCode.T => HandleViewToggle(),
             KeyCode.X => HandleActionMenu(),
             KeyCode.C => HandleClearActions(),
+            KeyCode.Backspace => HandleDrillDownBack(),
             (KeyCode)'?' => HandleHelp(),
             _ => false,
         };

--- a/src/App/AppKeyHandler.cs
+++ b/src/App/AppKeyHandler.cs
@@ -326,6 +326,13 @@ internal sealed class AppKeyHandler : IDisposable
         return true;
     }
 
+    /// <summary>
+    /// Handles back navigation from DrillDown (FocusedTable) via the Backspace key.
+    /// </summary>
+    /// <returns><c>true</c> if the key was handled; <c>false</c> otherwise.</returns>
+    private bool HandleDrillDownBack() =>
+        throw new NotImplementedException();
+
     private void OnGlobalKeyDown(object? sender, Key key)
     {
         if (key.Handled)

--- a/src/App/AppState.cs
+++ b/src/App/AppState.cs
@@ -1,7 +1,9 @@
 using DataMorph.Engine.IO;
 using DataMorph.Engine.IO.DrillDown;
+using DataMorph.Engine.IO.JsonObject;
 using DataMorph.Engine.Models;
 using DataMorph.Engine.Models.Actions;
+using DataMorph.Engine.Types;
 
 namespace DataMorph.App;
 
@@ -64,6 +66,12 @@ internal sealed class AppState : IDisposable
     /// Null when not in FocusedTable mode.
     /// </summary>
     public DrillDownState? DrillDown { get; set; }
+
+    /// <summary>
+    /// Gets or sets the cached top-level entries for JSON Object tree reconstruction.
+    /// Set once at file load for <see cref="DataFormat.JsonObject"/> files; null for all other formats.
+    /// </summary>
+    public IReadOnlyList<JsonObjectEntry>? JsonObjectEntries { get; set; }
 
     /// <summary>
     /// Renews the cancellation token source by cancelling the current one and creating a new one.

--- a/src/App/DrillDownState.cs
+++ b/src/App/DrillDownState.cs
@@ -8,4 +8,5 @@ namespace DataMorph.App;
 /// </summary>
 internal sealed record DrillDownState(
     IReadOnlyList<FocusedTableRow> Rows,
-    TableSchema Schema);
+    TableSchema Schema,
+    ViewMode PreviousMode);

--- a/src/App/FileDialogHandler.cs
+++ b/src/App/FileDialogHandler.cs
@@ -61,6 +61,7 @@ internal sealed class FileDialogHandler(
         _state.ActionStack = [];
         _state.RenewCtsWithCancel();
         _state.DrillDown = null;
+        _state.JsonObjectEntries = null;
 
         // JSON Object: scan keys via TopLevelScanner, then switch to tree view directly.
         // No IRowIndexer is needed — keys are not rows.
@@ -79,6 +80,7 @@ internal sealed class FileDialogHandler(
                 _app.Invoke(() =>
                 {
                     _state.CurrentMode = ViewMode.JsonObjectTree;
+                    _state.JsonObjectEntries = entries;
                     _viewManager.SwitchToJsonObjectTree(entries);
                 });
             }

--- a/src/App/ModeController.cs
+++ b/src/App/ModeController.cs
@@ -112,7 +112,7 @@ internal sealed class ModeController
             rows[i] = new FocusedTableRow(children[i], $"[{i}]");
         }
 
-        _state.DrillDown = new DrillDownState(rows, result.Value.schema);
+        _state.DrillDown = new DrillDownState(rows, result.Value.schema, default);
         _state.CurrentMode = ViewMode.FocusedTable;
 
         return Results.Success();
@@ -141,6 +141,6 @@ internal sealed class ModeController
             return Results.Failure<DrillDownState>(result.Error);
         }
 
-        return Results.Success(new DrillDownState(result.Value.rows, result.Value.schema));
+        return Results.Success(new DrillDownState(result.Value.rows, result.Value.schema, default));
     }
 }

--- a/src/App/ModeController.cs
+++ b/src/App/ModeController.cs
@@ -112,7 +112,7 @@ internal sealed class ModeController
             rows[i] = new FocusedTableRow(children[i], $"[{i}]");
         }
 
-        _state.DrillDown = new DrillDownState(rows, result.Value.schema, default);
+        _state.DrillDown = new DrillDownState(rows, result.Value.schema, _state.CurrentMode);
         _state.CurrentMode = ViewMode.FocusedTable;
 
         return Results.Success();
@@ -131,6 +131,7 @@ internal sealed class ModeController
         // Capture by value before Task.Run to avoid reading _state on the thread-pool thread.
         var filePath = _state.CurrentFilePath;
         var ct = _state.Cts.Token;
+        var previousMode = _state.CurrentMode;
 
         var result = await Task.Run(
             () => FullAggregationScanner.Scan(filePath, request.Format, request.KeyPath, ct),
@@ -141,6 +142,6 @@ internal sealed class ModeController
             return Results.Failure<DrillDownState>(result.Error);
         }
 
-        return Results.Success(new DrillDownState(result.Value.rows, result.Value.schema, default));
+        return Results.Success(new DrillDownState(result.Value.rows, result.Value.schema, previousMode));
     }
 }

--- a/src/App/ViewManager.cs
+++ b/src/App/ViewManager.cs
@@ -5,6 +5,7 @@ using DataMorph.App.Views;
 using DataMorph.Engine.IO;
 using DataMorph.Engine.IO.DrillDown;
 using DataMorph.Engine.IO.JsonLines;
+using DataMorph.Engine.IO.JsonObject;
 using DataMorph.Engine.Models;
 using DataMorph.Engine.Models.Actions;
 using DataMorph.Engine.Types;
@@ -327,7 +328,7 @@ internal sealed class ViewManager : IDisposable
         Justification = "Child views are owned by the container and disposed via SwapView."
     )]
     internal void SwitchToJsonObjectTree(
-        IReadOnlyList<(string key, JsonRawBytes value)> entries)
+        IReadOnlyList<JsonObjectEntry> entries)
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
         ArgumentNullException.ThrowIfNull(entries);

--- a/src/App/ViewManager.cs
+++ b/src/App/ViewManager.cs
@@ -606,6 +606,14 @@ internal sealed class ViewManager : IDisposable
         RefreshStatusBarHints();
     }
 
+    /// <summary>
+    /// Returns from <see cref="ViewMode.FocusedTable"/> to the tree mode the active DrillDown was
+    /// entered from, rebuilding that tree from its cached backing data on <see cref="AppState"/>.
+    /// A no-op when there is no active DrillDown session.
+    /// </summary>
+    internal void ReturnFromDrillDown() =>
+        throw new NotImplementedException();
+
     /// <inheritdoc/>
     public void Dispose()
     {

--- a/src/App/ViewManager.cs
+++ b/src/App/ViewManager.cs
@@ -104,6 +104,11 @@ internal sealed class ViewManager : IDisposable
             {
                 hints.Add("c:Clear");
             }
+
+            if (_state.CurrentMode == ViewMode.FocusedTable)
+            {
+                hints.Add("bs:Back");
+            }
         }
 
         hints.Add("?:Help");
@@ -611,8 +616,39 @@ internal sealed class ViewManager : IDisposable
     /// entered from, rebuilding that tree from its cached backing data on <see cref="AppState"/>.
     /// A no-op when there is no active DrillDown session.
     /// </summary>
-    internal void ReturnFromDrillDown() =>
-        throw new NotImplementedException();
+    internal void ReturnFromDrillDown()
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+
+        if (_state.DrillDown is not { } drillDown)
+        {
+            return;
+        }
+
+        _state.DrillDown = null;
+
+        switch (drillDown.PreviousMode)
+        {
+            case ViewMode.JsonLinesTree when _state.RowIndexer is not null:
+                _state.CurrentMode = ViewMode.JsonLinesTree;
+                SwitchToJsonLinesTree(_state.RowIndexer);
+                break;
+
+            case ViewMode.JsonArrayTree when _state.RowIndexer is not null:
+                _state.CurrentMode = ViewMode.JsonArrayTree;
+                SwitchToJsonArrayTree(_state.RowIndexer);
+                break;
+
+            case ViewMode.JsonObjectTree when _state.JsonObjectEntries is not null:
+                _state.CurrentMode = ViewMode.JsonObjectTree;
+                SwitchToJsonObjectTree(_state.JsonObjectEntries);
+                break;
+
+            default:
+                throw new UnreachableException(
+                    "DrillDownState.PreviousMode must be a tree mode with its backing data still cached on AppState.");
+        }
+    }
 
     /// <inheritdoc/>
     public void Dispose()

--- a/src/App/Views/Dialogs/HelpDialog.cs
+++ b/src/App/Views/Dialogs/HelpDialog.cs
@@ -25,7 +25,7 @@ internal sealed class HelpDialog : Dialog
         X = Pos.Center();
         Y = Pos.Center();
         Width = Dim.Absolute(54);
-        Height = Dim.Absolute(32);
+        Height = Dim.Absolute(37);
 
         var helpText = new Label
         {
@@ -48,29 +48,32 @@ internal sealed class HelpDialog : Dialog
         return """
             Global / File Operations
             -------------------------
-            o       : Open File
-            s       : Save Recipe
-            q       : Quit
-            t       : Toggle Tree/Table View (JSON Lines)
-            x       : Context-Sensitive Action Menu
-            c       : Clear all actions from the stack
-            ?       : Help (this overlay)
+            o         : Open File
+            s         : Save Recipe
+            q         : Quit
+            t         : Toggle Tree/Table View (JSON Lines)
+            x         : Context-Sensitive Action Menu
+            c         : Clear all actions from the stack
+            ?         : Help (this overlay)
+            BackSpace : Return to originating tree view
+                        (FocusedTable only)
 
             Navigation
             ----------
-            h/j/k/l : Move Left/Down/Up/Right
-            gg      : Jump to first row
-            G       : Jump to last row
-            Enter   : Expand/Collapse (Tree View)
+            h/j/k/l   : Move Left/Down/Up/Right
+            gg        : Jump to first row
+            G         : Jump to last row
+            Enter     : Expand/Collapse (Tree View)
 
             Context Actions (via 'x' menu)
             ------------------------------
-            Rename  : Rename the current column
-            Delete  : Remove the current column
-            Cast    : Change column data type
-            Filter  : Add a filter based on current column
-            Fill    : Fill empty cells in column
-            Format  : Format timestamp columns
+            Rename    : Rename the current column
+            Delete    : Remove the current column
+            Cast      : Change column data type
+            Filter    : Add a filter based on current column
+            Fill      : Fill empty cells in column
+            Format    : Format timestamp columns
+            DrillDown : Drill into the selected node
             """;
     }
 

--- a/src/App/Views/JsonObjectTreeView.cs
+++ b/src/App/Views/JsonObjectTreeView.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using DataMorph.App.Views.JsonTreeNodes;
 using DataMorph.Engine.IO.DrillDown;
+using DataMorph.Engine.IO.JsonObject;
 using Terminal.Gui.Views;
 
 namespace DataMorph.App.Views;
@@ -27,7 +28,7 @@ internal sealed class JsonObjectTreeView : MorphTreeView
     /// <param name="onPathChanged">Callback invoked with the current selection's KeyPath whenever the cursor moves.</param>
     /// <returns>A populated <see cref="JsonObjectTreeView"/>.</returns>
     internal static JsonObjectTreeView Create(
-        IReadOnlyList<(string key, JsonRawBytes value)> entries,
+        IReadOnlyList<JsonObjectEntry> entries,
         Action onTableModeToggle,
         Action<IReadOnlyList<KeyPathSegment>> onPathChanged)
     {

--- a/src/Engine/IO/JsonObject/JsonObjectEntry.cs
+++ b/src/Engine/IO/JsonObject/JsonObjectEntry.cs
@@ -1,0 +1,4 @@
+namespace DataMorph.Engine.IO.JsonObject;
+
+/// <summary>A single top-level key/value pair from a JSON Object file, as scanned by <see cref="TopLevelScanner"/>.</summary>
+public readonly record struct JsonObjectEntry(string Key, JsonRawBytes Value);

--- a/src/Engine/IO/JsonObject/TopLevelScanner.cs
+++ b/src/Engine/IO/JsonObject/TopLevelScanner.cs
@@ -18,7 +18,7 @@ public sealed class TopLevelScanner
     /// <param name="filePath">Path to the JSON Object file.</param>
     /// <param name="ct">Cancellation token for cooperative cancellation.</param>
     /// <returns>A read-only list of key-value pairs with raw JSON bytes for each value.</returns>
-    public static IReadOnlyList<(string key, JsonRawBytes value)> Scan(
+    public static IReadOnlyList<JsonObjectEntry> Scan(
         string filePath,
         CancellationToken ct = default
     )
@@ -38,7 +38,7 @@ public sealed class TopLevelScanner
             var fileSize = RandomAccess.GetLength(handle);
             var state = new JsonScanState(fileSize);
             var rootCompleted = false;
-            List<(string key, JsonRawBytes value)> result = [];
+            List<JsonObjectEntry> result = [];
             var keyIndex = new Dictionary<string, int>();
 
             while (true)
@@ -109,7 +109,7 @@ public sealed class TopLevelScanner
         ref Utf8JsonReader reader,
         ref JsonScanState state,
         byte[] buffer,
-        List<(string key, JsonRawBytes value)> result,
+        List<JsonObjectEntry> result,
         Dictionary<string, int> keyIndex
     )
     {
@@ -183,7 +183,7 @@ public sealed class TopLevelScanner
         byte[] buffer,
         int bufferOffset,
         int length,
-        List<(string key, JsonRawBytes value)> result,
+        List<JsonObjectEntry> result,
         Dictionary<string, int> keyIndex
     )
     {
@@ -199,12 +199,12 @@ public sealed class TopLevelScanner
 
         if (keyIndex.TryGetValue(key, out var idx))
         {
-            result[idx] = (key, mem);
+            result[idx] = new JsonObjectEntry(key, mem);
             return;
         }
 
         keyIndex[key] = result.Count;
-        result.Add((key, mem));
+        result.Add(new JsonObjectEntry(key, mem));
     }
 
     private static void EnsureBufferCapacity(ref byte[] buffer, int remainingLen)

--- a/tests/DataMorph.Tests/App/AppKeyHandlerTests.cs
+++ b/tests/DataMorph.Tests/App/AppKeyHandlerTests.cs
@@ -2,7 +2,10 @@ using AwesomeAssertions;
 using DataMorph.App;
 using DataMorph.App.Views;
 using DataMorph.App.Views.JsonTreeNodes;
+using DataMorph.Engine.IO.DrillDown;
 using DataMorph.Engine.IO.JsonObject;
+using DataMorph.Engine.Models;
+using DataMorph.Engine.Types;
 using Terminal.Gui.App;
 using Terminal.Gui.Drivers;
 using Terminal.Gui.Input;
@@ -19,6 +22,7 @@ public sealed class AppKeyHandlerTests
     [InlineData(KeyCode.T)]
     [InlineData(KeyCode.X)]
     [InlineData(KeyCode.C)]
+    [InlineData(KeyCode.Backspace)]
     [InlineData((KeyCode)'?')]
     public void IsGlobalShortcut_WithGlobalShortcutKeys_ReturnsTrue(KeyCode keyCode)
     {
@@ -52,6 +56,7 @@ public sealed class AppKeyHandlerTests
     [InlineData(KeyCode.T | KeyCode.CtrlMask)]
     [InlineData(KeyCode.X | KeyCode.CtrlMask)]
     [InlineData(KeyCode.C | KeyCode.CtrlMask)]
+    [InlineData(KeyCode.Backspace | KeyCode.CtrlMask)]
     [InlineData((KeyCode)'?' | KeyCode.CtrlMask)]
     public void IsGlobalShortcut_WithModifierKeys_ReturnsTrue(KeyCode keyCode)
     {
@@ -209,22 +214,53 @@ public sealed class AppKeyHandlerTests
     public void OnGlobalKeyDown_BackspaceInFocusedTableWithDrillDown_CallsReturnFromDrillDown()
     {
         // Arrange
+        using var app = CreateTestApp();
+        IReadOnlyList<JsonObjectEntry> entries = [new JsonObjectEntry("id", "1"u8.ToArray())];
+        var schema = new TableSchema { SourceFormat = DataFormat.JsonObject, Columns = [new ColumnSchema { Name = "col1", Type = ColumnType.Text }] };
+        using var state = new AppState
+        {
+            CurrentFilePath = "test.json",
+            CurrentMode = ViewMode.FocusedTable,
+            JsonObjectEntries = entries,
+            DrillDown = new DrillDownState(
+                [new FocusedTableRow(JsonRawBytes.Empty, "[0]")], schema, ViewMode.JsonObjectTree),
+        };
+        using var window = new Window();
+        var modeController = new ModeController(state);
+        using var viewManager = new ViewManager(window, state, modeController, action => action());
+        var fileDialogHandler = new FileDialogHandler(app, state, viewManager, _ => { }, () => { });
+        var recipeCommandHandler = new RecipeCommandHandler(app, state, viewManager);
+        using var handler = new AppKeyHandler(app, state, viewManager, fileDialogHandler, recipeCommandHandler, null);
+        handler.Subscribe();
 
         // Act
+        var handled = app.Keyboard.RaiseKeyDownEvent(KeyCode.Backspace);
 
         // Assert
-        Assert.Fail("Not implemented");
+        handled.Should().BeTrue();
+        state.CurrentMode.Should().Be(ViewMode.JsonObjectTree);
+        state.DrillDown.Should().BeNull();
     }
 
     [Fact]
     public void OnGlobalKeyDown_BackspaceOutsideFocusedTable_ReturnsUnhandled()
     {
         // Arrange
+        using var app = CreateTestApp();
+        using var state = new AppState { CurrentMode = ViewMode.FileSelection };
+        using var window = new Window();
+        var modeController = new ModeController(state);
+        using var viewManager = new ViewManager(window, state, modeController, action => action());
+        var fileDialogHandler = new FileDialogHandler(app, state, viewManager, _ => { }, () => { });
+        var recipeCommandHandler = new RecipeCommandHandler(app, state, viewManager);
+        using var handler = new AppKeyHandler(app, state, viewManager, fileDialogHandler, recipeCommandHandler, null);
+        handler.Subscribe();
 
         // Act
+        var handled = app.Keyboard.RaiseKeyDownEvent(KeyCode.Backspace);
 
         // Assert
-        Assert.Fail("Not implemented");
+        handled.Should().BeFalse();
     }
 
     [Fact]

--- a/tests/DataMorph.Tests/App/AppKeyHandlerTests.cs
+++ b/tests/DataMorph.Tests/App/AppKeyHandlerTests.cs
@@ -206,6 +206,28 @@ public sealed class AppKeyHandlerTests
     // MessageBox.Query display is not unit-testable; requires TUI event loop integration testing.
 
     [Fact]
+    public void OnGlobalKeyDown_BackspaceInFocusedTableWithDrillDown_CallsReturnFromDrillDown()
+    {
+        // Arrange
+
+        // Act
+
+        // Assert
+        Assert.Fail("Not implemented");
+    }
+
+    [Fact]
+    public void OnGlobalKeyDown_BackspaceOutsideFocusedTable_ReturnsUnhandled()
+    {
+        // Arrange
+
+        // Act
+
+        // Assert
+        Assert.Fail("Not implemented");
+    }
+
+    [Fact]
     public void HandleActionMenu_WithJsonObjectFormatAndArrayNode_DispatchesSingleDrillDown()
     {
         // Arrange

--- a/tests/DataMorph.Tests/App/AppKeyHandlerTests.cs
+++ b/tests/DataMorph.Tests/App/AppKeyHandlerTests.cs
@@ -2,6 +2,7 @@ using AwesomeAssertions;
 using DataMorph.App;
 using DataMorph.App.Views;
 using DataMorph.App.Views.JsonTreeNodes;
+using DataMorph.Engine.IO.JsonObject;
 using Terminal.Gui.App;
 using Terminal.Gui.Drivers;
 using Terminal.Gui.Input;
@@ -217,7 +218,7 @@ public sealed class AppKeyHandlerTests
             using var window = new Window();
             var modeController = new ModeController(state);
             using var viewManager = new ViewManager(window, state, modeController, action => action());
-            viewManager.SwitchToJsonObjectTree([("orders", "[{\"id\":1},{\"id\":2}]"u8.ToArray())]);
+            viewManager.SwitchToJsonObjectTree([new JsonObjectEntry("orders", "[{\"id\":1},{\"id\":2}]"u8.ToArray())]);
             var treeView = (MorphTreeView)viewManager.GetCurrentView()!;
             treeView.SelectedObject = JsonObjectTreeView.CreateKeyNode("orders", "[{\"id\":1},{\"id\":2}]"u8.ToArray());
             var fileDialogHandler = new FileDialogHandler(app, state, viewManager, _ => { }, () => { });
@@ -256,7 +257,7 @@ public sealed class AppKeyHandlerTests
             using var window = new Window();
             var modeController = new ModeController(state);
             using var viewManager = new ViewManager(window, state, modeController, action => action());
-            viewManager.SwitchToJsonObjectTree([("orders", "[{\"id\":1},{\"id\":2}]"u8.ToArray())]);
+            viewManager.SwitchToJsonObjectTree([new JsonObjectEntry("orders", "[{\"id\":1},{\"id\":2}]"u8.ToArray())]);
             var treeView = (MorphTreeView)viewManager.GetCurrentView()!;
             treeView.SelectedObject = selectedNode;
             var fileDialogHandler = new FileDialogHandler(app, state, viewManager, _ => { }, () => { });

--- a/tests/DataMorph.Tests/App/AppStateTests.cs
+++ b/tests/DataMorph.Tests/App/AppStateTests.cs
@@ -120,10 +120,12 @@ public sealed class AppStateTests
     public void JsonObjectEntries_Default_IsNull()
     {
         // Arrange
+        using var state = new AppState();
 
         // Act
+        var result = state.JsonObjectEntries;
 
         // Assert
-        Assert.Fail("Not implemented");
+        result.Should().BeNull();
     }
 }

--- a/tests/DataMorph.Tests/App/AppStateTests.cs
+++ b/tests/DataMorph.Tests/App/AppStateTests.cs
@@ -115,4 +115,15 @@ public sealed class AppStateTests
         // Assert
         result.Should().BeEmpty();
     }
+
+    [Fact]
+    public void JsonObjectEntries_Default_IsNull()
+    {
+        // Arrange
+
+        // Act
+
+        // Assert
+        Assert.Fail("Not implemented");
+    }
 }

--- a/tests/DataMorph.Tests/App/FileDialogHandlerTests.cs
+++ b/tests/DataMorph.Tests/App/FileDialogHandlerTests.cs
@@ -202,7 +202,8 @@ public sealed class FileDialogHandlerTests : IDisposable
         };
         state.DrillDown = new DrillDownState(
             [new FocusedTableRow(JsonRawBytes.Empty, "[0]")],
-            schema);
+            schema,
+            ViewMode.JsonObjectTree);
 
         var handler = new FileDialogHandler(app, state, viewManager, _ => { }, () => { });
 
@@ -214,5 +215,27 @@ public sealed class FileDialogHandlerTests : IDisposable
 
         // Assert
         state.DrillDown.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task HandleFileSelectedAsync_JsonObjectFile_PopulatesJsonObjectEntries()
+    {
+        // Arrange
+
+        // Act
+
+        // Assert
+        Assert.Fail("Not implemented");
+    }
+
+    [Fact]
+    public async Task HandleFileSelectedAsync_NonJsonObjectFile_ResetsJsonObjectEntriesToNull()
+    {
+        // Arrange
+
+        // Act
+
+        // Assert
+        Assert.Fail("Not implemented");
     }
 }

--- a/tests/DataMorph.Tests/App/FileDialogHandlerTests.cs
+++ b/tests/DataMorph.Tests/App/FileDialogHandlerTests.cs
@@ -3,6 +3,7 @@ using DataMorph.App;
 using DataMorph.App.Views;
 using DataMorph.Engine.IO;
 using DataMorph.Engine.IO.DrillDown;
+using DataMorph.Engine.IO.JsonObject;
 using DataMorph.Engine.Models;
 using DataMorph.Engine.Types;
 using Terminal.Gui.App;
@@ -221,21 +222,55 @@ public sealed class FileDialogHandlerTests : IDisposable
     public async Task HandleFileSelectedAsync_JsonObjectFile_PopulatesJsonObjectEntries()
     {
         // Arrange
+        using var app = CreateTestApp();
+        using var state = new AppState();
+        using var window = new Window();
+        var modeController = new ModeController(state);
+        using var viewManager = new ViewManager(window, state, modeController, action => action());
+        var handler = new FileDialogHandler(app, state, viewManager, _ => { }, () => { });
 
         // Act
+        app.Begin(window);
+        await handler.HandleFileSelectedAsync(_jsonObjectFile);
+        app.StopAfterFirstIteration = true;
+        app.Run(window);
 
         // Assert
-        Assert.Fail("Not implemented");
+        state.JsonObjectEntries.Should().NotBeNull();
+        state.JsonObjectEntries.Should().HaveCount(2);
+        state.JsonObjectEntries.Should().SatisfyRespectively(
+            e => e.Key.Should().Be("name"),
+            e => e.Key.Should().Be("count"));
     }
 
     [Fact]
     public async Task HandleFileSelectedAsync_NonJsonObjectFile_ResetsJsonObjectEntriesToNull()
     {
         // Arrange
+        using var app = CreateTestApp();
+        using var state = new AppState
+        {
+            JsonObjectEntries = [new JsonObjectEntry("stale", JsonRawBytes.Empty)],
+        };
+        using var window = new Window();
+        var modeController = new ModeController(state);
+        using var viewManager = new ViewManager(window, state, modeController, action => action());
+
+        IRowIndexer? capturedIndexer = null;
+        var handler = new FileDialogHandler(app, state, viewManager, indexer =>
+        {
+            capturedIndexer = indexer;
+            Task.Run(() => indexer.BuildIndex());
+        }, () => { });
 
         // Act
+        app.Begin(window);
+        await handler.HandleFileSelectedAsync(_jsonLinesFile);
+        app.StopAfterFirstIteration = true;
+        app.Run(window);
 
         // Assert
-        Assert.Fail("Not implemented");
+        state.JsonObjectEntries.Should().BeNull();
+        capturedIndexer.Should().NotBeNull();
     }
 }

--- a/tests/DataMorph.Tests/App/ModeControllerTests.cs
+++ b/tests/DataMorph.Tests/App/ModeControllerTests.cs
@@ -210,4 +210,26 @@ public sealed class ModeControllerTests : IDisposable
         state.DrillDown.Should().BeNull();
         state.CurrentMode.Should().Be(ViewMode.FileSelection);
     }
+
+    [Fact]
+    public void DrillDown_WhenCalledFromJsonObjectTree_CapturesPreviousModeAsJsonObjectTree()
+    {
+        // Arrange
+
+        // Act
+
+        // Assert
+        Assert.Fail("Not implemented");
+    }
+
+    [Fact]
+    public async Task FullAggregationDrillDownAsync_WhenCalledFromJsonLinesTree_CapturesPreviousModeAsJsonLinesTree()
+    {
+        // Arrange
+
+        // Act
+
+        // Assert
+        Assert.Fail("Not implemented");
+    }
 }

--- a/tests/DataMorph.Tests/App/ModeControllerTests.cs
+++ b/tests/DataMorph.Tests/App/ModeControllerTests.cs
@@ -215,21 +215,44 @@ public sealed class ModeControllerTests : IDisposable
     public void DrillDown_WhenCalledFromJsonObjectTree_CapturesPreviousModeAsJsonObjectTree()
     {
         // Arrange
+        JsonRawBytes nodeBytes = Encoding.UTF8.GetBytes("""[{"id":1}]""");
+        var request = new SingleDrillDownRequest(
+            Format: DataMorph.Engine.Types.DataFormat.JsonObject,
+            NodeBytes: nodeBytes,
+            KeyPath: []);
+        using var state = new AppState { CurrentMode = ViewMode.JsonObjectTree };
+        var controller = new ModeController(state);
 
         // Act
+        var result = controller.DrillDown(request);
 
         // Assert
-        Assert.Fail("Not implemented");
+        result.IsSuccess.Should().BeTrue();
+        state.DrillDown.Should().BeOfType<DrillDownState>()
+            .Which.PreviousMode.Should().Be(ViewMode.JsonObjectTree);
     }
 
     [Fact]
     public async Task FullAggregationDrillDownAsync_WhenCalledFromJsonLinesTree_CapturesPreviousModeAsJsonLinesTree()
     {
         // Arrange
+        await File.WriteAllTextAsync(
+            _jsonlFilePath, "{\"user\":{\"name\":\"Alice\"}}");
+        using var state = new AppState
+        {
+            CurrentFilePath = _jsonlFilePath,
+            CurrentMode = ViewMode.JsonLinesTree,
+        };
+        var controller = new ModeController(state);
+        var request = new FullAggregationDrillDownRequest(
+            Format: DataMorph.Engine.Types.DataFormat.JsonLines,
+            KeyPath: [new KeyPathSegment("user", KeyPathSegmentKind.Key)]);
 
         // Act
+        var result = await controller.FullAggregationDrillDownAsync(request);
 
         // Assert
-        Assert.Fail("Not implemented");
+        result.IsSuccess.Should().BeTrue();
+        result.Value.PreviousMode.Should().Be(ViewMode.JsonLinesTree);
     }
 }

--- a/tests/DataMorph.Tests/App/ViewManagerTests.cs
+++ b/tests/DataMorph.Tests/App/ViewManagerTests.cs
@@ -191,11 +191,22 @@ public sealed class ViewManagerTests : IDisposable
     public void RefreshStatusBarHints_WithFocusedTableMode_IncludesBackHint()
     {
         // Arrange
+        var filePath = CreateTempFile(".jsonl", "{\"col1\": \"value\"}\n");
+        using var app = CreateTestApp();
+        using var state = new AppState { CurrentFilePath = filePath, CurrentMode = ViewMode.FocusedTable };
+        using var window = new Window();
+        using var statusBar = new StatusBar();
+        window.Add(statusBar);
+        var modeController = new ModeController(state);
+        using var viewManager = new ViewManager(window, state, modeController, action => action());
 
         // Act
+        viewManager.RefreshStatusBarHints();
 
         // Assert
-        Assert.Fail("Not implemented");
+        var currentStatusBar = viewManager.GetCurrentStatusBar();
+        currentStatusBar.Should().NotBeNull();
+        currentStatusBar.SubViews.OfType<Shortcut>().Select(s => s.HelpText).Should().Contain("bs:Back");
     }
 
     [Fact]
@@ -801,55 +812,125 @@ public sealed class ViewManagerTests : IDisposable
     public void ReturnFromDrillDown_WithJsonLinesTreePreviousMode_RestoresJsonLinesTree()
     {
         // Arrange
+        var filePath = CreateTempFile(".jsonl", "{\"col1\": \"value\"}\n");
+        using var app = CreateTestApp();
+        var indexer = new DataMorph.Engine.IO.JsonLines.RowIndexer(filePath);
+        indexer.BuildIndex();
+        var schema = new TableSchema { SourceFormat = DataFormat.JsonLines, Columns = [new ColumnSchema { Name = "col1", Type = ColumnType.Text }] };
+        using var state = new AppState
+        {
+            CurrentFilePath = filePath,
+            CurrentMode = ViewMode.FocusedTable,
+            RowIndexer = indexer,
+            DrillDown = new DrillDownState(
+                [new FocusedTableRow(JsonRawBytes.Empty, "[0]")], schema, ViewMode.JsonLinesTree),
+        };
+        using var window = new Window();
+        var modeController = new ModeController(state);
+        using var viewManager = new ViewManager(window, state, modeController, action => action());
 
         // Act
+        viewManager.ReturnFromDrillDown();
 
         // Assert
-        Assert.Fail("Not implemented");
+        state.CurrentMode.Should().Be(ViewMode.JsonLinesTree);
+        state.DrillDown.Should().BeNull();
+        viewManager.GetCurrentView().Should().BeOfType<JsonLinesTreeView>();
     }
 
     [Fact]
     public void ReturnFromDrillDown_WithJsonArrayTreePreviousMode_RestoresJsonArrayTree()
     {
         // Arrange
+        var filePath = CreateTempFile(".json", "[1,2,3]");
+        using var app = CreateTestApp();
+        var indexer = new RowIndexer(filePath);
+        indexer.BuildIndex();
+        var schema = new TableSchema { SourceFormat = DataFormat.JsonArray, Columns = [new ColumnSchema { Name = "col1", Type = ColumnType.Text }] };
+        using var state = new AppState
+        {
+            CurrentFilePath = filePath,
+            CurrentMode = ViewMode.FocusedTable,
+            RowIndexer = indexer,
+            DrillDown = new DrillDownState(
+                [new FocusedTableRow(JsonRawBytes.Empty, "[0]")], schema, ViewMode.JsonArrayTree),
+        };
+        using var window = new Window();
+        var modeController = new ModeController(state);
+        using var viewManager = new ViewManager(window, state, modeController, action => action());
 
         // Act
+        viewManager.ReturnFromDrillDown();
 
         // Assert
-        Assert.Fail("Not implemented");
+        state.CurrentMode.Should().Be(ViewMode.JsonArrayTree);
+        state.DrillDown.Should().BeNull();
+        viewManager.GetCurrentView().Should().BeOfType<JsonArrayTreeView>();
     }
 
     [Fact]
     public void ReturnFromDrillDown_WithJsonObjectTreePreviousMode_RestoresJsonObjectTree()
     {
         // Arrange
+        using var app = CreateTestApp();
+        IReadOnlyList<JsonObjectEntry> entries = [new JsonObjectEntry("id", Encoding.UTF8.GetBytes("1"))];
+        var schema = new TableSchema { SourceFormat = DataFormat.JsonObject, Columns = [new ColumnSchema { Name = "col1", Type = ColumnType.Text }] };
+        using var state = new AppState
+        {
+            CurrentFilePath = "test.json",
+            CurrentMode = ViewMode.FocusedTable,
+            JsonObjectEntries = entries,
+            DrillDown = new DrillDownState(
+                [new FocusedTableRow(JsonRawBytes.Empty, "[0]")], schema, ViewMode.JsonObjectTree),
+        };
+        using var window = new Window();
+        var modeController = new ModeController(state);
+        using var viewManager = new ViewManager(window, state, modeController, action => action());
 
         // Act
+        viewManager.ReturnFromDrillDown();
 
         // Assert
-        Assert.Fail("Not implemented");
+        state.CurrentMode.Should().Be(ViewMode.JsonObjectTree);
+        state.DrillDown.Should().BeNull();
+        viewManager.GetCurrentView().Should().BeOfType<JsonObjectTreeView>();
     }
 
     [Fact]
     public void ReturnFromDrillDown_WithNullDrillDown_DoesNothing()
     {
         // Arrange
+        using var app = CreateTestApp();
+        using var state = new AppState { CurrentMode = ViewMode.FileSelection };
+        using var window = new Window();
+        var modeController = new ModeController(state);
+        using var viewManager = new ViewManager(window, state, modeController, action => action());
+        viewManager.SwitchToFileSelection();
 
         // Act
+        viewManager.ReturnFromDrillDown();
 
         // Assert
-        Assert.Fail("Not implemented");
+        state.CurrentMode.Should().Be(ViewMode.FileSelection);
+        state.DrillDown.Should().BeNull();
     }
 
     [Fact]
     public void ReturnFromDrillDown_AfterDisposal_ThrowsObjectDisposedException()
     {
         // Arrange
+        using var app = CreateTestApp();
+        using var state = new AppState();
+        using var window = new Window();
+        var modeController = new ModeController(state);
+        var viewManager = new ViewManager(window, state, modeController, action => action());
+        viewManager.Dispose();
 
         // Act
+        var act = () => viewManager.ReturnFromDrillDown();
 
         // Assert
-        Assert.Fail("Not implemented");
+        act.Should().Throw<ObjectDisposedException>();
     }
 
     /// <summary>

--- a/tests/DataMorph.Tests/App/ViewManagerTests.cs
+++ b/tests/DataMorph.Tests/App/ViewManagerTests.cs
@@ -5,6 +5,7 @@ using DataMorph.App.Views;
 using DataMorph.Engine.IO;
 using DataMorph.Engine.IO.DrillDown;
 using DataMorph.Engine.IO.JsonArray;
+using DataMorph.Engine.IO.JsonObject;
 using DataMorph.Engine.Models;
 using DataMorph.Engine.Types;
 using Terminal.Gui.App;
@@ -464,9 +465,9 @@ public sealed class ViewManagerTests : IDisposable
         using var window = new Window();
         var modeController = new ModeController(state);
         using var viewManager = new ViewManager(window, state, modeController, action => action());
-        IReadOnlyList<(string key, JsonRawBytes value)> entries =
+        IReadOnlyList<JsonObjectEntry> entries =
         [
-            ("id", System.Text.Encoding.UTF8.GetBytes("1")),
+            new JsonObjectEntry("id", System.Text.Encoding.UTF8.GetBytes("1")),
         ];
 
         // Act
@@ -485,7 +486,7 @@ public sealed class ViewManagerTests : IDisposable
         using var window = new Window();
         var modeController = new ModeController(state);
         using var viewManager = new ViewManager(window, state, modeController, action => action());
-        IReadOnlyList<(string key, JsonRawBytes value)>? nullEntries = null;
+        IReadOnlyList<JsonObjectEntry>? nullEntries = null;
 
         // Act
         var act = () => viewManager.SwitchToJsonObjectTree(nullEntries!);
@@ -504,7 +505,7 @@ public sealed class ViewManagerTests : IDisposable
         var modeController = new ModeController(state);
         var viewManager = new ViewManager(window, state, modeController, action => action());
         viewManager.Dispose();
-        IReadOnlyList<(string key, JsonRawBytes value)> entries = [];
+        IReadOnlyList<JsonObjectEntry> entries = [];
 
         // Act
         var act = () => viewManager.SwitchToJsonObjectTree(entries);
@@ -525,9 +526,9 @@ public sealed class ViewManagerTests : IDisposable
         window.Add(statusBar);
         var modeController = new ModeController(state);
         using var viewManager = new ViewManager(window, state, modeController, action => action());
-        IReadOnlyList<(string key, JsonRawBytes value)> entries =
+        IReadOnlyList<JsonObjectEntry> entries =
         [
-            ("id", System.Text.Encoding.UTF8.GetBytes("1")),
+            new JsonObjectEntry("id", System.Text.Encoding.UTF8.GetBytes("1")),
         ];
         viewManager.SwitchToJsonObjectTree(entries);
 

--- a/tests/DataMorph.Tests/App/ViewManagerTests.cs
+++ b/tests/DataMorph.Tests/App/ViewManagerTests.cs
@@ -188,6 +188,17 @@ public sealed class ViewManagerTests : IDisposable
     }
 
     [Fact]
+    public void RefreshStatusBarHints_WithFocusedTableMode_IncludesBackHint()
+    {
+        // Arrange
+
+        // Act
+
+        // Assert
+        Assert.Fail("Not implemented");
+    }
+
+    [Fact]
     public async Task ToggleJsonLinesModeAsync_WhenToggleFails_ShowsError()
     {
         // Arrange
@@ -784,6 +795,61 @@ public sealed class ViewManagerTests : IDisposable
 
         // Assert
         window.SubViews.OfType<BreadcrumbBar>().Single().Text.Should().Be("list[*]");
+    }
+
+    [Fact]
+    public void ReturnFromDrillDown_WithJsonLinesTreePreviousMode_RestoresJsonLinesTree()
+    {
+        // Arrange
+
+        // Act
+
+        // Assert
+        Assert.Fail("Not implemented");
+    }
+
+    [Fact]
+    public void ReturnFromDrillDown_WithJsonArrayTreePreviousMode_RestoresJsonArrayTree()
+    {
+        // Arrange
+
+        // Act
+
+        // Assert
+        Assert.Fail("Not implemented");
+    }
+
+    [Fact]
+    public void ReturnFromDrillDown_WithJsonObjectTreePreviousMode_RestoresJsonObjectTree()
+    {
+        // Arrange
+
+        // Act
+
+        // Assert
+        Assert.Fail("Not implemented");
+    }
+
+    [Fact]
+    public void ReturnFromDrillDown_WithNullDrillDown_DoesNothing()
+    {
+        // Arrange
+
+        // Act
+
+        // Assert
+        Assert.Fail("Not implemented");
+    }
+
+    [Fact]
+    public void ReturnFromDrillDown_AfterDisposal_ThrowsObjectDisposedException()
+    {
+        // Arrange
+
+        // Act
+
+        // Assert
+        Assert.Fail("Not implemented");
     }
 
     /// <summary>

--- a/tests/DataMorph.Tests/App/Views/Dialogs/HelpDialogTests.cs
+++ b/tests/DataMorph.Tests/App/Views/Dialogs/HelpDialogTests.cs
@@ -3,6 +3,7 @@ using DataMorph.App.Views.Dialogs;
 using Terminal.Gui.App;
 using Terminal.Gui.Drivers;
 using Terminal.Gui.Input;
+using Terminal.Gui.Views;
 
 namespace DataMorph.Tests.App.Views.Dialogs;
 
@@ -95,11 +96,14 @@ public sealed class HelpDialogTests
     public void Constructor_HelpText_IncludesBackspaceBinding()
     {
         // Arrange
+        using var app = CreateTestApp();
 
         // Act
+        using var dialog = new HelpDialog();
 
         // Assert
-        Assert.Fail("Not implemented");
+        var label = dialog.SubViews.OfType<Label>().Single();
+        label.Text.Should().Contain("BackSpace");
     }
 
     [Fact]

--- a/tests/DataMorph.Tests/App/Views/Dialogs/HelpDialogTests.cs
+++ b/tests/DataMorph.Tests/App/Views/Dialogs/HelpDialogTests.cs
@@ -92,6 +92,17 @@ public sealed class HelpDialogTests
     }
 
     [Fact]
+    public void Constructor_HelpText_IncludesBackspaceBinding()
+    {
+        // Arrange
+
+        // Act
+
+        // Assert
+        Assert.Fail("Not implemented");
+    }
+
+    [Fact]
     public void OnKeyDown_WithOtherKey_DoesNotCloseDialog()
     {
         // Arrange

--- a/tests/DataMorph.Tests/App/Views/FocusedTableSourceTests.cs
+++ b/tests/DataMorph.Tests/App/Views/FocusedTableSourceTests.cs
@@ -28,7 +28,7 @@ public sealed class FocusedTableSourceTests
     private static DrillDownState CreateState(
         IReadOnlyList<FocusedTableRow>? rows = null,
         TableSchema? schema = null) =>
-        new(rows ?? DefaultRows, schema ?? DefaultSchema);
+        new(rows ?? DefaultRows, schema ?? DefaultSchema, ViewMode.JsonLinesTree);
 
     [Fact]
     public void Constructor_NullDrillDownState_ThrowsArgumentNullException()

--- a/tests/DataMorph.Tests/App/Views/JsonObjectTreeViewTests.cs
+++ b/tests/DataMorph.Tests/App/Views/JsonObjectTreeViewTests.cs
@@ -3,6 +3,7 @@ using AwesomeAssertions;
 using DataMorph.App.Views;
 using DataMorph.App.Views.JsonTreeNodes;
 using DataMorph.Engine.IO.DrillDown;
+using DataMorph.Engine.IO.JsonObject;
 using Terminal.Gui.App;
 using Terminal.Gui.Drivers;
 
@@ -109,7 +110,7 @@ public sealed class JsonObjectTreeViewTests : IDisposable
     public void Create_WithNullEntries_ThrowsArgumentNullException()
     {
         // Arrange
-        IReadOnlyList<(string key, JsonRawBytes value)> nullEntries = null!;
+        IReadOnlyList<JsonObjectEntry> nullEntries = null!;
 
         // Act
         var act = () => JsonObjectTreeView.Create(nullEntries, () => { }, _ => { });
@@ -122,7 +123,7 @@ public sealed class JsonObjectTreeViewTests : IDisposable
     public void Create_WithNullToggle_ThrowsArgumentNullException()
     {
         // Arrange
-        IReadOnlyList<(string key, JsonRawBytes value)> entries = [];
+        IReadOnlyList<JsonObjectEntry> entries = [];
 
         // Act
         var act = () => JsonObjectTreeView.Create(entries, null!, _ => { });
@@ -135,7 +136,7 @@ public sealed class JsonObjectTreeViewTests : IDisposable
     public void Create_WithNullOnPathChanged_ThrowsArgumentNullException()
     {
         // Arrange
-        IReadOnlyList<(string key, JsonRawBytes value)> entries = [];
+        IReadOnlyList<JsonObjectEntry> entries = [];
 
         // Act
         var act = () => JsonObjectTreeView.Create(entries, () => { }, null!);
@@ -148,7 +149,7 @@ public sealed class JsonObjectTreeViewTests : IDisposable
     public void Create_WithEmptyEntries_AddsNoObjects()
     {
         // Arrange
-        IReadOnlyList<(string key, JsonRawBytes value)> entries = [];
+        IReadOnlyList<JsonObjectEntry> entries = [];
 
         // Act
         using var view = JsonObjectTreeView.Create(entries, () => { }, _ => { });
@@ -161,7 +162,7 @@ public sealed class JsonObjectTreeViewTests : IDisposable
     public void Create_OnSelectionChanged_InvokesOnPathChangedWithExpectedKeyPath()
     {
         // Arrange
-        IReadOnlyList<(string key, JsonRawBytes value)> entries = [("data", ToBytes("{\"a\":1}"))];
+        IReadOnlyList<JsonObjectEntry> entries = [new JsonObjectEntry("data", ToBytes("{\"a\":1}"))];
         List<IReadOnlyList<KeyPathSegment>> observedPaths = [];
         using var view = JsonObjectTreeView.Create(entries, () => { }, path => observedPaths.Add(path));
         var objects = view.Objects;
@@ -180,11 +181,11 @@ public sealed class JsonObjectTreeViewTests : IDisposable
     public void Create_WithEntries_AddsOneNodePerKey()
     {
         // Arrange
-        IReadOnlyList<(string key, JsonRawBytes value)> entries =
+        IReadOnlyList<JsonObjectEntry> entries =
         [
-            ("id", ToBytes("1")),
-            ("name", ToBytes("\"Alice\"")),
-            ("active", ToBytes("true")),
+            new JsonObjectEntry("id", ToBytes("1")),
+            new JsonObjectEntry("name", ToBytes("\"Alice\"")),
+            new JsonObjectEntry("active", ToBytes("true")),
         ];
 
         // Act

--- a/tests/DataMorph.Tests/Engine/IO/JsonObject/TopLevelScannerTests.Scan.cs
+++ b/tests/DataMorph.Tests/Engine/IO/JsonObject/TopLevelScannerTests.Scan.cs
@@ -58,8 +58,8 @@ public sealed partial class TopLevelScannerTests
 
         // Assert
         result.Should().HaveCount(1);
-        result[0].key.Should().Be("k");
-        result[0].value.ToArray().Should().BeEquivalentTo(Utf8("\"v\"").ToArray());
+        result[0].Key.Should().Be("k");
+        result[0].Value.ToArray().Should().BeEquivalentTo(Utf8("\"v\"").ToArray());
     }
 
     [Fact]
@@ -73,8 +73,8 @@ public sealed partial class TopLevelScannerTests
 
         // Assert
         result.Should().HaveCount(1);
-        result[0].key.Should().Be("n");
-        result[0].value.ToArray().Should().BeEquivalentTo(Utf8("42").ToArray());
+        result[0].Key.Should().Be("n");
+        result[0].Value.ToArray().Should().BeEquivalentTo(Utf8("42").ToArray());
     }
 
     [Fact]
@@ -88,8 +88,8 @@ public sealed partial class TopLevelScannerTests
 
         // Assert
         result.Should().HaveCount(1);
-        result[0].key.Should().Be("n");
-        result[0].value.ToArray().Should().BeEquivalentTo(Utf8("-42").ToArray());
+        result[0].Key.Should().Be("n");
+        result[0].Value.ToArray().Should().BeEquivalentTo(Utf8("-42").ToArray());
     }
 
     [Fact]
@@ -103,8 +103,8 @@ public sealed partial class TopLevelScannerTests
 
         // Assert
         result.Should().HaveCount(1);
-        result[0].key.Should().Be("n");
-        result[0].value.ToArray().Should().BeEquivalentTo(Utf8("3.14").ToArray());
+        result[0].Key.Should().Be("n");
+        result[0].Value.ToArray().Should().BeEquivalentTo(Utf8("3.14").ToArray());
     }
 
     [Fact]
@@ -118,8 +118,8 @@ public sealed partial class TopLevelScannerTests
 
         // Assert
         result.Should().HaveCount(1);
-        result[0].key.Should().Be("k");
-        result[0].value.ToArray().Should().BeEquivalentTo(Utf8("\"\"").ToArray());
+        result[0].Key.Should().Be("k");
+        result[0].Value.ToArray().Should().BeEquivalentTo(Utf8("\"\"").ToArray());
     }
 
     [Fact]
@@ -133,8 +133,8 @@ public sealed partial class TopLevelScannerTests
 
         // Assert
         result.Should().HaveCount(1);
-        result[0].key.Should().Be("o");
-        result[0].value.ToArray().Should().BeEquivalentTo(Utf8("{\"a\":1}").ToArray());
+        result[0].Key.Should().Be("o");
+        result[0].Value.ToArray().Should().BeEquivalentTo(Utf8("{\"a\":1}").ToArray());
     }
 
     [Fact]
@@ -148,8 +148,8 @@ public sealed partial class TopLevelScannerTests
 
         // Assert
         result.Should().HaveCount(1);
-        result[0].key.Should().Be("a");
-        result[0].value.ToArray().Should().BeEquivalentTo(Utf8("[1,2]").ToArray());
+        result[0].Key.Should().Be("a");
+        result[0].Value.ToArray().Should().BeEquivalentTo(Utf8("[1,2]").ToArray());
     }
 
     [Theory]
@@ -165,8 +165,8 @@ public sealed partial class TopLevelScannerTests
 
         // Assert
         result.Should().HaveCount(1);
-        result[0].key.Should().Be("k");
-        result[0].value.ToArray().Should().BeEquivalentTo(Utf8(expectedValue).ToArray());
+        result[0].Key.Should().Be("k");
+        result[0].Value.ToArray().Should().BeEquivalentTo(Utf8(expectedValue).ToArray());
     }
 
     [Fact]
@@ -180,10 +180,10 @@ public sealed partial class TopLevelScannerTests
 
         // Assert
         result.Should().HaveCount(2);
-        result[0].key.Should().Be("b");
-        result[0].value.ToArray().Should().BeEquivalentTo(Utf8("2").ToArray());
-        result[1].key.Should().Be("a");
-        result[1].value.ToArray().Should().BeEquivalentTo(Utf8("1").ToArray());
+        result[0].Key.Should().Be("b");
+        result[0].Value.ToArray().Should().BeEquivalentTo(Utf8("2").ToArray());
+        result[1].Key.Should().Be("a");
+        result[1].Value.ToArray().Should().BeEquivalentTo(Utf8("1").ToArray());
     }
 
     [Fact]
@@ -197,8 +197,8 @@ public sealed partial class TopLevelScannerTests
 
         // Assert
         result.Should().HaveCount(1);
-        result[0].key.Should().Be("k");
-        result[0].value.ToArray().Should().BeEquivalentTo(Utf8("2").ToArray());
+        result[0].Key.Should().Be("k");
+        result[0].Value.ToArray().Should().BeEquivalentTo(Utf8("2").ToArray());
     }
 
     [Fact]
@@ -212,8 +212,8 @@ public sealed partial class TopLevelScannerTests
 
         // Assert
         result.Should().HaveCount(1);
-        result[0].key.Should().Be("k");
-        result[0].value.ToArray().Should().BeEquivalentTo(Utf8("3").ToArray());
+        result[0].Key.Should().Be("k");
+        result[0].Value.ToArray().Should().BeEquivalentTo(Utf8("3").ToArray());
     }
 
     [Fact]
@@ -227,10 +227,10 @@ public sealed partial class TopLevelScannerTests
 
         // Assert
         result.Should().HaveCount(3);
-        result[0].key.Should().Be("a");
-        result[1].key.Should().Be("k");
-        result[2].key.Should().Be("b");
-        result[1].value.ToArray().Should().BeEquivalentTo(Utf8("2").ToArray());
+        result[0].Key.Should().Be("a");
+        result[1].Key.Should().Be("k");
+        result[2].Key.Should().Be("b");
+        result[1].Value.ToArray().Should().BeEquivalentTo(Utf8("2").ToArray());
     }
 
     [Fact]
@@ -244,8 +244,8 @@ public sealed partial class TopLevelScannerTests
 
         // Assert
         result.Should().HaveCount(1);
-        result[0].key.Should().Be("x");
-        result[0].value.ToArray().Should().BeEquivalentTo(Utf8("{\"y\":{\"z\":1}}").ToArray());
+        result[0].Key.Should().Be("x");
+        result[0].Value.ToArray().Should().BeEquivalentTo(Utf8("{\"y\":{\"z\":1}}").ToArray());
     }
 
     [Fact]
@@ -259,8 +259,8 @@ public sealed partial class TopLevelScannerTests
 
         // Assert
         result.Should().HaveCount(1);
-        result[0].key.Should().Be("日本語キー");
-        result[0].value.ToArray().Should().BeEquivalentTo(Utf8("1").ToArray());
+        result[0].Key.Should().Be("日本語キー");
+        result[0].Value.ToArray().Should().BeEquivalentTo(Utf8("1").ToArray());
     }
 
     [Fact]
@@ -274,8 +274,8 @@ public sealed partial class TopLevelScannerTests
 
         // Assert
         result.Should().HaveCount(1);
-        result[0].key.Should().Be("key\"q\"");
-        result[0].value.ToArray().Should().BeEquivalentTo(Utf8("1").ToArray());
+        result[0].Key.Should().Be("key\"q\"");
+        result[0].Value.ToArray().Should().BeEquivalentTo(Utf8("1").ToArray());
     }
 
     [Theory]
@@ -292,8 +292,8 @@ public sealed partial class TopLevelScannerTests
 
         // Assert
         result.Should().HaveCount(1);
-        result[0].key.Should().Be("k");
-        result[0].value.ToArray().Should().BeEquivalentTo(Utf8(expectedValue).ToArray());
+        result[0].Key.Should().Be("k");
+        result[0].Value.ToArray().Should().BeEquivalentTo(Utf8(expectedValue).ToArray());
     }
 
     [Fact]
@@ -309,10 +309,10 @@ public sealed partial class TopLevelScannerTests
 
         // Assert
         result.Should().HaveCount(90_000);
-        result[0].key.Should().Be("f0");
-        result[0].value.ToArray().Should().BeEquivalentTo(Utf8("0").ToArray());
-        result[89_999].key.Should().Be("f89999");
-        result[89_999].value.ToArray().Should().BeEquivalentTo(Utf8("89999").ToArray());
+        result[0].Key.Should().Be("f0");
+        result[0].Value.ToArray().Should().BeEquivalentTo(Utf8("0").ToArray());
+        result[89_999].Key.Should().Be("f89999");
+        result[89_999].Value.ToArray().Should().BeEquivalentTo(Utf8("89999").ToArray());
     }
 
     [Fact]
@@ -329,8 +329,8 @@ public sealed partial class TopLevelScannerTests
 
         // Assert
         result.Should().HaveCount(1);
-        result[0].key.Should().Be("big");
-        result[0].value.ToArray().Should().BeEquivalentTo(Utf8(innerObject).ToArray());
+        result[0].Key.Should().Be("big");
+        result[0].Value.ToArray().Should().BeEquivalentTo(Utf8(innerObject).ToArray());
     }
 
     [Fact]
@@ -388,8 +388,8 @@ public sealed partial class TopLevelScannerTests
 
         // Assert
         result.Should().HaveCount(1);
-        result[0].key.Should().Be("k");
-        result[0].value.ToArray().Should().BeEquivalentTo(Utf8("1").ToArray());
+        result[0].Key.Should().Be("k");
+        result[0].Value.ToArray().Should().BeEquivalentTo(Utf8("1").ToArray());
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Add `Backspace` key handling in `FocusedTable` mode (DrillDown) to return to the tree view it was entered from, via `DrillDownState.PreviousMode` captured at DrillDown entry
- Cache top-level JSON Object entries (`JsonObjectEntry`, replacing the previous `ValueTuple` shape) on `AppState` so `JsonObjectTree` can be rebuilt on return without a rescan
- Add discoverability: `bs:Back` status bar hint and a Help dialog entry

## Test plan
- [x] `dotnet format` — clean
- [x] `dotnet build` — 0 warnings / 0 errors
- [x] `dotnet test` — 1480 passed / 0 failed

Closes #239

🤖 Generated with [Claude Code](https://claude.com/claude-code)