### PR TITLE
chore: promote analyzer warnings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -42,6 +42,21 @@ dotnet_diagnostic.CA1303.severity = none
 # IDE0005: Using directive is unnecessary.
 dotnet_diagnostic.IDE0005.severity = warning
 
+# Promoted from silent to warning.
+dotnet_diagnostic.IDE0251.severity = warning
+dotnet_diagnostic.IDE0130.severity = warning
+dotnet_diagnostic.IDE0004.severity = warning
+dotnet_diagnostic.IDE0350.severity = warning
+dotnet_diagnostic.IDE0330.severity = warning
+dotnet_diagnostic.IDE0052.severity = warning
+dotnet_diagnostic.IDE0010.severity = warning
+
+# IDE0072: Populate switch (switch expressions). Left at its default (silent) — every
+# switch expression over an enum already requires a discard arm to satisfy the compiler's
+# own exhaustiveness check (CS8509/CS8524) regardless of this rule, and IDE0072 does not
+# accept a discard as sufficient, so enabling it would require suppressing it at every
+# such site with no corresponding safety benefit.
+
 # IDE2000: Disallow multiple blank lines.
 dotnet_diagnostic.IDE2000.severity = warning
 

--- a/SonarAnalyzer.globalconfig
+++ b/SonarAnalyzer.globalconfig
@@ -6,3 +6,15 @@ dotnet_analyzer_diagnostic.severity = silent
 
 dotnet_diagnostic.S3776.severity = warning # Cognitive Complexity of methods should not be too high
 dotnet_diagnostic.S1541.severity = warning # Methods and properties should not be too complex (Cyclomatic Complexity)
+
+# Promoted from silent to warning.
+dotnet_diagnostic.S2737.severity = warning
+dotnet_diagnostic.S6580.severity = warning
+dotnet_diagnostic.S127.severity = warning
+dotnet_diagnostic.S1450.severity = warning
+dotnet_diagnostic.S3626.severity = warning
+dotnet_diagnostic.S3400.severity = warning
+dotnet_diagnostic.S6966.severity = warning
+dotnet_diagnostic.S6618.severity = warning
+dotnet_diagnostic.S1905.severity = warning
+dotnet_diagnostic.S3358.severity = warning

--- a/src/App/AppKeyHandler.cs
+++ b/src/App/AppKeyHandler.cs
@@ -21,13 +21,6 @@ internal sealed class AppKeyHandler : IDisposable
     private readonly FileDialogHandler _fileDialogHandler;
     private readonly RecipeCommandHandler _recipeCommandHandler;
 
-    [SuppressMessage(
-        "Reliability",
-        "CA2213:Disposable fields should be disposed",
-        Justification = "Child views added to the Window will be disposed automatically when the Window is disposed."
-    )]
-    private readonly StatusBar? _statusBar;
-
     private bool _disposed;
 
     /// <summary>
@@ -46,8 +39,7 @@ internal sealed class AppKeyHandler : IDisposable
         AppState state,
         ViewManager viewManager,
         FileDialogHandler fileDialogHandler,
-        RecipeCommandHandler recipeCommandHandler,
-        StatusBar? statusBar
+        RecipeCommandHandler recipeCommandHandler
     )
     {
         _app = app;
@@ -55,7 +47,6 @@ internal sealed class AppKeyHandler : IDisposable
         _viewManager = viewManager;
         _fileDialogHandler = fileDialogHandler;
         _recipeCommandHandler = recipeCommandHandler;
-        _statusBar = statusBar;
     }
 
     internal void Subscribe()

--- a/src/App/Cli/CsvRecordReader.cs
+++ b/src/App/Cli/CsvRecordReader.cs
@@ -33,7 +33,7 @@ internal struct CsvRecordReader : IRecordReader
         _disposed = false;
     }
 
-    public ValueTask<bool> MoveNextAsync(CancellationToken ct)
+    public readonly ValueTask<bool> MoveNextAsync(CancellationToken ct)
     {
         ThrowIfDisposed();
         if (_reader is null)

--- a/src/App/Cli/CsvRecordWriter.cs
+++ b/src/App/Cli/CsvRecordWriter.cs
@@ -18,7 +18,7 @@ internal struct CsvRecordWriter : IRecordWriter
         _disposed = false;
     }
 
-    public async ValueTask WriteHeaderAsync(CancellationToken ct)
+    public async readonly ValueTask WriteHeaderAsync(CancellationToken ct)
     {
         ThrowIfDisposed();
         if (_writer is null)
@@ -41,14 +41,14 @@ internal struct CsvRecordWriter : IRecordWriter
         await _writer.WriteLineAsync(string.Empty.AsMemory(), ct).ConfigureAwait(false);
     }
 
-    public ValueTask WriteStartRecordAsync(CancellationToken ct)
+    public readonly ValueTask WriteStartRecordAsync(CancellationToken ct)
     {
         ThrowIfDisposed();
         _sb.Clear();
         return default;
     }
 
-    public void WriteCellSpan(int outputColumnIndex, ReadOnlySpan<char> value)
+    public readonly void WriteCellSpan(int outputColumnIndex, ReadOnlySpan<char> value)
     {
         ThrowIfDisposed();
         if (outputColumnIndex > 0)
@@ -66,7 +66,7 @@ internal struct CsvRecordWriter : IRecordWriter
         }
     }
 
-    public async ValueTask WriteEndRecordAsync(CancellationToken ct)
+    public async readonly ValueTask WriteEndRecordAsync(CancellationToken ct)
     {
         ThrowIfDisposed();
         if (_writer is null)
@@ -77,7 +77,7 @@ internal struct CsvRecordWriter : IRecordWriter
         await _writer.WriteLineAsync(_sb.ToString().AsMemory(), ct).ConfigureAwait(false);
     }
 
