### PR TITLE
chore: add release workflow for prebuilt binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,96 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      matrix:
+        include:
+          - rid: win-x64
+            runner: windows-latest
+            binary: refedle.exe
+            archive-ext: zip
+          - rid: osx-x64
+            runner: macos-13
+            binary: refedle
+            archive-ext: tar.gz
+          - rid: osx-arm64
+            runner: macos-latest
+            binary: refedle
+            archive-ext: tar.gz
+          - rid: linux-x64
+            runner: ubuntu-latest
+            binary: refedle
+            archive-ext: tar.gz
+          - rid: linux-arm64
+            runner: ubuntu-24.04-arm
+            binary: refedle
+            archive-ext: tar.gz
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v6
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Publish with Native AOT
+        run: dotnet publish src/App/Refedle.App.csproj --configuration Release -r ${{ matrix.rid }}
+
+      - name: Stage release contents
+        shell: bash
+        run: |
+          set -euo pipefail
+          publish_dir="src/App/bin/Release/net10.0/${{ matrix.rid }}/publish"
+          stage_dir="stage/refedle-${{ github.ref_name }}-${{ matrix.rid }}"
+          mkdir -p "$stage_dir"
+          cp "$publish_dir/${{ matrix.binary }}" "$stage_dir/"
+          cp LICENSE "$stage_dir/"
+          cp THIRD-PARTY-NOTICES.txt "$stage_dir/"
+
+      - name: Archive (zip)
+        if: matrix.archive-ext == 'zip'
+        shell: bash
+        run: |
+          cd stage
+          7z a "refedle-${{ github.ref_name }}-${{ matrix.rid }}.zip" "refedle-${{ github.ref_name }}-${{ matrix.rid }}"
+
+      - name: Archive (tar.gz)
+        if: matrix.archive-ext == 'tar.gz'
+        shell: bash
+        run: |
+          cd stage
+          chmod +x "refedle-${{ github.ref_name }}-${{ matrix.rid }}/${{ matrix.binary }}"
+          tar -czf "refedle-${{ github.ref_name }}-${{ matrix.rid }}.tar.gz" "refedle-${{ github.ref_name }}-${{ matrix.rid }}"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: refedle-${{ matrix.rid }}
+          path: stage/refedle-${{ github.ref_name }}-${{ matrix.rid }}.${{ matrix.archive-ext }}
+          retention-days: 7
+
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v6
+        with:
+          path: artifacts
+          merge-multiple: true
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: artifacts/*
+          generate_release_notes: true

--- a/README.md
+++ b/README.md
@@ -2,6 +2,33 @@
 
 Refedle is a TUI-driven data transformation tool for CSV and JSON files, built with .NET 10 and Terminal.Gui v2. It lets you explore a file interactively, apply column-level transformations, and replay them as a recipe against large files from the command line.
 
+## Download
+
+Prebuilt binaries (no .NET SDK required) are published on the [Releases page](https://github.com/Yuta-K19418/DataMorph/releases) for:
+
+| OS | Architecture |
+|---|---|
+| Windows | x64 |
+| macOS | Apple Silicon (arm64) |
+| macOS | Intel (x64) |
+| Linux | x64 |
+| Linux | arm64 |
+
+Download the archive matching your platform, extract it, and run the `refedle` (or `refedle.exe` on Windows) binary directly:
+
+```bash
+./refedle [--file <path>] [--recipe <path.yaml>]
+```
+
+The binaries are unsigned, so the OS may block them on first launch:
+
+- **macOS**: Gatekeeper quarantines downloaded files. Run `xattr -d com.apple.quarantine refedle` before launching, or allow it via System Settings → Privacy & Security.
+- **Windows**: SmartScreen may warn about an unrecognized app. Click "More info" → "Run anyway".
+
+In the examples below, `dotnet run --project src/App --` can be replaced with `./refedle` (or `refedle.exe` on Windows) when using a downloaded binary instead of building from source.
+
+To build and run from source instead, see [TUI Usage](#tui-usage) below.
+
 ## Supported Formats
 
 | Format | TUI (Tree) | TUI (Table) | CLI batch (`--cli`) |


### PR DESCRIPTION
## Summary
- Add a GitHub Actions release workflow that builds Native AOT binaries for win-x64, osx-x64, osx-arm64, linux-x64, and linux-arm64 on version tag push (`v*.*.*`), and publishes them to GitHub Releases
- Document the download/installation steps in README, including macOS Gatekeeper and Windows SmartScreen workarounds for unsigned binaries

## Test plan
- [ ] Push a `v*.*.*` tag and confirm all 5 platform archives are built and attached to the GitHub Release
- [ ] Download and run the win-x64 and osx-arm64 binaries locally to confirm they launch without a .NET SDK installed