### PR TITLE
docs: add README, MIT license, and third-party notices

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Yuta-K19418
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,81 @@
+![Refedle](docs/images/refedle-terminal-mark.svg)
+
+Refedle is a TUI-driven data transformation tool for CSV and JSON files, built with .NET 10 and Terminal.Gui v2. It lets you explore a file interactively, apply column-level transformations, and replay them as a recipe against large files from the command line.
+
+## Supported Formats
+
+| Format | TUI (Tree) | TUI (Table) | CLI batch (`--cli`) |
+|---|---|---|---|
+| CSV | — | ✅ | ✅ |
+| JSON Lines (`.jsonl`) | ✅ | ✅ | ✅ |
+| JSON Array | ✅ | not yet implemented | ❌ |
+| JSON Object | ✅ (top-level only) | — | ❌ |
+
+CLI batch mode currently accepts `.csv` and `.jsonl` only — standard `.json` (array/object) input is explicitly rejected (`NotSupportedException`). CSV ↔ JSON Lines conversion is supported in batch mode.
+
+## TUI Usage
+
+```bash
+dotnet run --project src/App -- --file <path> [--recipe <path.yaml>]
+```
+
+Key bindings (`src/App/AppKeyHandler.cs`):
+
+| Key | Action |
+|---|---|
+| `o` | Open file |
+| `s` | Save recipe |
+| `t` | Toggle Tree/Table view (JSON Lines only) |
+| `x` | Column/row action menu |
+| `c` | Clear action stack |
+| `Backspace` | Back from drill-down |
+| `?` | Help |
+| `q` | Quit (confirms if there are unsaved actions) |
+
+Column actions available from the action menu: Rename, Delete, Cast, Filter, Fill, Format Timestamp. Two drill-down modes exist: a single-node drill-down for JSON Object arrays, and a full-file aggregation drill-down for JSON Lines/Array.
+
+## CLI Batch Usage
+
+```bash
+dotnet run --project src/App -- --cli --input <in.csv|in.jsonl> --recipe <recipe.yaml> --output <out.csv|out.jsonl>
+```
+
+Recipes are saved from the TUI as `.yaml` and applied here without opening the UI. Format dispatch (reader → transform → writer) is resolved at compile time via a source generator (`src/Generators/FormatDispatcherGenerator.cs`), not reflection.
+
+## Project Structure
+
+```
+src/
+  App/         TUI (Terminal.Gui v2) and CLI entry point (Program.cs, Cli/)
+  Engine/      File I/O (mmap-backed), schema scanning, filtering, actions, recipe (de)serialization
+  Generators/  Roslyn incremental source generator for format-agnostic dispatch
+tests/
+  Refedle.Tests/
+docs/          Design documents
+```
+
+## Implementation Notes
+
+- File reads use `System.IO.MemoryMappedFiles` with `ArrayPool<byte>` buffer reuse; CSV parsing is backed by the [Sep](https://github.com/nietras/Sep) library. There is no SIMD/vectorized scanning code in the engine at this time.
+- Recipe YAML is a hand-written, AOT-safe reader/writer (no YamlDotNet or reflection-based serialization).
+- Error handling favors a `Result`/`Result<T>` return type over exceptions on expected failure paths.
+- Both `App` and `Engine` are configured for Native AOT (`PublishAot=true` / `IsAotCompatible=true`) with `TreatWarningsAsErrors` enabled.
+
+## Requirements
+
+- .NET SDK 10.0.201+ (see [global.json](global.json))
+
+## Build & Test
+
+```bash
+dotnet build
+dotnet test
+```
+
+## Acknowledgements
+
+Built with [Terminal.Gui](https://github.com/gui-cs/Terminal.Gui) and [Sep](https://github.com/nietras/Sep), both MIT licensed. See [THIRD-PARTY-NOTICES.txt](THIRD-PARTY-NOTICES.txt) for full license texts.
+
+## License
+
+[MIT](LICENSE)

--- a/THIRD-PARTY-NOTICES.txt
+++ b/THIRD-PARTY-NOTICES.txt
@@ -1,0 +1,57 @@
+THIRD-PARTY NOTICES
+
+Refedle bundles the following third-party libraries in its compiled binaries.
+
+--------------------------------------------------------------------------------
+Terminal.Gui
+https://github.com/gui-cs/Terminal.Gui
+--------------------------------------------------------------------------------
+
+Copyright 2007-2011 Novell Inc
+Copyright 2017 Microsoft Corp
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+--------------------------------------------------------------------------------
+Sep
+https://github.com/nietras/Sep
+--------------------------------------------------------------------------------
+
+MIT License
+
+Copyright (c) 2023 nietras
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/docs/images/refedle-terminal-mark.svg
+++ b/docs/images/refedle-terminal-mark.svg
@@ -1,0 +1,41 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 520 258" width="520" height="258">
+  <defs>
+    <clipPath id="win-clip">
+      <rect x="0" y="0" width="520" height="258" rx="10" ry="10"/>
+    </clipPath>
+  </defs>
+
+  <g clip-path="url(#win-clip)">
+    <rect x="0" y="0" width="520" height="258" fill="#141210"/>
+    <rect x="0" y="0" width="520" height="34" fill="#1A1712"/>
+    <line x1="0" y1="34" x2="520" y2="34" stroke="#2C2620" stroke-width="1"/>
+  </g>
+  <rect x="0.5" y="0.5" width="519" height="257" rx="9.5" ry="9.5" fill="none" stroke="#2C2620"/>
+
+  <circle cx="22" cy="17" r="5" fill="none" stroke="#55503F"/>
+  <circle cx="40" cy="17" r="5" fill="none" stroke="#55503F"/>
+  <circle cx="58" cy="17" r="5" fill="none" stroke="#55503F"/>
+
+  <text x="260" y="21.5" text-anchor="middle" font-family="'JetBrains Mono','SF Mono','Cascadia Code',Consolas,Menlo,monospace" font-size="12" letter-spacing="0.4" fill="#8B8271">zsh — refedle</text>
+
+  <text x="24" y="66" font-family="'JetBrains Mono','SF Mono','Cascadia Code',Consolas,Menlo,monospace" font-size="15" fill="#E7E1D2"><tspan fill="#E2823E">❯</tspan> refedle</text>
+
+  <g transform="translate(24,84)">
+    <rect x="0"  y="0"  width="16" height="16" fill="#E2823E"/>
+    <rect x="19" y="0"  width="16" height="16" fill="#E2823E"/>
+    <rect x="38" y="0"  width="16" height="16" fill="#E2823E"/>
+    <rect x="0"  y="19" width="16" height="16" fill="#E2823E"/>
+    <rect x="19" y="19" width="16" height="16" fill="#E2823E"/>
+    <rect x="38" y="19" width="16" height="16" fill="#E2823E"/>
+    <rect x="0"  y="38" width="16" height="16" fill="#E2823E"/>
+    <rect x="19" y="38" width="16" height="16" fill="#E2823E"/>
+    <polygon points="38,38 54,38 38,54" fill="#7CB1A2"/>
+  </g>
+
+  <text x="96" y="126" font-family="'JetBrains Mono','SF Mono','Cascadia Code',Consolas,Menlo,monospace" font-size="34" font-weight="700" letter-spacing="1" fill="#E7E1D2">REFEDLE</text>
+
+  <text x="24" y="166" font-family="'JetBrains Mono','SF Mono','Cascadia Code',Consolas,Menlo,monospace" font-size="13" fill="#8B8271"># refine what's rough</text>
+
+  <text x="24" y="203" font-family="'JetBrains Mono','SF Mono','Cascadia Code',Consolas,Menlo,monospace" font-size="15" fill="#E7E1D2"><tspan fill="#E2823E">❯</tspan></text>
+  <rect x="38" y="191" width="8" height="14" fill="#E7E1D2"/>
+</svg>


### PR DESCRIPTION
## Summary
- Add README with TUI/CLI usage, supported formats, project structure
- Add MIT LICENSE
- Add THIRD-PARTY-NOTICES.txt for Terminal.Gui and Sep (for future binary distribution)
- Add logo to README

Refs #21 (README will continue to be updated in follow-up PRs, not closing this issue yet)