-    public async ValueTask FlushAsync(CancellationToken ct)
+    public async readonly ValueTask FlushAsync(CancellationToken ct)
     {
         ThrowIfDisposed();
         if (_writer is null)

--- a/src/App/Cli/Factories/CsvRecordReaderFactory.cs
+++ b/src/App/Cli/Factories/CsvRecordReaderFactory.cs
@@ -3,7 +3,7 @@ using Refedle.Engine;
 using Refedle.Engine.Models;
 using Refedle.Engine.Types;
 
-namespace Refedle.App.Cli;
+namespace Refedle.App.Cli.Factories;
 
 [RecordReader(DataFormat.Csv)]
 internal readonly struct CsvRecordReaderFactory : IRecordReaderFactory<CsvRecordReader>

--- a/src/App/Cli/Factories/CsvRecordWriterFactory.cs
+++ b/src/App/Cli/Factories/CsvRecordWriterFactory.cs
@@ -2,7 +2,7 @@ using System.Text;
 using Refedle.Engine;
 using Refedle.Engine.Types;
 
-namespace Refedle.App.Cli;
+namespace Refedle.App.Cli.Factories;
 
 [RecordWriter(DataFormat.Csv)]
 internal readonly struct CsvRecordWriterFactory : IRecordWriterFactory<CsvRecordWriter>

--- a/src/App/Cli/Factories/IRecordReaderFactory.cs
+++ b/src/App/Cli/Factories/IRecordReaderFactory.cs
@@ -1,7 +1,7 @@
 using Refedle.Engine;
 using Refedle.Engine.Models;
 
-namespace Refedle.App.Cli;
+namespace Refedle.App.Cli.Factories;
 
 internal interface IRecordReaderFactory<TReader> where TReader : struct, IRecordReader
 {

--- a/src/App/Cli/Factories/IRecordWriterFactory.cs
+++ b/src/App/Cli/Factories/IRecordWriterFactory.cs
@@ -1,6 +1,6 @@
 using Refedle.Engine;
 
-namespace Refedle.App.Cli;
+namespace Refedle.App.Cli.Factories;
 
 internal interface IRecordWriterFactory<TWriter> where TWriter : struct, IRecordWriter
 {

--- a/src/App/Cli/Factories/JsonLinesRecordReaderFactory.cs
+++ b/src/App/Cli/Factories/JsonLinesRecordReaderFactory.cs
@@ -2,7 +2,7 @@ using Refedle.Engine;
 using Refedle.Engine.Models;
 using Refedle.Engine.Types;
 
-namespace Refedle.App.Cli;
+namespace Refedle.App.Cli.Factories;
 
 [RecordReader(DataFormat.JsonLines)]
 internal readonly struct JsonLinesRecordReaderFactory : IRecordReaderFactory<JsonLinesRecordReader>

--- a/src/App/Cli/Factories/JsonLinesRecordWriterFactory.cs
+++ b/src/App/Cli/Factories/JsonLinesRecordWriterFactory.cs
@@ -1,7 +1,7 @@
 using Refedle.Engine;
 using Refedle.Engine.Types;
 
-namespace Refedle.App.Cli;
+namespace Refedle.App.Cli.Factories;
 
 [RecordWriter(DataFormat.JsonLines)]
 internal readonly struct JsonLinesRecordWriterFactory : IRecordWriterFactory<JsonLinesRecordWriter>

--- a/src/App/Cli/JsonLinesRecordReader.cs
+++ b/src/App/Cli/JsonLinesRecordReader.cs
@@ -1,6 +1,5 @@
 using System.Text;
 using Refedle.Engine;
-using Refedle.Engine.Filtering;
 using Refedle.Engine.IO.Json;
 using Refedle.Engine.IO.JsonLines;
 using Refedle.Engine.Models;
@@ -86,7 +85,7 @@ internal struct JsonLinesRecordReader : IRecordReader
     public readonly bool EvaluateFilters()
     {
         ThrowIfDisposed();
-        return FilterEvaluator.EvaluateJsonFilters(_currentLineBytes, (IReadOnlyList<FilterSpec>)_filters, _filterIndexToNameBytes);
+        return FilterEvaluator.EvaluateJsonFilters(_currentLineBytes, _filters, _filterIndexToNameBytes);
     }
 
     public readonly ReadOnlySpan<char> GetCellSpan(int outputColumnIndex)

--- a/src/App/Cli/JsonLinesRecordWriter.cs
+++ b/src/App/Cli/JsonLinesRecordWriter.cs
@@ -33,13 +33,13 @@ internal partial struct JsonLinesRecordWriter : IRecordWriter
         _disposed = false;
     }
 
-    public ValueTask WriteHeaderAsync(CancellationToken ct)
+    public readonly ValueTask WriteHeaderAsync(CancellationToken ct)
     {
         ThrowIfDisposed();
         return default;
     }
 
-    public ValueTask WriteStartRecordAsync(CancellationToken ct)
+    public readonly ValueTask WriteStartRecordAsync(CancellationToken ct)
     {
         ThrowIfDisposed();
         if (_jsonWriter is null || _bufferWriter is null)
@@ -53,7 +53,7 @@ internal partial struct JsonLinesRecordWriter : IRecordWriter
         return default;
     }
 
-    public void WriteCellSpan(int outputColumnIndex, ReadOnlySpan<char> value)
+    public readonly void WriteCellSpan(int outputColumnIndex, ReadOnlySpan<char> value)
     {
         ThrowIfDisposed();
         if (_jsonWriter is null)
@@ -66,7 +66,7 @@ internal partial struct JsonLinesRecordWriter : IRecordWriter
         WriteJsonValue(_jsonWriter, value);
     }
 
-    public async ValueTask WriteEndRecordAsync(CancellationToken ct)
+    public async readonly ValueTask WriteEndRecordAsync(CancellationToken ct)
     {
         ThrowIfDisposed();
         if (_jsonWriter is null || _stream is null || _bufferWriter is null)
@@ -93,7 +93,7 @@ internal partial struct JsonLinesRecordWriter : IRecordWriter
         }
     }
 
-    public async ValueTask FlushAsync(CancellationToken ct)
+    public async readonly ValueTask FlushAsync(CancellationToken ct)
     {
         ThrowIfDisposed();
         if (_stream is null)

--- a/src/App/Cli/JsonLinesRecordWriter.cs
+++ b/src/App/Cli/JsonLinesRecordWriter.cs
@@ -76,9 +76,9 @@ internal partial struct JsonLinesRecordWriter : IRecordWriter
 
         _jsonWriter.WriteEndObject();
 
-#pragma warning disable CA1849 // Flush to IBufferWriter is synchronous and fast
+#pragma warning disable CA1849, S6966 // Flush to IBufferWriter is synchronous and fast
         _jsonWriter.Flush();
-#pragma warning restore CA1849
+#pragma warning restore CA1849, S6966
 
         // Add newline (using \n as standard for JSONL across platforms)
         var span = _bufferWriter.GetSpan(1);

--- a/src/App/IndexTaskManager.cs
+++ b/src/App/IndexTaskManager.cs
@@ -8,7 +8,7 @@ namespace Refedle.App;
 /// </summary>
 internal sealed class IndexTaskManager : IDisposable
 {
-    private readonly object _lock = new();
+    private readonly Lock _lock = new();
     private CancellationTokenSource? _cts;
     private bool _disposed;
 

--- a/src/App/MainWindow.cs
+++ b/src/App/MainWindow.cs
@@ -16,7 +16,6 @@ internal sealed class MainWindow : Window
     private readonly IApplication _app;
     private readonly AppState _state;
     private readonly IndexTaskManager _indexTaskManager = new();
-    private readonly ModeController _modeController;
     private readonly ViewManager _viewManager;
     private readonly AppKeyHandler _keyHandler;
     private readonly FileDialogHandler _fileDialogHandler;
@@ -51,14 +50,14 @@ internal sealed class MainWindow : Window
     {
         _app = app;
         _state = state;
-        _modeController = new ModeController(state);
+        var modeController = new ModeController(state);
 
         X = 0;
         Y = 0;
         Width = Dim.Fill();
         Height = Dim.Fill();
 
-        _viewManager = new ViewManager(this, state, _modeController, app.Invoke);
+        _viewManager = new ViewManager(this, state, modeController, app.Invoke);
 
         _fileDialogHandler = new FileDialogHandler(app, state, _viewManager, StartIndexing, StopCurrentIndexing);
         _recipeCommandHandler = new RecipeCommandHandler(app, state, _viewManager);

--- a/src/App/MainWindow.cs
+++ b/src/App/MainWindow.cs
@@ -64,7 +64,7 @@ internal sealed class MainWindow : Window
 
         InitializeMenu();
         InitializeStatusBar();
-        _keyHandler = new AppKeyHandler(app, state, _viewManager, _fileDialogHandler, _recipeCommandHandler, _statusBar);
+        _keyHandler = new AppKeyHandler(app, state, _viewManager, _fileDialogHandler, _recipeCommandHandler);
         _viewManager.SwitchToFileSelection();
     }
 

--- a/src/App/ViewManager.cs
+++ b/src/App/ViewManager.cs
@@ -251,7 +251,7 @@ internal sealed class ViewManager : IDisposable
 
         ITableSource rawSource = new Views.VirtualTableSource(indexer, schema);
         var source = _state.ActionStack.Count > 0
-            ? (ITableSource)new Views.LazyTransformer(
+            ? new Views.LazyTransformer(
                 rawSource,
                 schema,
                 _state.ActionStack,

--- a/src/App/ViewManager.cs
+++ b/src/App/ViewManager.cs
@@ -429,6 +429,11 @@ internal sealed class ViewManager : IDisposable
     /// Called after a morph action is added to <see cref="AppState.ActionStack"/> so that
     /// <see cref="Views.LazyTransformer"/> is reconstructed with the updated stack.
     /// </summary>
+    [SuppressMessage(
+        "Style",
+        "IDE0010:Populate switch",
+        Justification = "Only CsvTable/JsonLinesTable refresh here; all other modes are a no-op via the default arm."
+    )]
     internal void RefreshCurrentTableView()
     {
         switch (_state.CurrentMode)
@@ -440,6 +445,12 @@ internal sealed class ViewManager : IDisposable
             case ViewMode.JsonLinesTable
                 when _state.RowIndexer is not null && _state.Schema is not null:
                 SwitchToJsonLinesTableView(_state.RowIndexer, _state.Schema);
+                break;
+
+            default:
+                // Reached from mode-independent callers (e.g. global "clear actions" shortcut,
+                // recipe load) when the current view isn't a table (tree view, file selection, etc.);
+                // no-op preserves the existing view instead of crashing.
                 break;
         }
     }
@@ -632,6 +643,11 @@ internal sealed class ViewManager : IDisposable
     /// entered from, rebuilding that tree from its cached backing data on <see cref="AppState"/>.
     /// A no-op when there is no active DrillDown session.
     /// </summary>
+    [SuppressMessage(
+        "Style",
+        "IDE0010:Populate switch",
+        Justification = "Only tree ViewMode values are valid PreviousMode; the default arm throws for any other member."
+    )]
     internal void ReturnFromDrillDown()
     {
         ObjectDisposedException.ThrowIf(_disposed, this);

--- a/src/App/Views/Dialogs/HelpDialog.cs
+++ b/src/App/Views/Dialogs/HelpDialog.cs
@@ -33,7 +33,7 @@ internal sealed class HelpDialog : Dialog
             Y = 0,
             Width = Dim.Fill(),
             Height = Dim.Fill() - 1,
-            Text = GetHelpText(),
+            Text = HelpText,
         };
 
         Add(helpText);
@@ -43,39 +43,36 @@ internal sealed class HelpDialog : Dialog
         AddButton(closeButton);
     }
 
-    private static string GetHelpText()
-    {
-        return """
-            Global / File Operations
-            -------------------------
-            o         : Open File
-            s         : Save Recipe
-            q         : Quit
-            t         : Toggle Tree/Table View (JSON Lines)
-            x         : Context-Sensitive Action Menu
-            c         : Clear all actions from the stack
-            ?         : Help (this overlay)
-            BackSpace : Return to originating tree view
-                        (FocusedTable only)
+    private const string HelpText = """
+        Global / File Operations
+        -------------------------
+        o         : Open File
+        s         : Save Recipe
+        q         : Quit
+        t         : Toggle Tree/Table View (JSON Lines)
+        x         : Context-Sensitive Action Menu
+        c         : Clear all actions from the stack
+        ?         : Help (this overlay)
+        BackSpace : Return to originating tree view
+                    (FocusedTable only)
 
-            Navigation
-            ----------
-            h/j/k/l   : Move Left/Down/Up/Right
-            gg        : Jump to first row
-            G         : Jump to last row
-            Enter     : Expand/Collapse (Tree View)
+        Navigation
+        ----------
+        h/j/k/l   : Move Left/Down/Up/Right
+        gg        : Jump to first row
+        G         : Jump to last row
+        Enter     : Expand/Collapse (Tree View)
 
-            Context Actions (via 'x' menu)
-            ------------------------------
-            Rename    : Rename the current column
-            Delete    : Remove the current column
-            Cast      : Change column data type
-            Filter    : Add a filter based on current column
-            Fill      : Fill empty cells in column
-            Format    : Format timestamp columns
-            DrillDown : Drill into the selected node
-            """;
-    }
+        Context Actions (via 'x' menu)
+        ------------------------------
+        Rename    : Rename the current column
+        Delete    : Remove the current column
+        Cast      : Change column data type
+        Filter    : Add a filter based on current column
+        Fill      : Fill empty cells in column
+        Format    : Format timestamp columns
+        DrillDown : Drill into the selected node
+        """;
 
     /// <inheritdoc/>
     protected override bool OnKeyDown(Key key)

--- a/src/App/Views/Dialogs/OptionSelectorExtensions.cs
+++ b/src/App/Views/Dialogs/OptionSelectorExtensions.cs
@@ -30,7 +30,7 @@ internal static class OptionSelectorExtensions
             };
         }
 
-        selector.KeyDown += (object? sender, Key key) =>
+        selector.KeyDown += (sender, key) =>
         {
             if (key == Key.J)
             {

--- a/src/App/Views/Dialogs/OptionSelectorExtensions.cs
+++ b/src/App/Views/Dialogs/OptionSelectorExtensions.cs
@@ -51,8 +51,6 @@ internal static class OptionSelectorExtensions
                     selector.FocusedItem--;
                     key.Handled = true;
                 }
-
-                return;
             }
         };
     }

