### PR TITLE
chore: add SonarAnalyzer.CSharp with complexity rules only

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -339,3 +339,85 @@ dotnet_diagnostic.CA1849.severity = none
 # Test code runs on the test context and doesn't need ConfigureAwait.
 # xUnit tests should not use ConfigureAwait(false) (xUnit1030).
 dotnet_diagnostic.CA2007.severity = none
+
+# SonarAnalyzer.CSharp: S3776/S1541 (Cognitive/Cyclomatic Complexity) pre-existing violations,
+# grandfathered per-file pending a follow-up refactor task.
+[src/Engine/Filtering/FilterEvaluator.cs]
+dotnet_diagnostic.S3776.severity = none
+dotnet_diagnostic.S1541.severity = none
+
+[src/Engine/IO/ColumnTypeResolver.cs]
+dotnet_diagnostic.S3776.severity = none
+dotnet_diagnostic.S1541.severity = none
+
+[src/Engine/ActionApplier.cs]
+dotnet_diagnostic.S3776.severity = none
+dotnet_diagnostic.S1541.severity = none
+
+[src/Engine/IO/Csv/DataRowReader.cs]
+dotnet_diagnostic.S3776.severity = none
+dotnet_diagnostic.S1541.severity = none
+
+[src/Engine/Recipes/RecipeYamlParser.cs]
+dotnet_diagnostic.S3776.severity = none
+dotnet_diagnostic.S1541.severity = none
+
+[src/Engine/IO/JsonObject/TopLevelScanner.cs]
+dotnet_diagnostic.S3776.severity = none
+dotnet_diagnostic.S1541.severity = none
+
+[src/Engine/IO/DrillDown/KeyPathTraverser.cs]
+dotnet_diagnostic.S3776.severity = none
+dotnet_diagnostic.S1541.severity = none
+
+[src/Engine/IO/JsonArray/RowIndexer.cs]
+dotnet_diagnostic.S3776.severity = none
+dotnet_diagnostic.S1541.severity = none
+
+[src/Engine/IO/JsonArray/ElementReader.cs]
+dotnet_diagnostic.S3776.severity = none
+dotnet_diagnostic.S1541.severity = none
+
+[src/Engine/IO/JsonLines/TypeInferrer.cs]
+dotnet_diagnostic.S3776.severity = none
+dotnet_diagnostic.S1541.severity = none
+
+[src/Engine/IO/JsonLines/SchemaScanner.cs]
+dotnet_diagnostic.S3776.severity = none
+dotnet_diagnostic.S1541.severity = none
+
+[src/Engine/IO/JsonLines/RowReader.cs]
+dotnet_diagnostic.S3776.severity = none
+dotnet_diagnostic.S1541.severity = none
+
+[src/App/Cli/ArgumentParser.cs]
+dotnet_diagnostic.S3776.severity = none
+dotnet_diagnostic.S1541.severity = none
+
+[src/App/AppKeyHandler.cs]
+dotnet_diagnostic.S3776.severity = none
+dotnet_diagnostic.S1541.severity = none
+
+[src/App/Views/VimKeyTranslator.cs]
+dotnet_diagnostic.S3776.severity = none
+dotnet_diagnostic.S1541.severity = none
+
+[src/App/FileDialogHandler.cs]
+dotnet_diagnostic.S3776.severity = none
+dotnet_diagnostic.S1541.severity = none
+
+[src/App/ViewManager.cs]
+dotnet_diagnostic.S3776.severity = none
+dotnet_diagnostic.S1541.severity = none
+
+[src/App/Views/MorphTableView.cs]
+dotnet_diagnostic.S3776.severity = none
+dotnet_diagnostic.S1541.severity = none
+
+[src/App/Views/MorphTreeView.cs]
+dotnet_diagnostic.S3776.severity = none
+dotnet_diagnostic.S1541.severity = none
+
+[src/App/Views/LazyTransformer.cs]
+dotnet_diagnostic.S3776.severity = none
+dotnet_diagnostic.S1541.severity = none

--- a/SonarAnalyzer.globalconfig
+++ b/SonarAnalyzer.globalconfig
@@ -1,0 +1,8 @@
+is_global = true
+
+# Only complexity rules are active; every other SonarAnalyzer.CSharp rule stays
+# at its default (which is "disabled" for most, "silent" bulk-override for the rest).
+dotnet_analyzer_diagnostic.severity = silent
+
+dotnet_diagnostic.S3776.severity = warning # Cognitive Complexity of methods should not be too high
+dotnet_diagnostic.S1541.severity = warning # Methods and properties should not be too complex (Cyclomatic Complexity)

--- a/src/App/Refedle.App.csproj
+++ b/src/App/Refedle.App.csproj
@@ -6,8 +6,16 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.30.0.144632">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="Terminal.Gui" Version="2.4.17" />
     <PackageReference Include="Sep" Version="0.15.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <GlobalAnalyzerConfigFiles Include="$(MSBuildThisFileDirectory)..\..\SonarAnalyzer.globalconfig" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Engine/Refedle.Engine.csproj
+++ b/src/Engine/Refedle.Engine.csproj
@@ -17,10 +17,18 @@
 
   <ItemGroup>
     <PackageReference Include="Sep" Version="0.15.1" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.30.0.144632">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>
     <InternalsVisibleTo Include="Refedle.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <GlobalAnalyzerConfigFiles Include="$(MSBuildThisFileDirectory)..\..\SonarAnalyzer.globalconfig" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- Add `SonarAnalyzer.CSharp` to `src/App` and `src/Engine`
- Enable only S3776 (Cognitive Complexity) and S1541 (Cyclomatic Complexity) via a shared `SonarAnalyzer.globalconfig`; every other Sonar rule stays silent
- Grandfather 20 pre-existing complexity violations across 20 files via per-file `.editorconfig` sections; refactoring them is tracked as a separate follow-up task

## Test plan
- [x] `dotnet build` — 0 warnings, 0 errors
- [x] `dotnet test` — 1497 passed
- [x] `dotnet format` — no diff
- [x] Verified `dotnet_analyzer_diagnostic.severity = silent` does not suppress built-in CA/IDE analyzers (CA1822, IDE0005 still fire as errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)