### PR TITLE
chore: consolidate code-analysis suppressions into GlobalSuppressions.cs

### DIFF
--- a/src/App/AppKeyHandler.cs
+++ b/src/App/AppKeyHandler.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics.CodeAnalysis;
 using Refedle.App.Views;
 using Refedle.App.Views.Dialogs;
 using Refedle.App.Views.JsonTreeNodes;
@@ -87,11 +86,6 @@ internal sealed class AppKeyHandler : IDisposable
     /// Handles help overlay shortcut (?).
     /// </summary>
     /// <returns><c>true</c> if the key was handled; <c>false</c> otherwise.</returns>
-    [SuppressMessage(
-        "Reliability",
-        "CA2000:Dispose objects before losing scope",
-        Justification = "The dialog is managed by Terminal.Gui's IApplication.Run() and will be disposed automatically."
-    )]
     private bool HandleHelp()
     {
         var dialog = new HelpDialog();
@@ -172,11 +166,6 @@ internal sealed class AppKeyHandler : IDisposable
         return false;
     }
 
-    [SuppressMessage(
-        "Reliability",
-        "CA2000:Dispose objects before losing scope",
-        Justification = "The dialog is managed by Terminal.Gui's IApplication.Run() and will be disposed automatically."
-    )]
     private bool HandleActionMenuForTable(MorphTableView mt)
     {
         if (mt.Table is null || mt.GetRawColumnName is null
@@ -227,11 +216,6 @@ internal sealed class AppKeyHandler : IDisposable
     /// Single-node DrillDown: JSON Object format only. Requires the selected node to be a
     /// <see cref="JsonArrayTreeNode"/> whose direct children are all <see cref="JsonObjectTreeNode"/>.
     /// </summary>
-    [SuppressMessage(
-        "Reliability",
-        "CA2000:Dispose objects before losing scope",
-        Justification = "The dialog is managed by Terminal.Gui's IApplication.Run() and will be disposed automatically."
-    )]
     private bool HandleSingleDrillDown(ITreeNode selectedNode, DataFormat format)
     {
         if (selectedNode is not JsonArrayTreeNode arrayNode)
@@ -265,11 +249,6 @@ internal sealed class AppKeyHandler : IDisposable
     /// <summary>
     /// Full Aggregation DrillDown: JSON Lines / JSON Array format, any node type, always a full file scan.
     /// </summary>
-    [SuppressMessage(
-        "Reliability",
-        "CA2000:Dispose objects before losing scope",
-        Justification = "The dialog is managed by Terminal.Gui's IApplication.Run() and will be disposed automatically."
-    )]
     private bool HandleFullAggregationDrillDown(ITreeNode selectedNode, DataFormat format)
     {
         var keyPath = KeyPathBuilder.Build(selectedNode);

--- a/src/App/Cli/Factories/CsvRecordWriterFactory.cs
+++ b/src/App/Cli/Factories/CsvRecordWriterFactory.cs
@@ -7,7 +7,6 @@ namespace Refedle.App.Cli.Factories;
 [RecordWriter(DataFormat.Csv)]
 internal readonly struct CsvRecordWriterFactory : IRecordWriterFactory<CsvRecordWriter>
 {
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "Ownership is transferred to the caller.")]
     public ValueTask<CsvRecordWriter> CreateAsync(Arguments args, BatchOutputSchema outputSchema, IAppLogger logger, CancellationToken ct)
     {
         StreamWriter writer = new(args.OutputFile, append: false, Encoding.UTF8);

--- a/src/App/Cli/Factories/JsonLinesRecordReaderFactory.cs
+++ b/src/App/Cli/Factories/JsonLinesRecordReaderFactory.cs
@@ -7,7 +7,6 @@ namespace Refedle.App.Cli.Factories;
 [RecordReader(DataFormat.JsonLines)]
 internal readonly struct JsonLinesRecordReaderFactory : IRecordReaderFactory<JsonLinesRecordReader>
 {
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "Ownership is transferred to the caller.")]
     public ValueTask<JsonLinesRecordReader> CreateAsync(Arguments args, TableSchema inputSchema, BatchOutputSchema outputSchema, IAppLogger logger, CancellationToken ct)
     {
         Engine.IO.JsonLines.RowIndexer rowIndexer = new(args.InputFile);

--- a/src/App/Cli/Factories/JsonLinesRecordWriterFactory.cs
+++ b/src/App/Cli/Factories/JsonLinesRecordWriterFactory.cs
@@ -7,7 +7,6 @@ namespace Refedle.App.Cli.Factories;
 internal readonly struct JsonLinesRecordWriterFactory : IRecordWriterFactory<JsonLinesRecordWriter>
 {
     private const int StreamBufferSize = 1024 * 64; // 64 KB
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "Ownership is transferred to the caller.")]
     public ValueTask<JsonLinesRecordWriter> CreateAsync(Arguments args, BatchOutputSchema outputSchema, IAppLogger logger, CancellationToken ct)
     {
         FileStream stream = new(args.OutputFile, FileMode.Create, FileAccess.Write, FileShare.Read, StreamBufferSize, useAsync: true);

--- a/src/App/Cli/JsonLinesRecordWriter.cs
+++ b/src/App/Cli/JsonLinesRecordWriter.cs
@@ -5,7 +5,6 @@ using Refedle.Engine;
 
 namespace Refedle.App.Cli;
 
-[System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1001:Types that own disposable fields should be disposable", Justification = "JsonLinesRecordWriter is a struct designed for monomorphization as per ADR. It implements IRecordWriter which inherits from IDisposable and IAsyncDisposable, but CA1001 analyzer may be confused by structs or specific field types.")]
 internal partial struct JsonLinesRecordWriter : IRecordWriter
 {
     private const int InitialBufferSize = 1024 * 64; // 64 KB
@@ -76,9 +75,7 @@ internal partial struct JsonLinesRecordWriter : IRecordWriter
 
         _jsonWriter.WriteEndObject();
 
-#pragma warning disable CA1849, S6966 // Flush to IBufferWriter is synchronous and fast
         _jsonWriter.Flush();
-#pragma warning restore CA1849, S6966
 
         // Add newline (using \n as standard for JSONL across platforms)
         var span = _bufferWriter.GetSpan(1);

--- a/src/App/Cli/Runner.cs
+++ b/src/App/Cli/Runner.cs
@@ -67,9 +67,7 @@ internal static class Runner
             await logger.WriteErrorAsync(ex.Message);
             return ExitCode.Failure;
         }
-#pragma warning disable CA1031 // Do not catch general exception types
         catch (Exception ex)
-#pragma warning restore CA1031 // Do not catch general exception types
         {
             await logger.WriteErrorAsync($"Error: {ex.Message}");
             return ExitCode.Failure;

--- a/src/App/FileDialogHandler.cs
+++ b/src/App/FileDialogHandler.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics.CodeAnalysis;
 using Refedle.App.Schema.Csv;
 using Refedle.Engine.IO;
 using Refedle.Engine.Types;
@@ -23,11 +22,6 @@ internal sealed class FileDialogHandler(
     private readonly Action<IRowIndexer> _onIndexerStart = onIndexerStart;
     private readonly Action _stopIndexing = stopIndexing;
 
-    [SuppressMessage(
-        "Reliability",
-        "CA2000:Dispose objects before losing scope",
-        Justification = "The OpenDialog is managed by Terminal.Gui's IApplication.Run() and will be disposed automatically."
-    )]
     internal async Task ShowAsync()
     {
         var dialog = new OpenDialog { Title = "Open File" };
@@ -116,9 +110,7 @@ internal sealed class FileDialogHandler(
             });
         }
         catch (OperationCanceledException) { /* file reloaded before scan completed */ }
-#pragma warning disable CA1031 // UI top-level handler
         catch (Exception ex)
-#pragma warning restore CA1031
         {
             _app.Invoke(() =>
                 _viewManager.ShowError($"Error loading JSON Object: {ex.Message}"));
@@ -167,9 +159,7 @@ internal sealed class FileDialogHandler(
                 _onIndexerStart(indexer);
             });
         }
-#pragma warning disable CA1031 // UI top-level handler
         catch (Exception ex)
-#pragma warning restore CA1031
         {
             _app.Invoke(() => _viewManager.ShowError($"Error scanning CSV: {ex.Message}"));
         }
@@ -196,9 +186,7 @@ internal sealed class FileDialogHandler(
                 _viewManager.SwitchToJsonLinesTree(indexer);
             });
         }
-#pragma warning disable CA1031 // UI top-level handler
         catch (Exception ex)
-#pragma warning restore CA1031
         {
             _app.Invoke(() => _viewManager.ShowError($"Error loading JSON Lines: {ex.Message}"));
         }
@@ -225,9 +213,7 @@ internal sealed class FileDialogHandler(
                 _viewManager.SwitchToJsonArrayTree(indexer);
             });
         }
-#pragma warning disable CA1031 // UI top-level handler
         catch (Exception ex)
-#pragma warning restore CA1031
         {
             _app.Invoke(() => _viewManager.ShowError($"Error loading JSON Array: {ex.Message}"));
         }

--- a/src/App/GlobalSuppressions.cs
+++ b/src/App/GlobalSuppressions.cs
@@ -1,0 +1,296 @@
+// Roslyn resolves [assembly: SuppressMessage] Targets via fully-qualified
+// documentation-comment signatures (e.g. ~M:N.T.Method(ParamType)), so parameter
+// types must be spelled out explicitly.
+using System.Diagnostics.CodeAnalysis;
+
+// ViewManager
+[assembly: SuppressMessage(
+    "Reliability",
+    "CA2213:Disposable fields should be disposed",
+    Scope = "member",
+    Target = "~F:Refedle.App.ViewManager._breadcrumbBar",
+    Justification = "BreadcrumbBar is added to the Window (_container) and is disposed automatically when the Window is disposed.")]
+[assembly: SuppressMessage(
+    "Reliability",
+    "CA2213:Disposable fields should be disposed",
+    Scope = "member",
+    Target = "~F:Refedle.App.ViewManager._contentContainer",
+    Justification = "ContentContainer is added to the Window (_container) and is disposed automatically when the Window is disposed.")]
+[assembly: SuppressMessage(
+    "Reliability",
+    "CA2000:Dispose objects before losing scope",
+    Scope = "member",
+    Target = "~M:Refedle.App.ViewManager.SwitchToCsvTable(Refedle.Engine.IO.IRowIndexer,Refedle.Engine.Models.TableSchema)",
+    Justification = "Child views are owned by the container and disposed via SwapView.")]
+[assembly: SuppressMessage(
+    "Reliability",
+    "CA2000:Dispose objects before losing scope",
+    Scope = "member",
+    Target = "~M:Refedle.App.ViewManager.SwitchToJsonLinesTree(Refedle.Engine.IO.IRowIndexer)",
+    Justification = "Child views are owned by the container and disposed via SwapView.")]
+[assembly: SuppressMessage(
+    "Reliability",
+    "CA2000:Dispose objects before losing scope",
+    Scope = "member",
+    Target = "~M:Refedle.App.ViewManager.SwitchToJsonArrayTree(Refedle.Engine.IO.IRowIndexer)",
+    Justification = "Child views are owned by the container and disposed via SwapView.")]
+[assembly: SuppressMessage(
+    "Reliability",
+    "CA2000:Dispose objects before losing scope",
+    Scope = "member",
+    Target = "~M:Refedle.App.ViewManager.SwitchToJsonObjectTree(System.Collections.Generic.IReadOnlyList{Refedle.Engine.IO.JsonObject.JsonObjectEntry})",
+    Justification = "Child views are owned by the container and disposed via SwapView.")]
+[assembly: SuppressMessage(
+    "Reliability",
+    "CA2000:Dispose objects before losing scope",
+    Scope = "member",
+    Target = "~M:Refedle.App.ViewManager.SwitchToJsonLinesTableView(Refedle.Engine.IO.IRowIndexer,Refedle.Engine.Models.TableSchema)",
+    Justification = "Child views are owned by the container and disposed via SwapView.")]
+[assembly: SuppressMessage(
+    "Style",
+    "IDE0010:Populate switch",
+    Scope = "member",
+    Target = "~M:Refedle.App.ViewManager.RefreshCurrentTableView",
+    Justification = "Only CsvTable/JsonLinesTable refresh here; all other modes are a no-op via the default arm.")]
+[assembly: SuppressMessage(
+    "Reliability",
+    "CA2000:Dispose objects before losing scope",
+    Scope = "member",
+    Target = "~M:Refedle.App.ViewManager.ShowError(System.String)",
+    Justification = "Child views are owned by the container and disposed via SwapView.")]
+[assembly: SuppressMessage(
+    "Reliability",
+    "CA2000:Dispose objects before losing scope",
+    Scope = "member",
+    Target = "~M:Refedle.App.ViewManager.SwitchToFocusedTable(Refedle.App.DrillDownState)",
+    Justification = "Owned by container via SwapView.")]
+[assembly: SuppressMessage(
+    "Style",
+    "IDE0010:Populate switch",
+    Scope = "member",
+    Target = "~M:Refedle.App.ViewManager.ReturnFromDrillDown",
+    Justification = "Only tree ViewMode values are valid PreviousMode; the default arm throws for any other member.")]
+
+// MainWindow
+[assembly: SuppressMessage(
+    "Reliability",
+    "CA2213:Disposable fields should be disposed",
+    Scope = "member",
+    Target = "~F:Refedle.App.MainWindow._progressBar",
+    Justification = "Child views added to the Window will be disposed automatically when the Window is disposed.")]
+[assembly: SuppressMessage(
+    "Reliability",
+    "CA2213:Disposable fields should be disposed",
+    Scope = "member",
+    Target = "~F:Refedle.App.MainWindow._progressLabel",
+    Justification = "Child views added to the Window will be disposed automatically when the Window is disposed.")]
+[assembly: SuppressMessage(
+    "Reliability",
+    "CA2000:Dispose objects before losing scope",
+    Scope = "member",
+    Target = "~M:Refedle.App.MainWindow.InitializeMenu",
+    Justification = "Child views added to the Window will be disposed automatically when the Window is disposed.")]
+[assembly: SuppressMessage(
+    "Reliability",
+    "CA2000:Dispose objects before losing scope",
+    Scope = "member",
+    Target = "~M:Refedle.App.MainWindow.InitializeStatusBar",
+    Justification = "Child views added to the Window will be disposed automatically when the Window is disposed.")]
+[assembly: SuppressMessage(
+    "Reliability",
+    "CA2000:Dispose objects before losing scope",
+    Scope = "member",
+    Target = "~M:Refedle.App.MainWindow.ShowIndexingProgress",
+    Justification = "Child views added to the Window will be disposed automatically when the Window is disposed.")]
+
+// AppKeyHandler
+[assembly: SuppressMessage(
+    "Reliability",
+    "CA2000:Dispose objects before losing scope",
+    Scope = "member",
+    Target = "~M:Refedle.App.AppKeyHandler.HandleHelp",
+    Justification = "The dialog is managed by Terminal.Gui's IApplication.Run() and will be disposed automatically.")]
+[assembly: SuppressMessage(
+    "Reliability",
+    "CA2000:Dispose objects before losing scope",
+    Scope = "member",
+    Target = "~M:Refedle.App.AppKeyHandler.HandleActionMenuForTable(Refedle.App.Views.MorphTableView)",
+    Justification = "The dialog is managed by Terminal.Gui's IApplication.Run() and will be disposed automatically.")]
+[assembly: SuppressMessage(
+    "Reliability",
+    "CA2000:Dispose objects before losing scope",
+    Scope = "member",
+    Target = "~M:Refedle.App.AppKeyHandler.HandleSingleDrillDown(Terminal.Gui.Views.ITreeNode,Refedle.Engine.Types.DataFormat)",
+    Justification = "The dialog is managed by Terminal.Gui's IApplication.Run() and will be disposed automatically.")]
+[assembly: SuppressMessage(
+    "Reliability",
+    "CA2000:Dispose objects before losing scope",
+    Scope = "member",
+    Target = "~M:Refedle.App.AppKeyHandler.HandleFullAggregationDrillDown(Terminal.Gui.Views.ITreeNode,Refedle.Engine.Types.DataFormat)",
+    Justification = "The dialog is managed by Terminal.Gui's IApplication.Run() and will be disposed automatically.")]
+
+// RecipeCommandHandler
+[assembly: SuppressMessage(
+    "Reliability",
+    "CA2000:Dispose objects before losing scope",
+    Scope = "member",
+    Target = "~M:Refedle.App.RecipeCommandHandler.SaveAsync",
+    Justification = "The OpenDialog is managed by Terminal.Gui's IApplication.Run() and will be disposed automatically.")]
+[assembly: SuppressMessage(
+    "Reliability",
+    "CA2000:Dispose objects before losing scope",
+    Scope = "member",
+    Target = "~M:Refedle.App.RecipeCommandHandler.LoadAsync",
+    Justification = "The OpenDialog is managed by Terminal.Gui's IApplication.Run() and will be disposed automatically.")]
+
+// FileDialogHandler
+[assembly: SuppressMessage(
+    "Reliability",
+    "CA2000:Dispose objects before losing scope",
+    Scope = "member",
+    Target = "~M:Refedle.App.FileDialogHandler.ShowAsync",
+    Justification = "The OpenDialog is managed by Terminal.Gui's IApplication.Run() and will be disposed automatically.")]
+[assembly: SuppressMessage(
+    "Design",
+    "CA1031:Do not catch general exception types",
+    Scope = "member",
+    Target = "~M:Refedle.App.FileDialogHandler.LoadJsonObjectAsync(System.String)",
+    Justification = "UI top-level handler")]
+[assembly: SuppressMessage(
+    "Design",
+    "CA1031:Do not catch general exception types",
+    Scope = "member",
+    Target = "~M:Refedle.App.FileDialogHandler.LoadCsvAsync(System.String,Refedle.Engine.IO.IRowIndexer)",
+    Justification = "UI top-level handler")]
+[assembly: SuppressMessage(
+    "Design",
+    "CA1031:Do not catch general exception types",
+    Scope = "member",
+    Target = "~M:Refedle.App.FileDialogHandler.LoadJsonLinesAsync(Refedle.Engine.IO.IRowIndexer)",
+    Justification = "UI top-level handler")]
+[assembly: SuppressMessage(
+    "Design",
+    "CA1031:Do not catch general exception types",
+    Scope = "member",
+    Target = "~M:Refedle.App.FileDialogHandler.LoadJsonArrayAsync(Refedle.Engine.IO.IRowIndexer)",
+    Justification = "UI top-level handler")]
+
+// KeyPathBuilder
+[assembly: SuppressMessage(
+    "Performance",
+    "CA1859:Use concrete types when possible for improved performance",
+    Scope = "member",
+    Target = "~M:Refedle.App.KeyPathBuilder.Build(Terminal.Gui.Views.ITreeNode)",
+    Justification = "IReadOnlyList<KeyPathSegment> is the KeyPath contract shared with FullAggregationDrillDownRequest; the concrete List<KeyPathSegment> used to build it is an implementation detail that should not leak out.")]
+
+// TuiApplication
+[assembly: SuppressMessage(
+    "Reliability",
+    "CA2000:Dispose objects before losing scope",
+    Scope = "member",
+    Target = "~M:Refedle.App.TuiApplication.Create",
+    Justification = "The created IApplication and MainWindow are returned to the caller, which is responsible for disposal.")]
+
+// Cli.JsonLinesRecordWriter
+[assembly: SuppressMessage(
+    "Design",
+    "CA1001:Types that own disposable fields should be disposable",
+    Scope = "type",
+    Target = "~T:Refedle.App.Cli.JsonLinesRecordWriter",
+    Justification = "JsonLinesRecordWriter is a struct designed for monomorphization as per ADR. It implements IRecordWriter which inherits from IDisposable and IAsyncDisposable, but CA1001 analyzer may be confused by structs or specific field types.")]
+[assembly: SuppressMessage(
+    "Reliability",
+    "CA1849:Call async methods when in an async method",
+    Scope = "member",
+    Target = "~M:Refedle.App.Cli.JsonLinesRecordWriter.WriteEndRecordAsync(System.Threading.CancellationToken)",
+    Justification = "Flush to IBufferWriter is synchronous and fast")]
+[assembly: SuppressMessage(
+    "Sonar Code Smell",
+    "S6966",
+    Scope = "member",
+    Target = "~M:Refedle.App.Cli.JsonLinesRecordWriter.WriteEndRecordAsync(System.Threading.CancellationToken)",
+    Justification = "Flush to IBufferWriter is synchronous and fast")]
+
+// Cli.Runner
+[assembly: SuppressMessage(
+    "Design",
+    "CA1031:Do not catch general exception types",
+    Scope = "member",
+    Target = "~M:Refedle.App.Cli.Runner.RunAsync(Refedle.App.Cli.Arguments,Refedle.App.Cli.IAppLogger,System.Threading.CancellationToken)",
+    Justification = "Top-level CLI handler reports any unexpected exception as an error exit code.")]
+
+// Cli.Factories
+[assembly: SuppressMessage(
+    "Reliability",
+    "CA2000:Dispose objects before losing scope",
+    Scope = "member",
+    Target = "~M:Refedle.App.Cli.Factories.JsonLinesRecordWriterFactory.CreateAsync(Refedle.App.Cli.Arguments,Refedle.Engine.BatchOutputSchema,Refedle.App.Cli.IAppLogger,System.Threading.CancellationToken)",
+    Justification = "Ownership is transferred to the caller.")]
+[assembly: SuppressMessage(
+    "Reliability",
+    "CA2000:Dispose objects before losing scope",
+    Scope = "member",
+    Target = "~M:Refedle.App.Cli.Factories.JsonLinesRecordReaderFactory.CreateAsync(Refedle.App.Cli.Arguments,Refedle.Engine.Models.TableSchema,Refedle.Engine.BatchOutputSchema,Refedle.App.Cli.IAppLogger,System.Threading.CancellationToken)",
+    Justification = "Ownership is transferred to the caller.")]
+[assembly: SuppressMessage(
+    "Reliability",
+    "CA2000:Dispose objects before losing scope",
+    Scope = "member",
+    Target = "~M:Refedle.App.Cli.Factories.CsvRecordWriterFactory.CreateAsync(Refedle.App.Cli.Arguments,Refedle.Engine.BatchOutputSchema,Refedle.App.Cli.IAppLogger,System.Threading.CancellationToken)",
+    Justification = "Ownership is transferred to the caller.")]
+
+// Views.Dialogs
+[assembly: SuppressMessage(
+    "Reliability",
+    "CA2000:Dispose objects before losing scope",
+    Scope = "member",
+    Target = "~M:Refedle.App.Views.Dialogs.DeleteColumnDialog.#ctor(System.String)",
+    Justification = "Child views are owned by the Dialog and disposed when the Dialog is disposed.")]
+[assembly: SuppressMessage(
+    "Reliability",
+    "CA2000:Dispose objects before losing scope",
+    Scope = "member",
+    Target = "~M:Refedle.App.Views.Dialogs.FilterColumnDialog.#ctor(System.String)",
+    Justification = "Child views are owned by the Dialog and disposed when the Dialog is disposed.")]
+[assembly: SuppressMessage(
+    "Reliability",
+    "CA2000:Dispose objects before losing scope",
+    Scope = "member",
+    Target = "~M:Refedle.App.Views.Dialogs.CastColumnDialog.#ctor(System.String,Refedle.Engine.Types.ColumnType,Refedle.Engine.Types.DataFormat)",
+    Justification = "Child views are owned by the Dialog and disposed when the Dialog is disposed.")]
+[assembly: SuppressMessage(
+    "Reliability",
+    "CA2000:Dispose objects before losing scope",
+    Scope = "member",
+    Target = "~M:Refedle.App.Views.Dialogs.RenameColumnDialog.#ctor(System.String)",
+    Justification = "Child views are owned by the Dialog and disposed when the Dialog is disposed.")]
+[assembly: SuppressMessage(
+    "Reliability",
+    "CA2000:Dispose objects before losing scope",
+    Scope = "member",
+    Target = "~M:Refedle.App.Views.Dialogs.HelpDialog.#ctor",
+    Justification = "Child views are owned by Dialog and disposed when Dialog is disposed.")]
+[assembly: SuppressMessage(
+    "Reliability",
+    "CA2000:Dispose objects before losing scope",
+    Scope = "member",
+    Target = "~M:Refedle.App.Views.Dialogs.FormatTimestampDialog.#ctor(System.String)",
+    Justification = "Child views are owned by Dialog and disposed when Dialog is disposed.")]
+[assembly: SuppressMessage(
+    "Reliability",
+    "CA2000:Dispose objects before losing scope",
+    Scope = "member",
+    Target = "~M:Refedle.App.Views.Dialogs.FillColumnDialog.#ctor(System.String)",
+    Justification = "Child views are owned by Dialog and disposed when Dialog is disposed.")]
+[assembly: SuppressMessage(
+    "Reliability",
+    "CA2213:Disposable fields should be disposed",
+    Scope = "member",
+    Target = "~F:Refedle.App.Views.Dialogs.ActionMenuDialog._listView",
+    Justification = "Child views added to Dialog will be disposed automatically when the Dialog is disposed.")]
+[assembly: SuppressMessage(
+    "Reliability",
+    "CA2000:Dispose objects before losing scope",
+    Scope = "member",
+    Target = "~M:Refedle.App.Views.Dialogs.ActionMenuDialog.#ctor(System.String[],System.Action{System.String})",
+    Justification = "Child views are owned by Dialog and disposed when Dialog is disposed.")]

--- a/src/App/KeyPathBuilder.cs
+++ b/src/App/KeyPathBuilder.cs
@@ -1,5 +1,4 @@
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 using Refedle.App.Views.JsonTreeNodes;
 using Refedle.Engine.IO.DrillDown;
 using Terminal.Gui.Views;
@@ -20,12 +19,6 @@ internal static class KeyPathBuilder
     /// </summary>
     /// <param name="node">The selected tree node to build the KeyPath from.</param>
     /// <returns>An ordered list of path segments from root to <paramref name="node"/>.</returns>
-    [SuppressMessage(
-        "Performance",
-        "CA1859:Use concrete types when possible for improved performance",
-        Justification = "IReadOnlyList<KeyPathSegment> is the KeyPath contract shared with FullAggregationDrillDownRequest; " +
-            "the concrete List<KeyPathSegment> used to build it is an implementation detail that should not leak out."
-    )]
     internal static IReadOnlyList<KeyPathSegment> Build(ITreeNode node)
     {
         List<KeyPathSegment> segments = [];

--- a/src/App/MainWindow.cs
+++ b/src/App/MainWindow.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics.CodeAnalysis;
 using Refedle.Engine.IO;
 using Terminal.Gui.App;
 using Terminal.Gui.ViewBase;
@@ -25,26 +24,9 @@ internal sealed class MainWindow : Window
     private Action<long, long>? _onProgressChanged;
     private Action? _onBuildIndexCompleted;
 
-    [SuppressMessage(
-        "Reliability",
-        "CA2213:Disposable fields should be disposed",
-        Justification = "Child views added to the Window will be disposed automatically when the Window is disposed."
-    )]
     private ProgressBar? _progressBar;
 
-    [SuppressMessage(
-        "Reliability",
-        "CA2213:Disposable fields should be disposed",
-        Justification = "Child views added to the Window will be disposed automatically when the Window is disposed."
-    )]
     private Label? _progressLabel;
-
-    [SuppressMessage(
-        "Reliability",
-        "CA2213:Disposable fields should be disposed",
-        Justification = "Child views added to the Window will be disposed automatically when the Window is disposed."
-    )]
-    private StatusBar? _statusBar;
 
     public MainWindow(IApplication app, AppState state)
     {
@@ -77,11 +59,6 @@ internal sealed class MainWindow : Window
         _keyHandler.Subscribe();
     }
 
-    [SuppressMessage(
-        "Reliability",
-        "CA2000:Dispose objects before losing scope",
-        Justification = "Child views added to the Window will be disposed automatically when the Window is disposed."
-    )]
     private void InitializeMenu()
     {
         var openMenuItem = new MenuItem("_Open", "", async () => await _fileDialogHandler.ShowAsync());
@@ -94,14 +71,9 @@ internal sealed class MainWindow : Window
         Add(menuBar);
     }
 
-    [SuppressMessage(
-        "Reliability",
-        "CA2000:Dispose objects before losing scope",
-        Justification = "Child views added to the Window will be disposed automatically when the Window is disposed."
-    )]
     private void InitializeStatusBar()
     {
-        _statusBar = new StatusBar
+        var statusBar = new StatusBar
         {
             X = 0,
             // Place at the very last line of the window
@@ -111,7 +83,7 @@ internal sealed class MainWindow : Window
         };
 
         _viewManager.RefreshStatusBarHints();
-        Add(_statusBar);
+        Add(statusBar);
     }
 
     protected override void Dispose(bool disposing)
@@ -202,11 +174,6 @@ internal sealed class MainWindow : Window
         DismissIndexingProgress();
     }
 
-    [SuppressMessage(
-        "Reliability",
-        "CA2000:Dispose objects before losing scope",
-        Justification = "Child views added to the Window will be disposed automatically when the Window is disposed."
-    )]
     private void ShowIndexingProgress()
     {
         DismissIndexingProgress();

--- a/src/App/RecipeCommandHandler.cs
+++ b/src/App/RecipeCommandHandler.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics.CodeAnalysis;
 using Refedle.Engine.Models;
 using Refedle.Engine.Recipes;
 using Terminal.Gui.App;
@@ -19,11 +18,6 @@ internal sealed class RecipeCommandHandler(
     private readonly ViewManager _viewManager = viewManager;
     private readonly RecipeManager _recipeManager = new();
 
-    [SuppressMessage(
-        "Reliability",
-        "CA2000:Dispose objects before losing scope",
-        Justification = "The OpenDialog is managed by Terminal.Gui's IApplication.Run() and will be disposed automatically."
-    )]
     internal async Task SaveAsync()
     {
         if (_state.CurrentMode is not (ViewMode.CsvTable or ViewMode.JsonLinesTable or ViewMode.JsonLinesTree))
@@ -67,11 +61,6 @@ internal sealed class RecipeCommandHandler(
         });
     }
 
-    [SuppressMessage(
-        "Reliability",
-        "CA2000:Dispose objects before losing scope",
-        Justification = "The OpenDialog is managed by Terminal.Gui's IApplication.Run() and will be disposed automatically."
-    )]
     internal async Task LoadAsync()
     {
         if (string.IsNullOrWhiteSpace(_state.CurrentFilePath))

--- a/src/App/TuiApplication.cs
+++ b/src/App/TuiApplication.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics.CodeAnalysis;
 using Terminal.Gui.App;
 
 namespace Refedle.App;
@@ -18,11 +17,6 @@ internal static class TuiApplication
     /// returned by this method. Child views added to the MainWindow will be disposed automatically
     /// when the MainWindow is disposed.
     /// </remarks>
-    [SuppressMessage(
-        "Reliability",
-        "CA2000:Dispose objects before losing scope",
-        Justification = "The created IApplication and MainWindow are returned to the caller, which is responsible for disposal."
-    )]
     public static (IApplication app, MainWindow mainWindow) Create()
     {
         var app = Application.Create();

--- a/src/App/ViewManager.cs
+++ b/src/App/ViewManager.cs
@@ -1,5 +1,4 @@
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 using System.Text;
 using Refedle.App.Views;
 using Refedle.Engine.IO;
@@ -26,17 +25,7 @@ internal sealed class ViewManager : IDisposable
     private readonly AppState _state;
     private readonly ModeController _modeController;
     private readonly Action<Action> _uiThreadInvoke;
-    [SuppressMessage(
-        "Reliability",
-        "CA2213:Disposable fields should be disposed",
-        Justification = "BreadcrumbBar is added to the Window (_container) and is disposed automatically when the Window is disposed."
-    )]
     private readonly BreadcrumbBar _breadcrumbBar;
-    [SuppressMessage(
-        "Reliability",
-        "CA2213:Disposable fields should be disposed",
-        Justification = "ContentContainer is added to the Window (_container) and is disposed automatically when the Window is disposed."
-    )]
     private readonly View _contentContainer;
     private View? _currentView;
     private Label? _itemCountLabel;
@@ -237,11 +226,6 @@ internal sealed class ViewManager : IDisposable
     /// </summary>
     /// <param name="indexer">The CSV row indexer for the loaded file.</param>
     /// <param name="schema">The detected table schema.</param>
-    [SuppressMessage(
-        "Reliability",
-        "CA2000:Dispose objects before losing scope",
-        Justification = "Child views are owned by the container and disposed via SwapView."
-    )]
     internal void SwitchToCsvTable(IRowIndexer indexer, TableSchema schema)
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
@@ -292,11 +276,6 @@ internal sealed class ViewManager : IDisposable
     /// Switches the content area to the JSON Lines hierarchical tree view.
     /// </summary>
     /// <param name="indexer">The JSON Lines row indexer for the loaded file.</param>
-    [SuppressMessage(
-        "Reliability",
-        "CA2000:Dispose objects before losing scope",
-        Justification = "Child views are owned by the container and disposed via SwapView."
-    )]
     internal void SwitchToJsonLinesTree(IRowIndexer indexer)
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
@@ -316,11 +295,6 @@ internal sealed class ViewManager : IDisposable
     /// Switches the content area to the JSON Array hierarchical tree view.
     /// </summary>
     /// <param name="indexer">The JSON Array row indexer for the loaded file.</param>
-    [SuppressMessage(
-        "Reliability",
-        "CA2000:Dispose objects before losing scope",
-        Justification = "Child views are owned by the container and disposed via SwapView."
-    )]
     internal void SwitchToJsonArrayTree(IRowIndexer indexer)
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
@@ -343,11 +317,6 @@ internal sealed class ViewManager : IDisposable
     /// <param name="entries">
     /// The key-value pairs returned by <see cref="Engine.IO.JsonObject.TopLevelScanner.Scan"/>.
     /// </param>
-    [SuppressMessage(
-        "Reliability",
-        "CA2000:Dispose objects before losing scope",
-        Justification = "Child views are owned by the container and disposed via SwapView."
-    )]
     internal void SwitchToJsonObjectTree(
         IReadOnlyList<JsonObjectEntry> entries)
     {
@@ -369,11 +338,6 @@ internal sealed class ViewManager : IDisposable
     /// </summary>
     /// <param name="indexer">The JSON Lines row indexer for the loaded file.</param>
     /// <param name="schema">The detected table schema.</param>
-    [SuppressMessage(
-        "Reliability",
-        "CA2000:Dispose objects before losing scope",
-        Justification = "Child views are owned by the container and disposed via SwapView."
-    )]
     internal void SwitchToJsonLinesTableView(IRowIndexer indexer, TableSchema schema)
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
@@ -429,11 +393,6 @@ internal sealed class ViewManager : IDisposable
     /// Called after a morph action is added to <see cref="AppState.ActionStack"/> so that
     /// <see cref="Views.LazyTransformer"/> is reconstructed with the updated stack.
     /// </summary>
-    [SuppressMessage(
-        "Style",
-        "IDE0010:Populate switch",
-        Justification = "Only CsvTable/JsonLinesTable refresh here; all other modes are a no-op via the default arm."
-    )]
     internal void RefreshCurrentTableView()
     {
         switch (_state.CurrentMode)
@@ -470,11 +429,6 @@ internal sealed class ViewManager : IDisposable
     /// Displays an error message in a placeholder view.
     /// </summary>
     /// <param name="message">The error message to display.</param>
-    [SuppressMessage(
-        "Reliability",
-        "CA2000:Dispose objects before losing scope",
-        Justification = "Child views are owned by the container and disposed via SwapView."
-    )]
     internal void ShowError(string message)
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
@@ -620,7 +574,6 @@ internal sealed class ViewManager : IDisposable
     /// <summary>
     /// Creates FocusedTableSource and FocusedTableView, then switches to the FocusedTable view.
     /// </summary>
-    [SuppressMessage("Reliability", "CA2000", Justification = "Owned by container via SwapView.")]
     internal void SwitchToFocusedTable(DrillDownState drillDown)
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
@@ -643,11 +596,6 @@ internal sealed class ViewManager : IDisposable
     /// entered from, rebuilding that tree from its cached backing data on <see cref="AppState"/>.
     /// A no-op when there is no active DrillDown session.
     /// </summary>
-    [SuppressMessage(
-        "Style",
-        "IDE0010:Populate switch",
-        Justification = "Only tree ViewMode values are valid PreviousMode; the default arm throws for any other member."
-    )]
     internal void ReturnFromDrillDown()
     {
         ObjectDisposedException.ThrowIf(_disposed, this);

--- a/src/App/Views/Dialogs/ActionMenuDialog.cs
+++ b/src/App/Views/Dialogs/ActionMenuDialog.cs
@@ -1,6 +1,5 @@
 using System.Collections.ObjectModel;
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 using Terminal.Gui.Drivers;
 using Terminal.Gui.Input;
 using Terminal.Gui.ViewBase;
@@ -14,11 +13,6 @@ namespace Refedle.App.Views.Dialogs;
 /// </summary>
 internal sealed class ActionMenuDialog : Dialog
 {
-    [SuppressMessage(
-        "Reliability",
-        "CA2213:Disposable fields should be disposed",
-        Justification = "Child views added to Dialog will be disposed automatically when the Dialog is disposed."
-    )]
     private readonly ListView _listView;
     private readonly Action<string> _onConfirmed;
 
@@ -37,11 +31,6 @@ internal sealed class ActionMenuDialog : Dialog
     /// </summary>
     /// <param name="availableActions">List of actions available for the current context.</param>
     /// <param name="onConfirmed">Callback invoked when the user confirms an action selection.</param>
-    [SuppressMessage(
-        "Reliability",
-        "CA2000:Dispose objects before losing scope",
-        Justification = "Child views are owned by Dialog and disposed when Dialog is disposed."
-    )]
     internal ActionMenuDialog(string[] availableActions, Action<string> onConfirmed)
     {
         ArgumentNullException.ThrowIfNull(availableActions);

--- a/src/App/Views/Dialogs/CastColumnDialog.cs
+++ b/src/App/Views/Dialogs/CastColumnDialog.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics.CodeAnalysis;
 using Refedle.Engine.Types;
 using Terminal.Gui.ViewBase;
 using Terminal.Gui.Views;
@@ -29,11 +28,6 @@ internal sealed class CastColumnDialog : Dialog
     /// <param name="columnName">The name of the column to cast.</param>
     /// <param name="currentType">The current column type, pre-selected in the option list.</param>
     /// <param name="format">The data format of the current file.</param>
-    [SuppressMessage(
-        "Reliability",
-        "CA2000:Dispose objects before losing scope",
-        Justification = "Child views are owned by the Dialog and disposed when the Dialog is disposed."
-    )]
     internal CastColumnDialog(string columnName, ColumnType currentType, DataFormat format)
     {
         Title = "Cast Column Type";

--- a/src/App/Views/Dialogs/DeleteColumnDialog.cs
+++ b/src/App/Views/Dialogs/DeleteColumnDialog.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics.CodeAnalysis;
 using Terminal.Gui.Views;
 
 namespace Refedle.App.Views.Dialogs;
@@ -17,11 +16,6 @@ internal sealed class DeleteColumnDialog : Dialog
     /// Initializes a new instance of the <see cref="DeleteColumnDialog"/> class.
     /// </summary>
     /// <param name="columnName">The name of the column to be deleted, shown in the prompt.</param>
-    [SuppressMessage(
-        "Reliability",
-        "CA2000:Dispose objects before losing scope",
-        Justification = "Child views are owned by the Dialog and disposed when the Dialog is disposed."
-    )]
     internal DeleteColumnDialog(string columnName)
     {
         Title = "Delete Column";

--- a/src/App/Views/Dialogs/FillColumnDialog.cs
+++ b/src/App/Views/Dialogs/FillColumnDialog.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics.CodeAnalysis;
 using Terminal.Gui.ViewBase;
 using Terminal.Gui.Views;
 
@@ -24,11 +23,6 @@ internal sealed class FillColumnDialog : Dialog
     /// Initializes a new instance of the <see cref="FillColumnDialog"/> class.
     /// </summary>
     /// <param name="columnName">The name of the column to fill.</param>
-    [SuppressMessage(
-        "Reliability",
-        "CA2000:Dispose objects before losing scope",
-        Justification = "Child views are owned by Dialog and disposed when Dialog is disposed."
-    )]
     internal FillColumnDialog(string columnName)
     {
         Title = "Fill Column";

--- a/src/App/Views/Dialogs/FilterColumnDialog.cs
+++ b/src/App/Views/Dialogs/FilterColumnDialog.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics.CodeAnalysis;
 using Refedle.Engine.Models.Actions;
 using Terminal.Gui.ViewBase;
 using Terminal.Gui.Views;
@@ -33,11 +32,6 @@ internal sealed class FilterColumnDialog : Dialog
     /// Initializes a new instance of the <see cref="FilterColumnDialog"/> class.
     /// </summary>
     /// <param name="columnName">The name of the column to filter on.</param>
-    [SuppressMessage(
-        "Reliability",
-        "CA2000:Dispose objects before losing scope",
-        Justification = "Child views are owned by the Dialog and disposed when the Dialog is disposed."
-    )]
     internal FilterColumnDialog(string columnName)
     {
         Title = "Filter Column";

--- a/src/App/Views/Dialogs/FormatTimestampDialog.cs
+++ b/src/App/Views/Dialogs/FormatTimestampDialog.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics.CodeAnalysis;
 using Terminal.Gui.ViewBase;
 using Terminal.Gui.Views;
 
@@ -24,11 +23,6 @@ internal sealed class FormatTimestampDialog : Dialog
     /// Initializes a new instance of the <see cref="FormatTimestampDialog"/> class.
     /// </summary>
     /// <param name="columnName">The name of column to format.</param>
-    [SuppressMessage(
-        "Reliability",
-        "CA2000:Dispose objects before losing scope",
-        Justification = "Child views are owned by Dialog and disposed when Dialog is disposed."
-    )]
     internal FormatTimestampDialog(string columnName)
     {
         Title = "Format Timestamp";

--- a/src/App/Views/Dialogs/HelpDialog.cs
+++ b/src/App/Views/Dialogs/HelpDialog.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics.CodeAnalysis;
 using Terminal.Gui.Drivers;
 using Terminal.Gui.Input;
 using Terminal.Gui.ViewBase;
@@ -14,11 +13,6 @@ internal sealed class HelpDialog : Dialog
     /// <summary>
     /// Initializes a new instance of the <see cref="HelpDialog"/> class.
     /// </summary>
-    [SuppressMessage(
-        "Reliability",
-        "CA2000:Dispose objects before losing scope",
-        Justification = "Child views are owned by Dialog and disposed when Dialog is disposed."
-    )]
     internal HelpDialog()
     {
         Title = "Help - Key Bindings";

--- a/src/App/Views/Dialogs/RenameColumnDialog.cs
+++ b/src/App/Views/Dialogs/RenameColumnDialog.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics.CodeAnalysis;
 using Terminal.Gui.ViewBase;
 using Terminal.Gui.Views;
 
@@ -26,11 +25,6 @@ internal sealed class RenameColumnDialog : Dialog
     /// Initializes a new instance of the <see cref="RenameColumnDialog"/> class.
     /// </summary>
     /// <param name="currentName">The current column name shown as the pre-filled value.</param>
-    [SuppressMessage(
-        "Reliability",
-        "CA2000:Dispose objects before losing scope",
-        Justification = "Child views are owned by the Dialog and disposed when the Dialog is disposed."
-    )]
     internal RenameColumnDialog(string currentName)
     {
         Title = "Rename Column";

--- a/src/Engine/GlobalSuppressions.cs
+++ b/src/Engine/GlobalSuppressions.cs
@@ -1,0 +1,51 @@
+// Roslyn resolves [assembly: SuppressMessage] Targets via fully-qualified documentation
+// signatures, so parameter/event types are spelled out explicitly.
+using System.Diagnostics.CodeAnalysis;
+
+// MmapService
+[assembly: SuppressMessage(
+    "Reliability",
+    "CA2000:Dispose objects before losing scope",
+    Scope = "member",
+    Target = "~M:Refedle.Engine.IO.MmapService.Open(System.String,System.IO.FileAccess)",
+    Justification = "MmapService ownership is transferred to the caller via Result<T>")]
+
+// RowIndexerBase — Action-based events are an intentional design decision; see class remarks.
+[assembly: SuppressMessage(
+    "Design",
+    "CA1003:Use generic event handler instances",
+    Scope = "member",
+    Target = "~E:Refedle.Engine.IO.RowIndexerBase.FirstCheckpointReached",
+    Justification = "See class remarks for rationale")]
+[assembly: SuppressMessage(
+    "Design",
+    "CA1003:Use generic event handler instances",
+    Scope = "member",
+    Target = "~E:Refedle.Engine.IO.RowIndexerBase.ProgressChanged",
+    Justification = "See class remarks for rationale")]
+[assembly: SuppressMessage(
+    "Design",
+    "CA1003:Use generic event handler instances",
+    Scope = "member",
+    Target = "~E:Refedle.Engine.IO.RowIndexerBase.BuildIndexCompleted",
+    Justification = "See class remarks for rationale")]
+
+// IRowIndexer
+[assembly: SuppressMessage(
+    "Design",
+    "CA1003:Use generic event handler instances",
+    Scope = "member",
+    Target = "~E:Refedle.Engine.IO.IRowIndexer.FirstCheckpointReached",
+    Justification = "See RowIndexerBase remarks for rationale")]
+[assembly: SuppressMessage(
+    "Design",
+    "CA1003:Use generic event handler instances",
+    Scope = "member",
+    Target = "~E:Refedle.Engine.IO.IRowIndexer.ProgressChanged",
+    Justification = "See RowIndexerBase remarks for rationale")]
+[assembly: SuppressMessage(
+    "Design",
+    "CA1003:Use generic event handler instances",
+    Scope = "member",
+    Target = "~E:Refedle.Engine.IO.IRowIndexer.BuildIndexCompleted",
+    Justification = "See RowIndexerBase remarks for rationale")]

--- a/src/Engine/IO/IRowIndexer.cs
+++ b/src/Engine/IO/IRowIndexer.cs
@@ -10,7 +10,6 @@ public interface IRowIndexer
     /// </summary>
     void BuildIndex(CancellationToken ct = default);
 
-#pragma warning disable CA1003
     /// <summary>
     /// Raised once when the first checkpoint has been indexed.
     /// </summary>
@@ -25,7 +24,6 @@ public interface IRowIndexer
     /// Raised once when BuildIndex returns.
     /// </summary>
     event Action? BuildIndexCompleted;
-#pragma warning restore CA1003
 
     /// <summary>
     /// Gets the bytes read so far.

--- a/src/Engine/IO/MmapService.cs
+++ b/src/Engine/IO/MmapService.cs
@@ -1,5 +1,4 @@
 using System.Buffers;
-using System.Diagnostics.CodeAnalysis;
 using System.IO.MemoryMappedFiles;
 
 namespace Refedle.Engine.IO;
@@ -48,7 +47,6 @@ public sealed class MmapService : IDisposable
     /// A Result containing the MmapService on success, or an error message on failure.
     /// </returns>
     /// <exception cref="ArgumentException">Thrown when filePath is null, empty, or whitespace.</exception>
-    [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "MmapService ownership is transferred to the caller via Result<T>")]
     public static Result<MmapService> Open(string filePath, FileAccess access = FileAccess.Read)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(filePath);

--- a/src/Engine/IO/RowIndexerBase.cs
+++ b/src/Engine/IO/RowIndexerBase.cs
@@ -67,7 +67,6 @@ public abstract class RowIndexerBase : IRowIndexer
     /// <inheritdoc />
     public abstract string FilePath { get; }
 
-#pragma warning disable CA1003 // See class <remarks> for rationale
     /// <inheritdoc />
     public event Action? FirstCheckpointReached;
 
@@ -76,7 +75,6 @@ public abstract class RowIndexerBase : IRowIndexer
 
     /// <inheritdoc />
     public event Action? BuildIndexCompleted;
-#pragma warning restore CA1003
 
     /// <inheritdoc />
     public abstract void BuildIndex(CancellationToken ct = default);

--- a/src/Generators/GlobalSuppressions.cs
+++ b/src/Generators/GlobalSuppressions.cs
@@ -1,0 +1,11 @@
+// Centralized code-analysis suppressions for the Generators project.
+using System.Diagnostics.CodeAnalysis;
+
+// IsExternalInit polyfill — the namespace must be System.Runtime.CompilerServices for the
+// compiler to recognize it, which deliberately violates the folder-structure rule.
+[assembly: SuppressMessage(
+    "Style",
+    "IDE0130:Namespace does not match folder structure",
+    Scope = "namespace",
+    Target = "~N:System.Runtime.CompilerServices",
+    Justification = "Namespace must be System.Runtime.CompilerServices for the compiler to recognize this polyfill.")]

--- a/src/Generators/IsExternalInit.cs
+++ b/src/Generators/IsExternalInit.cs
@@ -1,6 +1,4 @@
-#pragma warning disable IDE0130 // Namespace must be System.Runtime.CompilerServices for the compiler to recognize this polyfill
 namespace System.Runtime.CompilerServices;
-#pragma warning restore IDE0130
 
 /// <summary>
 /// This class is required by the C# compiler to support the 'record' and 'init' keywords

--- a/tests/Refedle.Tests/App/IndexTaskManagerTests.cs
+++ b/tests/Refedle.Tests/App/IndexTaskManagerTests.cs
@@ -85,10 +85,7 @@ public sealed class IndexTaskManagerTests : IDisposable
     public void Dispose_WithoutPriorStart_DoesNotThrow()
     {
         // Arrange
-        // CA2000: manager is disposed via act() below; suppress false positive.
-#pragma warning disable CA2000
         var manager = new IndexTaskManager();
-#pragma warning restore CA2000
 
         // Act
         var act = () => manager.Dispose();
@@ -188,10 +185,7 @@ public sealed class IndexTaskManagerTests : IDisposable
     public void CancelCurrent_AfterDisposal_ThrowsObjectDisposedException()
     {
         // Arrange
-        // CA2000: manager is disposed via manager.Dispose() below; suppress false positive.
-#pragma warning disable CA2000
         var manager = new IndexTaskManager();
-#pragma warning restore CA2000
         manager.Dispose();
 
         // Act
@@ -237,13 +231,11 @@ public sealed class IndexTaskManagerTests : IDisposable
     {
         public bool WasCancelled { get; private set; }
 
-#pragma warning disable CA1003
         public event Action? FirstCheckpointReached;
 #pragma warning disable CS0067
         public event Action<long, long>? ProgressChanged;
 #pragma warning restore CS0067
         public event Action? BuildIndexCompleted;
-#pragma warning restore CA1003
 
         public long BytesRead => 0;
         public long FileSize => 0;

--- a/tests/Refedle.Tests/App/Views/JsonLinesTableSourceTests.cs
+++ b/tests/Refedle.Tests/App/Views/JsonLinesTableSourceTests.cs
@@ -304,9 +304,7 @@ public sealed class JsonLinesTableSourceTests : IDisposable
     public void Dispose_DisposesRowByteCache()
     {
         // Arrange
-#pragma warning disable CA2000 // Ownership transferred to source
         var cache = new RowByteCache(_indexer);
-#pragma warning restore CA2000
         var schema = new TableSchema
         {
             Columns = [new ColumnSchema { Name = "id", Type = ColumnType.WholeNumber, ColumnIndex = 0 }],

--- a/tests/Refedle.Tests/GlobalSuppressions.cs
+++ b/tests/Refedle.Tests/GlobalSuppressions.cs
@@ -1,0 +1,43 @@
+// Roslyn resolves [assembly: SuppressMessage] Targets via fully-qualified documentation
+// signatures, so member types are spelled out explicitly.
+using System.Diagnostics.CodeAnalysis;
+
+// IndexTaskManagerTests
+[assembly: SuppressMessage(
+    "Reliability",
+    "CA2000:Dispose objects before losing scope",
+    Scope = "member",
+    Target = "~M:Refedle.Tests.App.IndexTaskManagerTests.Dispose_WithoutPriorStart_DoesNotThrow",
+    Justification = "manager is disposed via act() below; suppress false positive.")]
+[assembly: SuppressMessage(
+    "Reliability",
+    "CA2000:Dispose objects before losing scope",
+    Scope = "member",
+    Target = "~M:Refedle.Tests.App.IndexTaskManagerTests.CancelCurrent_AfterDisposal_ThrowsObjectDisposedException",
+    Justification = "manager is disposed via manager.Dispose() below; suppress false positive.")]
+[assembly: SuppressMessage(
+    "Design",
+    "CA1003:Use generic event handler instances",
+    Scope = "member",
+    Target = "~E:Refedle.Tests.App.IndexTaskManagerTests.BlockingIndexer.FirstCheckpointReached",
+    Justification = "Test stub mirrors IRowIndexer's Action-based event contract.")]
+[assembly: SuppressMessage(
+    "Design",
+    "CA1003:Use generic event handler instances",
+    Scope = "member",
+    Target = "~E:Refedle.Tests.App.IndexTaskManagerTests.BlockingIndexer.ProgressChanged",
+    Justification = "Test stub mirrors IRowIndexer's Action-based event contract.")]
+[assembly: SuppressMessage(
+    "Design",
+    "CA1003:Use generic event handler instances",
+    Scope = "member",
+    Target = "~E:Refedle.Tests.App.IndexTaskManagerTests.BlockingIndexer.BuildIndexCompleted",
+    Justification = "Test stub mirrors IRowIndexer's Action-based event contract.")]
+
+// JsonLinesTableSourceTests
+[assembly: SuppressMessage(
+    "Reliability",
+    "CA2000:Dispose objects before losing scope",
+    Scope = "member",
+    Target = "~M:Refedle.Tests.App.Views.JsonLinesTableSourceTests.Dispose_DisposesRowByteCache",
+    Justification = "Ownership transferred to source")]


### PR DESCRIPTION
## Summary
- Move scattered inline `[SuppressMessage]` attributes into one `GlobalSuppressions.cs` per project (`src/App`, `src/Engine`, `src/Generators`, `tests/Refedle.Tests`)
- No logic changes; mechanical relocation of ~65 suppression entries with Target/Scope verified against actual member signatures
- `MainWindow._statusBar` field demoted to a local variable (matching the `_modeController`/`f9fbdc1` precedent) instead of adding a new `S1450` suppression, after this warning newly surfaced once the CA2213 attribute moved off the field itself
- Two categories of inline `#pragma warning disable` intentionally kept (documented in code):
  - `IDE0005` in `OptionSelectorExtensions.cs` — moving to `GlobalSuppressions.cs` would require `Scope="namespace"`, which would over-suppress unrelated unused-using warnings across the whole namespace
  - `CS0067` in test stub files — compiler diagnostic, not suppressible via `[SuppressMessage]`

## Test plan
- [x] `dotnet format` — no diff
- [x] `dotnet build --no-incremental` — 0 Warning(s), 0 Error(s)
- [x] `dotnet test` — 1530 passed, 0 failed