--- a/src/App/Views/JsonRangeTreeNodes/JsonArrayRangeTreeNode.cs
+++ b/src/App/Views/JsonRangeTreeNodes/JsonArrayRangeTreeNode.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Text.Json;
 using Refedle.App.Views.JsonTreeNodes;
 using Refedle.Engine.IO;
@@ -25,8 +26,8 @@ internal sealed class JsonArrayRangeTreeNode : RangeTreeNodeBase
         _indexer = indexer;
         _reader = reader;
         Text = count == 0
-            ? FormattableString.Invariant($"[{startIndex:N0} - (empty)]")
-            : FormattableString.Invariant($"[{startIndex:N0} - {startIndex + count - 1:N0}]");
+            ? string.Create(CultureInfo.InvariantCulture, $"[{startIndex:N0} - (empty)]")
+            : string.Create(CultureInfo.InvariantCulture, $"[{startIndex:N0} - {startIndex + count - 1:N0}]");
     }
 
     /// <summary>
@@ -34,7 +35,7 @@ internal sealed class JsonArrayRangeTreeNode : RangeTreeNodeBase
     /// </summary>
     internal static ITreeNode CreateElementNode(JsonRawBytes bytes, long index)
     {
-        var prefix = FormattableString.Invariant($"[{index:N0}]: ");
+        var prefix = string.Create(CultureInfo.InvariantCulture, $"[{index:N0}]: ");
         ITreeNode invalidNode() =>
             new JsonValueTreeNode($"{prefix}[Invalid JSON]") { ValueKind = JsonValueKind.Undefined };
 

--- a/src/App/Views/JsonRangeTreeNodes/JsonLinesRangeTreeNode.cs
+++ b/src/App/Views/JsonRangeTreeNodes/JsonLinesRangeTreeNode.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Text.Json;
 using Refedle.App.Views.JsonTreeNodes;
 using Refedle.Engine.IO;
@@ -25,8 +26,8 @@ internal sealed class JsonLinesRangeTreeNode : RangeTreeNodeBase
         _indexer = indexer;
         _reader = reader;
         Text = count == 0
-            ? FormattableString.Invariant($"Lines {startIndex + 1:N0} (empty)")
-            : FormattableString.Invariant($"Lines {startIndex + 1:N0} - {startIndex + count:N0}");
+            ? string.Create(CultureInfo.InvariantCulture, $"Lines {startIndex + 1:N0} (empty)")
+            : string.Create(CultureInfo.InvariantCulture, $"Lines {startIndex + 1:N0} - {startIndex + count:N0}");
     }
 
     /// <summary>
