### PR TITLE
docs: refine and expand development rule docs

### DIFF
--- a/.claude/rules/csharp-standards.md
+++ b/.claude/rules/csharp-standards.md
@@ -50,6 +50,10 @@ paths:
 - Use `ref` **only** as a performance optimization: when a large value-type (`struct`) would otherwise be copied repeatedly on every call, passing it by `ref` avoids that overhead
 - Do NOT use `ref` to return computed values or to simulate multiple return values — use tuples or result types instead
 
+### Collection Output Parameters
+- Do NOT create a collection (`List<T>`, `Dictionary<TKey, TValue>`, etc.) in the caller and pass it into a method solely to have that method populate it as a side effect, when the method could just create and return the collection itself
+- Exception: when a method is called repeatedly and its role is to accumulate into one shared collection across those calls (e.g., appending rows for every line scanned in a file), passing the shared collection as a parameter is allowed — recreating and merging a new collection on every call would add unnecessary allocations
+
 ## Structure & Complexity (STRICT)
 
 ### Class Size

--- a/.claude/rules/csharp-standards.md
+++ b/.claude/rules/csharp-standards.md
@@ -85,6 +85,12 @@ paths:
 - **Consistency with existing code**: if existing types follow a naming convention (e.g., a specific suffix or prefix), new types must follow the same pattern — flag any new class, interface, or member whose name breaks the established convention in its namespace or layer
 - **ValueTuple element names**: use **camelCase** (e.g., `(string key, string value)`, `(int count, bool found)`). Tuple elements are destructured into local variables, so camelCase aligns with the local variable naming convention
 
+## ValueTuple
+- `ValueTuple` (`(...)`) is for returning multiple values from a method, or as a local variable for intermediate processing within a method
+- Do NOT define `ValueTuple` as a class/struct **field or property type**, including inside collections (e.g., `IReadOnlyList<(int Id, string Name)>`, `Dictionary<string, (bool, int)>`) — an unnamed tuple shape is not self-documenting once it becomes state that other members or callers rely on
+- When a tuple-shaped value needs to be held as a field or property, define a `record`, `record struct`, `class`, or `struct` instead
+  - Example: instead of `(int Min, int Max) Range => (...)`, define `public readonly record struct Range(int Min, int Max);` and expose `public Range Range { get; }`
+
 ## Project and Directory Placement
 - Every class must reside in the project that matches its abstraction layer (`Engine` for core logic, `App` for TUI/presentation, `Tests` for test code)
 - Even within the correct project, verify the directory is appropriate for the abstraction or domain the class belongs to — a misplaced file is a discoverability and maintainability problem

--- a/.claude/rules/csharp-standards.md
+++ b/.claude/rules/csharp-standards.md
@@ -65,6 +65,10 @@ paths:
 - Limit indentation to a maximum of **2 levels**
 - If logic requires deeper nesting, refactor by extracting methods
 
+### Variable Declaration
+- Do NOT declare a variable without an initializer (e.g., `int count;`)
+- Always assign a value at the point of declaration, even if the real value is computed later (e.g., inside a `try` block) — keeping declaration and meaning together avoids forcing the reader to scan forward to find the first assignment
+
 ## Zero Warnings Policy
 - The project must compile with **zero warnings**
 - `<TreatWarningsAsErrors>true</TreatWarningsAsErrors>` and `<AnalysisLevel>latest-all</AnalysisLevel>` must be enabled in `.csproj`

--- a/.claude/rules/csharp-standards.md
+++ b/.claude/rules/csharp-standards.md
@@ -65,6 +65,10 @@ paths:
 - Do NOT use `else` clauses
 - Use **Guard Clauses** (early return) or `continue` to keep the logic flat
 
+### Loop Termination
+- If a `while` loop's termination condition can be expressed in the loop's own condition clause, do so — do NOT write it as an `if (condition) { break; }` in the body instead
+- If it cannot be cleanly expressed there (e.g., the condition depends on work that must happen inside the body first), an `if (condition) { break; }` is acceptable
+
 ### Max Nesting
 - Limit indentation to a maximum of **2 levels**
 - If logic requires deeper nesting, refactor by extracting methods

--- a/.claude/rules/documentation-style-and-git.md
+++ b/.claude/rules/documentation-style-and-git.md
@@ -3,12 +3,16 @@ paths:
   - "**/*"
 ---
 
-# Language & Git Policy
+# Documentation Style & Git Policy
 
 ## Language Policy
 - **Documentation**: All documentation (including README, specs, design docs, and TASKS.md) must be written in **English ONLY**.
 - **Comments**: All code comments (inline `//` and XML documentation comments `///`) must be written in **English**.
 - **Commit Messages**: Must be written in **English**.
