### PR TITLE
chore: correct macOS runner targets in workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
             rid: linux-x64
             binary: refedle
           - os: macos-latest
-            rid: osx-x64
+            rid: osx-arm64
             binary: refedle
           - os: windows-latest
             rid: win-x64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,10 +18,6 @@ jobs:
             runner: windows-latest
             binary: refedle.exe
             archive-ext: zip
-          - rid: osx-x64
-            runner: macos-13
-            binary: refedle
-            archive-ext: tar.gz
           - rid: osx-arm64
             runner: macos-latest
             binary: refedle

--- a/README.md
+++ b/README.md
@@ -10,9 +10,10 @@ Prebuilt binaries (no .NET SDK required) are published on the [Releases page](ht
 |---|---|
 | Windows | x64 |
 | macOS | Apple Silicon (arm64) |
-| macOS | Intel (x64) |
 | Linux | x64 |
 | Linux | arm64 |
+
+Intel Macs are not covered by a prebuilt binary (Apple discontinued Intel support as of macOS 26 Tahoe, and GitHub Actions retired its `osx-x64` runner). Build from source instead with `dotnet publish src/App/Refedle.App.csproj -r osx-x64 -c Release`.
 
 Download the archive matching your platform, extract it, and run the `refedle` (or `refedle.exe` on Windows) binary directly:
 


### PR DESCRIPTION
## Summary
- Drop `osx-x64` from the release binaries matrix — GitHub Actions retired the `macos-13` runner, and Apple discontinued Intel Mac support as of macOS 26 Tahoe. README now points Intel Mac users to build from source.
- Fix `ci.yml`'s AOT compilation check: `macos-latest` runs on Apple Silicon, so it was cross-compiling for `osx-x64` without verifying the native `osx-arm64` target.

## Test plan
- [ ] Push a `v*.*.*` tag and confirm the 4 remaining platform archives (win-x64, osx-arm64, linux-x64, linux-arm64) build and attach to the GitHub Release
- [ ] Confirm CI's `aot-compilation-check (macos-latest)` job still passes with `osx-arm64`