@@ -35,7 +36,7 @@ internal sealed class JsonLinesRangeTreeNode : RangeTreeNodeBase
     /// </summary>
     internal static ITreeNode CreateLineNode(JsonRawBytes lineBytes, long lineIndex)
     {
-        var prefix = FormattableString.Invariant($"Line {lineIndex + 1:N0}: ");
+        var prefix = string.Create(CultureInfo.InvariantCulture, $"Line {lineIndex + 1:N0}: ");
         ITreeNode invalidNode() =>
             new JsonValueTreeNode($"{prefix}[Invalid JSON]") { ValueKind = JsonValueKind.Undefined };
 

--- a/src/App/Views/LazyTransformer.cs
+++ b/src/App/Views/LazyTransformer.cs
@@ -324,7 +324,7 @@ internal sealed class LazyTransformer : ITableSource, IDisposable
 
     private static string FormatTimestamp(string rawValue, string? formatString)
     {
-        if (!DateTime.TryParse(rawValue, out var dt))
+        if (!DateTime.TryParse(rawValue, CultureInfo.InvariantCulture, DateTimeStyles.None, out var dt))
         {
             return ParseFailureLabel;
         }

--- a/src/App/Views/LazyTransformer.cs
+++ b/src/App/Views/LazyTransformer.cs
@@ -312,8 +312,15 @@ internal sealed class LazyTransformer : ITableSource, IDisposable
             ? d.ToString(CultureInfo.InvariantCulture)
             : ParseFailureLabel;
 
-    private static string FormatBoolean(string rawValue) =>
-        bool.TryParse(rawValue, out var b) ? (b ? "true" : "false") : ParseFailureLabel;
+    private static string FormatBoolean(string rawValue)
+    {
+        if (!bool.TryParse(rawValue, out var b))
+        {
+            return ParseFailureLabel;
+        }
+
+        return b ? "true" : "false";
+    }
 
     private static string FormatTimestamp(string rawValue, string? formatString)
     {

--- a/src/App/Views/LazyTransformer.cs
+++ b/src/App/Views/LazyTransformer.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Globalization;
 using Refedle.Engine.Filtering;
 using Refedle.Engine.IO.Csv;
@@ -212,6 +213,8 @@ internal sealed class LazyTransformer : ITableSource, IDisposable
             case FormatTimestampAction formatTs:
                 ApplyFormatTimestamp(formatTs, working, nameToIndex);
                 break;
+            default:
+                throw new UnreachableException($"Unhandled {nameof(MorphAction)} type: {action.GetType()}");
         }
     }
 

--- a/src/Engine/IO/Json/JsonByteExtractor.cs
+++ b/src/Engine/IO/Json/JsonByteExtractor.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Text.Json;
 
 namespace Refedle.Engine.IO.Json;
@@ -114,7 +115,7 @@ public static class JsonByteExtractor
     public static string FormatObjectPreview(ref Utf8JsonReader reader)
     {
         var propertyCount = CountObjectProperties(ref reader);
-        return FormattableString.Invariant($"{{Object: {propertyCount:N0} properties}}");
+        return string.Create(CultureInfo.InvariantCulture, $"{{Object: {propertyCount:N0} properties}}");
     }
 
     /// <summary>
@@ -124,6 +125,6 @@ public static class JsonByteExtractor
     public static string FormatArrayPreview(ref Utf8JsonReader reader)
     {
         var elementCount = CountArrayElements(ref reader);
-        return FormattableString.Invariant($"[Array: {elementCount:N0} items]");
+        return string.Create(CultureInfo.InvariantCulture, $"[Array: {elementCount:N0} items]");
     }
 }