+
+## Comment Content Policy
+- Keep comments to a maximum of **3 lines**. If a longer explanation is needed, write it as an XML documentation comment (`///`) or in project documentation instead
+- **WHY, not WHAT**: Only write a comment when the reasoning is non-obvious — a hidden constraint, a subtle invariant, or a gotcha a reader would otherwise miss. Do not explain what the code already makes clear
 
 ## Git Workflow
 - **ALWAYS** run `dotnet format` and `dotnet test` BEFORE committing.

--- a/.claude/rules/safety-and-nullability.md
+++ b/.claude/rules/safety-and-nullability.md
@@ -10,6 +10,12 @@ paths:
 - Do NOT use the `unsafe` keyword
 - Use safe low-level alternatives like `Span<T>`, `ReadOnlySpan<T>`, and `ref struct`
 
+## Recursion
+- Prefer iteration over recursion by default
+- Recursion is allowed only when the recursion depth is provably bounded and shallow (e.g., a fixed, small number of levels known at compile time) — not when depth depends on external input
+- ❌ Do NOT use recursion to traverse structures whose depth is determined by untrusted or unbounded input — a `StackOverflowException` cannot be caught and crashes the process
+- When traversal depth is unbounded, convert it to an iterative equivalent (e.g., a loop for linear cases, or an explicit stack for tree/graph-like traversals) instead
+
 ## Null-Forgiving Operator (`!`) in Production Code
 - **STRICTLY FORBIDDEN**
 - Never use `!` to silence nullable warnings

--- a/.claude/skills/code-reviewer/SKILL.md
+++ b/.claude/skills/code-reviewer/SKILL.md
@@ -43,7 +43,7 @@ Read all of these files before reviewing:
 - `.claude/rules/safety-and-nullability.md`
 - `.claude/rules/testing.md`
 - `.claude/rules/performance-and-aot.md`
-- `.claude/rules/language-and-git.md`
+- `.claude/rules/documentation-style-and-git.md`
 
 These are the source of truth. Apply them as written.
 

--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -60,5 +60,5 @@ Run:
 `git commit -m "<generated_message>"`
 
 ## Reference
--   [.claude/rules/language-and-git.md](../../rules/language-and-git.md)
+-   [.claude/rules/documentation-style-and-git.md](../../rules/documentation-style-and-git.md)
 -   [.claude/rules/commands.md](../../rules/commands.md)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ Always consult the following files before generating code or providing reviews. 
 
 ### Process & Guidelines
 - [[.claude/rules/testing.md]] - Testing strategies and requirements.
-- [[.claude/rules/language-and-git.md]] - Language usage and Git commit conventions.
+- [[.claude/rules/documentation-style-and-git.md]] - Documentation/comment style, language usage, and Git commit conventions.
 - [[docs/development_guidelines.md]] - General development workflow, architectural overview, and Git commit message conventions.
 
 ### Tooling

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@ All development guidelines have been organized into `.claude/rules/` for better 
 ## Quick Reference
 
 - **Commands**: See [.claude/rules/commands.md](.claude/rules/commands.md)
-- **Language & Git Policy**: See [.claude/rules/language-and-git.md](.claude/rules/language-and-git.md)
+- **Documentation Style & Git Policy**: See [.claude/rules/documentation-style-and-git.md](.claude/rules/documentation-style-and-git.md)
 - **C# Coding Standards**: See [.claude/rules/csharp-standards.md](.claude/rules/csharp-standards.md)
 - **Safety & Nullability**: See [.claude/rules/safety-and-nullability.md](.claude/rules/safety-and-nullability.md)
 - **Performance & Native AOT**: See [.claude/rules/performance-and-aot.md](.claude/rules/performance-and-aot.md)

--- a/opencode.json
+++ b/opencode.json
@@ -3,7 +3,7 @@
   "instructions": [
     "./.claude/rules/commands.md",
     "./.claude/rules/csharp-standards.md",
-    "./.claude/rules/language-and-git.md",
+    "./.claude/rules/documentation-style-and-git.md",
     "./.claude/rules/performance-and-aot.md",
     "./.claude/rules/safety-and-nullability.md",
     "./.claude/rules/testing.md",


### PR DESCRIPTION
## Summary
- Renamed `language-and-git.md` to `documentation-style-and-git.md`
- Added a `ValueTuple` scope rule (top-level section, moved out of Pure Functions)
- Added rules for: initializing variables at declaration, bounding recursion depth, forbidding caller-created collection output parameters, and expressing `while`-loop termination in the loop's own condition

## Test plan
- Docs-only change; no build/test required