--- a/src/Engine/IO/JsonObject/BufferState.cs
+++ b/src/Engine/IO/JsonObject/BufferState.cs
@@ -7,10 +7,10 @@ internal ref struct BufferState(long fileSize)
     private long _readHead;
     private int _remainingLen;
 
-    public int RemainingLen => _remainingLen;
-    public long ReadHead => _readHead;
-    public long BufferOffset => _readHead - _remainingLen;
-    public bool IsFinalBlock => _readHead >= _fileSize;
+    public readonly int RemainingLen => _remainingLen;
+    public readonly long ReadHead => _readHead;
+    public readonly long BufferOffset => _readHead - _remainingLen;
+    public readonly bool IsFinalBlock => _readHead >= _fileSize;
 
     public void RecordBytesRead(int bytesRead)
     {

--- a/src/Engine/IO/JsonObject/EntryState.cs
+++ b/src/Engine/IO/JsonObject/EntryState.cs
@@ -5,9 +5,9 @@ internal ref struct EntryState()
     private string _currentKey = string.Empty;
     private long _valueStart = -1L;
 
-    public string CurrentKey => _currentKey;
-    public long ValueStart => _valueStart;
-    public bool IsNested => _valueStart >= 0;
+    public readonly string CurrentKey => _currentKey;
+    public readonly long ValueStart => _valueStart;
+    public readonly bool IsNested => _valueStart >= 0;
 
     public void StartEntry(string key)
     {

--- a/src/Engine/IO/JsonObject/TopLevelScanner.cs
+++ b/src/Engine/IO/JsonObject/TopLevelScanner.cs
@@ -156,7 +156,7 @@ public sealed class TopLevelScanner
         if (reader.TokenType is JsonTokenType.StartObject or JsonTokenType.StartArray)
         {
             state.Entry.RecordValueStart(
-                newValueStart: state.Buffer.BufferOffset + (long)reader.TokenStartIndex
+                newValueStart: state.Buffer.BufferOffset + reader.TokenStartIndex
             );
             state.RollbackCheckpoint = state.PrevCheckpoint;
             return false;
@@ -181,7 +181,7 @@ public sealed class TopLevelScanner
             key: state.Entry.CurrentKey,
             buffer: buffer,
             bufferOffset: (int)reader.TokenStartIndex,
-            length: (int)(reader.BytesConsumed - (long)reader.TokenStartIndex),
+            length: (int)(reader.BytesConsumed - reader.TokenStartIndex),
             result: result,
             keyIndex: keyIndex
         );

--- a/src/Engine/Recipes/RecipeManager.cs
+++ b/src/Engine/Recipes/RecipeManager.cs
@@ -23,10 +23,6 @@ public sealed class RecipeManager : IRecipeManager
             var yaml = await File.ReadAllTextAsync(filePath, Encoding.UTF8, ct).ConfigureAwait(false);
             return RecipeYamlParser.Parse(yaml);
         }
-        catch (OperationCanceledException)
-        {
-            throw;
-        }
         catch (IOException ex)
         {
             return Results.Failure<Recipe>(ex.Message);
@@ -50,10 +46,6 @@ public sealed class RecipeManager : IRecipeManager
                 ct
             ).ConfigureAwait(false);
             return Results.Success();
-        }
-        catch (OperationCanceledException)
-        {
-            throw;
         }
         catch (IOException ex)
         {

--- a/src/Engine/Recipes/RecipeYamlParser.cs
+++ b/src/Engine/Recipes/RecipeYamlParser.cs
@@ -228,7 +228,8 @@ internal sealed class RecipeYamlParser
     private static string UnescapeString(ReadOnlySpan<char> inner)
     {
         var sb = new StringBuilder(inner.Length);
-        for (var i = 0; i < inner.Length; i++)
+        var i = 0;
+        while (i < inner.Length)
         {
             if (inner[i] == '\\' && i + 1 < inner.Length)
             {
@@ -238,11 +239,12 @@ internal sealed class RecipeYamlParser
                     '\\' => '\\',
                     var c => c,
                 });
-                i++;
+                i += 2;
                 continue;
             }
 
             sb.Append(inner[i]);
+            i++;
         }
 
         return sb.ToString();

--- a/src/Engine/Recipes/RecipeYamlParser.cs
+++ b/src/Engine/Recipes/RecipeYamlParser.cs
@@ -174,7 +174,7 @@ internal sealed class RecipeYamlParser
 
     private static Result<DateTimeOffset> TryParseLastModified(string value)
     {
-        if (!DateTimeOffset.TryParse(UnquoteString(value), null, DateTimeStyles.RoundtripKind, out var dt))
+        if (!DateTimeOffset.TryParse(UnquoteString(value), CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out var dt))
         {
             return Results.Failure<DateTimeOffset>($"Invalid lastModified value: '{value}'");
         }

--- a/src/Generators/FormatDispatcherGenerator.cs
+++ b/src/Generators/FormatDispatcherGenerator.cs
@@ -170,6 +170,7 @@ public class FormatDispatcherGenerator : IIncrementalGenerator
         sb.AppendLine("using Refedle.Engine.Models;");
         sb.AppendLine("using Refedle.Engine.Types;");
         sb.AppendLine("using Refedle.App.Cli;");
+        sb.AppendLine("using Refedle.App.Cli.Factories;");
         sb.AppendLine();
         sb.AppendLine("namespace Refedle.App.Cli.Generated;");
         sb.AppendLine();

--- a/src/Generators/IsExternalInit.cs
+++ b/src/Generators/IsExternalInit.cs
@@ -1,4 +1,6 @@
+#pragma warning disable IDE0130 // Namespace must be System.Runtime.CompilerServices for the compiler to recognize this polyfill
 namespace System.Runtime.CompilerServices;
+#pragma warning restore IDE0130
 
 /// <summary>
 /// This class is required by the C# compiler to support the 'record' and 'init' keywords

--- a/tests/Refedle.Tests/App/AppKeyHandlerTests.cs
+++ b/tests/Refedle.Tests/App/AppKeyHandlerTests.cs
@@ -340,13 +340,13 @@ public sealed class AppKeyHandlerTests
     public static IEnumerable<object[]> InvalidSingleDrillDownSelections()
     {
         // Guard 1: a primitive value node is not a JsonArrayTreeNode.
-        yield return [(object)new JsonValueTreeNode("not-an-array")];
+        yield return [(new JsonValueTreeNode("not-an-array"))];
 
         // Guard 2: array whose lazy Children parse to zero elements.
-        yield return [(object)new JsonArrayTreeNode("[]"u8.ToArray())];
+        yield return [(new JsonArrayTreeNode("[]"u8.ToArray()))];
 
         // Guard 3: mixed-type children (object + value) fail the "all children must be objects" check.
-        yield return [(object)new JsonArrayTreeNode("[{},1]"u8.ToArray())];
+        yield return [(new JsonArrayTreeNode("[{},1]"u8.ToArray()))];
     }
 
     private static IApplication CreateTestApp()

--- a/tests/Refedle.Tests/App/AppKeyHandlerTests.cs
+++ b/tests/Refedle.Tests/App/AppKeyHandlerTests.cs
@@ -80,7 +80,7 @@ public sealed class AppKeyHandlerTests
         using var viewManager = new ViewManager(window, state, modeController, action => action());
         var fileDialogHandler = new FileDialogHandler(app, state, viewManager, _ => { }, () => { });
         var recipeCommandHandler = new RecipeCommandHandler(app, state, viewManager);
-        using var handler = new AppKeyHandler(app, state, viewManager, fileDialogHandler, recipeCommandHandler, null);
+        using var handler = new AppKeyHandler(app, state, viewManager, fileDialogHandler, recipeCommandHandler);
 
         // Act
         var result = handler.HandleActionMenu();
@@ -102,7 +102,7 @@ public sealed class AppKeyHandlerTests
         window.Add(view);
         var fileDialogHandler = new FileDialogHandler(app, state, viewManager, _ => { }, () => { });
         var recipeCommandHandler = new RecipeCommandHandler(app, state, viewManager);
-        using var handler = new AppKeyHandler(app, state, viewManager, fileDialogHandler, recipeCommandHandler, null);
+        using var handler = new AppKeyHandler(app, state, viewManager, fileDialogHandler, recipeCommandHandler);
 
         // Act
         var result = handler.HandleActionMenu();
@@ -124,7 +124,7 @@ public sealed class AppKeyHandlerTests
         window.Add(view);
         var fileDialogHandler = new FileDialogHandler(app, state, viewManager, _ => { }, () => { });
         var recipeCommandHandler = new RecipeCommandHandler(app, state, viewManager);
-        using var handler = new AppKeyHandler(app, state, viewManager, fileDialogHandler, recipeCommandHandler, null);
+        using var handler = new AppKeyHandler(app, state, viewManager, fileDialogHandler, recipeCommandHandler);
 
         // Act
         var result = handler.HandleActionMenu();
@@ -150,7 +150,7 @@ public sealed class AppKeyHandlerTests
         window.Add(view);
         var fileDialogHandler = new FileDialogHandler(app, state, viewManager, _ => { }, () => { });
         var recipeCommandHandler = new RecipeCommandHandler(app, state, viewManager);
-        using var handler = new AppKeyHandler(app, state, viewManager, fileDialogHandler, recipeCommandHandler, null);
+        using var handler = new AppKeyHandler(app, state, viewManager, fileDialogHandler, recipeCommandHandler);
 
         // Act
         var result = handler.HandleActionMenu();
@@ -178,7 +178,7 @@ public sealed class AppKeyHandlerTests
         window.Add(view);
         var fileDialogHandler = new FileDialogHandler(app, state, viewManager, _ => { }, () => { });
         var recipeCommandHandler = new RecipeCommandHandler(app, state, viewManager);
-        using var handler = new AppKeyHandler(app, state, viewManager, fileDialogHandler, recipeCommandHandler, null);
+        using var handler = new AppKeyHandler(app, state, viewManager, fileDialogHandler, recipeCommandHandler);
 
         // Act
         var result = handler.HandleActionMenu();
@@ -198,7 +198,7 @@ public sealed class AppKeyHandlerTests
         using var viewManager = new ViewManager(window, state, modeController, action => action());
         var fileDialogHandler = new FileDialogHandler(app, state, viewManager, _ => { }, () => { });
         var recipeCommandHandler = new RecipeCommandHandler(app, state, viewManager);
-        using var handler = new AppKeyHandler(app, state, viewManager, fileDialogHandler, recipeCommandHandler, null);
+        using var handler = new AppKeyHandler(app, state, viewManager, fileDialogHandler, recipeCommandHandler);
 
         // Act
         var result = handler.HandleClearActions();
@@ -230,7 +230,7 @@ public sealed class AppKeyHandlerTests
         using var viewManager = new ViewManager(window, state, modeController, action => action());
         var fileDialogHandler = new FileDialogHandler(app, state, viewManager, _ => { }, () => { });
         var recipeCommandHandler = new RecipeCommandHandler(app, state, viewManager);
-        using var handler = new AppKeyHandler(app, state, viewManager, fileDialogHandler, recipeCommandHandler, null);
+        using var handler = new AppKeyHandler(app, state, viewManager, fileDialogHandler, recipeCommandHandler);
         handler.Subscribe();
 
         // Act
@@ -253,7 +253,7 @@ public sealed class AppKeyHandlerTests
         using var viewManager = new ViewManager(window, state, modeController, action => action());
         var fileDialogHandler = new FileDialogHandler(app, state, viewManager, _ => { }, () => { });
         var recipeCommandHandler = new RecipeCommandHandler(app, state, viewManager);
-        using var handler = new AppKeyHandler(app, state, viewManager, fileDialogHandler, recipeCommandHandler, null);
+        using var handler = new AppKeyHandler(app, state, viewManager, fileDialogHandler, recipeCommandHandler);
         handler.Subscribe();
 
         // Act
@@ -281,7 +281,7 @@ public sealed class AppKeyHandlerTests
             treeView.SelectedObject = JsonObjectTreeView.CreateKeyNode("orders", "[{\"id\":1},{\"id\":2}]"u8.ToArray());
             var fileDialogHandler = new FileDialogHandler(app, state, viewManager, _ => { }, () => { });
             var recipeCommandHandler = new RecipeCommandHandler(app, state, viewManager);
-            using var handler = new AppKeyHandler(app, state, viewManager, fileDialogHandler, recipeCommandHandler, null);
+            using var handler = new AppKeyHandler(app, state, viewManager, fileDialogHandler, recipeCommandHandler);
             app.Iteration += (_, _) => app.Keyboard.RaiseKeyDownEvent(Key.Enter);
 
             // Act — HandleActionMenu detects JsonObject format and dispatches to HandleSingleDrillDown,
@@ -320,7 +320,7 @@ public sealed class AppKeyHandlerTests
             treeView.SelectedObject = selectedNode;
             var fileDialogHandler = new FileDialogHandler(app, state, viewManager, _ => { }, () => { });
             var recipeCommandHandler = new RecipeCommandHandler(app, state, viewManager);
-            using var handler = new AppKeyHandler(app, state, viewManager, fileDialogHandler, recipeCommandHandler, null);
+            using var handler = new AppKeyHandler(app, state, viewManager, fileDialogHandler, recipeCommandHandler);
 
             // Act
             var result = handler.HandleActionMenu();

--- a/tests/Refedle.Tests/App/Cli/RecordProcessorTests.TestRecordReader.cs
+++ b/tests/Refedle.Tests/App/Cli/RecordProcessorTests.TestRecordReader.cs
@@ -29,7 +29,7 @@ public sealed partial class RecordProcessorTests
             _recordsProcessed = 0;
         }
 
-        public void Dispose() { }
+        public readonly void Dispose() { }
 
         public ValueTask<bool> MoveNextAsync(CancellationToken ct)
         {
@@ -47,7 +47,7 @@ public sealed partial class RecordProcessorTests
             return ValueTask.FromResult(hasNext);
         }
 
-        public bool EvaluateFilters()
+        public readonly bool EvaluateFilters()
         {
             if (Filters.Count == 0)
             {
@@ -74,7 +74,7 @@ public sealed partial class RecordProcessorTests
             return true;
         }
 
-        public ReadOnlySpan<char> GetCellSpan(int outputColumnIndex)
+        public readonly ReadOnlySpan<char> GetCellSpan(int outputColumnIndex)
         {
             if (_currentIndex < 0 || _currentIndex >= Records.Length)
             {

--- a/tests/Refedle.Tests/App/Cli/RecordProcessorTests.TestRecordWriter.cs
+++ b/tests/Refedle.Tests/App/Cli/RecordProcessorTests.TestRecordWriter.cs
@@ -19,33 +19,33 @@ public sealed partial class RecordProcessorTests
             _cells = [];
         }
 
-        public void Dispose() { }
-        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+        public readonly void Dispose() { }
+        public readonly ValueTask DisposeAsync() => ValueTask.CompletedTask;
 
-        public ValueTask WriteHeaderAsync(CancellationToken ct)
+        public readonly ValueTask WriteHeaderAsync(CancellationToken ct)
         {
             WriteHeaderCallback?.Invoke();
             return ValueTask.CompletedTask;
         }
 
-        public ValueTask WriteStartRecordAsync(CancellationToken ct)
+        public readonly ValueTask WriteStartRecordAsync(CancellationToken ct)
         {
             _cells.Clear();
             return ValueTask.CompletedTask;
         }
 
-        public void WriteCellSpan(int outputColumnIndex, ReadOnlySpan<char> value)
+        public readonly void WriteCellSpan(int outputColumnIndex, ReadOnlySpan<char> value)
         {
             _cells.Add(value.ToString());
         }
 
-        public ValueTask WriteEndRecordAsync(CancellationToken ct)
+        public readonly ValueTask WriteEndRecordAsync(CancellationToken ct)
         {
             WriteCellCallback?.Invoke([.. _cells]);
             return ValueTask.CompletedTask;
         }
 
-        public ValueTask FlushAsync(CancellationToken ct)
+        public readonly ValueTask FlushAsync(CancellationToken ct)
         {
             return ValueTask.CompletedTask;
         }

--- a/tests/Refedle.Tests/App/Schema/Csv/IncrementalSchemaScannerTests.cs
+++ b/tests/Refedle.Tests/App/Schema/Csv/IncrementalSchemaScannerTests.cs
@@ -2,7 +2,7 @@ using AwesomeAssertions;
 using Refedle.App.Schema.Csv;
 using Refedle.Engine.Types;
 
-namespace Refedle.Tests.App.Schema;
+namespace Refedle.Tests.App.Schema.Csv;
 
 public sealed class IncrementalSchemaScannerTests : IDisposable
 {

--- a/tests/Refedle.Tests/Engine/IO/JsonArray/ElementByteCacheTests.cs
+++ b/tests/Refedle.Tests/Engine/IO/JsonArray/ElementByteCacheTests.cs
@@ -84,7 +84,7 @@ public sealed class ElementByteCacheTests : IDisposable
     {
         // Arrange
         using var cache = new ElementByteCache(_indexer);
-        var lastIndex = (int)cache.TotalRows - 1;
+        var lastIndex = cache.TotalRows - 1;
 
         // Act
         var result = cache.GetRow(lastIndex);

--- a/tests/Refedle.Tests/Engine/Models/Actions/FillColumnActionTests.cs
+++ b/tests/Refedle.Tests/Engine/Models/Actions/FillColumnActionTests.cs
@@ -56,7 +56,7 @@ public sealed class FillColumnActionTests
 
         // Act
         var json = JsonSerializer.Serialize(
-            (MorphAction)action,
+            action,
             JsonContext.Default.MorphAction
         );
 

--- a/tests/Refedle.Tests/Engine/Models/Actions/FilterActionTests.cs
+++ b/tests/Refedle.Tests/Engine/Models/Actions/FilterActionTests.cs
@@ -78,7 +78,7 @@ public sealed class FilterActionTests
 
         // Act
         var json = JsonSerializer.Serialize(
-            (MorphAction)action,
+            action,
             JsonContext.Default.MorphAction
         );
 

--- a/tests/Refedle.Tests/Engine/Models/Actions/FormatTimestampActionTests.cs
+++ b/tests/Refedle.Tests/Engine/Models/Actions/FormatTimestampActionTests.cs
@@ -28,7 +28,7 @@ public sealed class FormatTimestampActionTests
 
         // Act
         var json = JsonSerializer.Serialize(
-            (MorphAction)action,
+            action,
             JsonContext.Default.MorphAction
         );
         var deserialized = JsonSerializer.Deserialize(json, JsonContext.Default.MorphAction);

--- a/tests/Refedle.Tests/Engine/Recipes/RecipeManagerTests.cs
+++ b/tests/Refedle.Tests/Engine/Recipes/RecipeManagerTests.cs
@@ -101,7 +101,7 @@ public sealed class RecipeManagerTests : IDisposable
 
         // Assert
         // UTF-8 BOM starts with 0xEF 0xBB 0xBF; absence of 0xEF confirms no BOM is written
-        bytes[0].Should().NotBe((byte)0xEF);
+        bytes[0].Should().NotBe(0xEF);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Promotes a batch of previously silent/suggestion-level analyzer rules (IDE*, S*, CA*) to warning severity in `.editorconfig` and `SonarAnalyzer.globalconfig`
- Fixes all resulting warnings across the codebase (redundant casts, ternary extraction, unread fields, switch defaults, namespace alignment, locking primitives, format providers, etc.)

## Test plan
- [ ] `dotnet format` clean
- [ ] `dotnet build` with zero warnings
- [ ] `dotnet test` all passing

Closes https://github.com/Yuta-K19418/Refedle/issues/260

🤖 Generated with [Claude Code](https://claude.com/claude-code)