### PR TITLE
fix: convert KeyPathTraverser recursion to iterative DFS

### DIFF
--- a/src/Engine/IO/DrillDown/KeyPathLeafCollector.cs
+++ b/src/Engine/IO/DrillDown/KeyPathLeafCollector.cs
@@ -1,0 +1,157 @@
+using System.Buffers;
+using System.Text.Json;
+using Refedle.Engine.IO.Json;
+using Refedle.Engine.Types;
+
+namespace Refedle.Engine.IO.DrillDown;
+
+/// <summary>
+/// Collects leaf row(s) and schema observations at the end of a KeyPath descent, plus the byte-level
+/// value lookup used to descend object-key segments. Extracted from <see cref="KeyPathTraverser"/> so
+/// the traversal control flow depends only one-way on collection: KeyPathTraverser calls into this
+/// type, never the reverse. All value slicing delegates to <see cref="JsonByteExtractor"/>.
+/// </summary>
+internal static class KeyPathLeafCollector
+{
+    internal static void CollectLeafRows(
+        JsonRawBytes leafBytes,
+        string posHash,
+        string colName,
+        byte[] colNameUtf8,
+        List<FocusedTableRow> rows,
+        List<string> keyOrder,
+        HashSet<string> keySet,
+        Dictionary<string, ColumnType> columnTypes,
+        Dictionary<string, int> keyObservedCount)
+    {
+        var reader = new Utf8JsonReader(leafBytes.Span);
+        if (!reader.Read())
+        {
+            return;
+        }
+
+        if (reader.TokenType == JsonTokenType.StartObject)
+        {
+            rows.Add(new FocusedTableRow(leafBytes, posHash));
+            var observedKeys = new HashSet<string>(StringComparer.Ordinal);
+            SchemaScanner.ScanObject(leafBytes.Span, keyOrder, keySet, columnTypes, observedKeys);
+            SchemaScanner.IncrementObservationCounts(observedKeys, keyObservedCount);
+            return;
+        }
+
+        if (reader.TokenType == JsonTokenType.StartArray)
+        {
+            CollectArrayLeafRows(leafBytes, posHash, rows, keyOrder, keySet, columnTypes, keyObservedCount);
+            return;
+        }
+
+        // Primitive leaf (including null) — synthesize a single-key object so
+        // JsonObjectCellExtractor can extract it without modification.
+        // Note: ScanObject is NOT called here, so no type inference is performed;
+        // the synthesized column always receives ColumnType.Text (Phase 2 limitation).
+        var synthBytes = SynthesizeObject(colNameUtf8, leafBytes.Span);
+        rows.Add(new FocusedTableRow(synthBytes, posHash));
+        SchemaScanner.RegisterKeyIfNew(colName, keyOrder, keySet);
+        SchemaScanner.IncrementObservationCounts([colName], keyObservedCount);
+    }
+
+    internal static void CollectArrayLeafRows(
+        JsonRawBytes leafBytes,
+        string posHash,
+        List<FocusedTableRow> rows,
+        List<string> keyOrder,
+        HashSet<string> keySet,
+        Dictionary<string, ColumnType> columnTypes,
+        Dictionary<string, int> keyObservedCount)
+    {
+        var reader = new Utf8JsonReader(leafBytes.Span);
+        if (!reader.Read() || reader.TokenType != JsonTokenType.StartArray)
+        {
+            return;
+        }
+
+        var elementIndex = 0;
+        while (reader.Read())
+        {
+            if (reader.TokenType == JsonTokenType.EndArray)
+            {
+                break;
+            }
+
+            if (reader.CurrentDepth != 1)
+            {
+                continue;
+            }
+
+            var isObjectElement = reader.TokenType == JsonTokenType.StartObject;
+            var elementBytes = JsonByteExtractor.ExtractValueBytes(ref reader, leafBytes);
+            var elementHash = $"{posHash}:{elementIndex}";
+
+            if (isObjectElement)
+            {
+                rows.Add(new FocusedTableRow(elementBytes, elementHash));
+                var observedKeys = new HashSet<string>(StringComparer.Ordinal);
+                SchemaScanner.ScanObject(elementBytes.Span, keyOrder, keySet, columnTypes, observedKeys);
+                SchemaScanner.IncrementObservationCounts(observedKeys, keyObservedCount);
+                elementIndex++;
+                continue;
+            }
+
+            // Primitive element (including null) — synthesize {"value": element}.
+            var synthBytes = SynthesizeObject("value"u8, elementBytes.Span);
+            rows.Add(new FocusedTableRow(synthBytes, elementHash));
+            SchemaScanner.RegisterKeyIfNew("value", keyOrder, keySet);
+            SchemaScanner.IncrementObservationCounts(["value"], keyObservedCount);
+            elementIndex++;
+        }
+    }
+
+    internal static JsonRawBytes? FindValueByKey(JsonRawBytes objectBytes, string key)
+    {
+        var reader = new Utf8JsonReader(objectBytes.Span);
+        if (!reader.Read() || reader.TokenType != JsonTokenType.StartObject)
+        {
+            return null;
+        }
+
+        while (reader.Read())
+        {
+            if (reader.TokenType == JsonTokenType.EndObject)
+            {
+                return null;
+            }
+
+            if (reader.TokenType != JsonTokenType.PropertyName)
+            {
+                continue;
+            }
+
+            if (!reader.ValueTextEquals(key))
+            {
+                reader.Skip();
+                continue;
+            }
+
+            if (!reader.Read())
+            {
+                return null;
+            }
+
+            return JsonByteExtractor.ExtractValueBytes(ref reader, objectBytes);
+        }
+
+        return null;
+    }
+
+    private static JsonRawBytes SynthesizeObject(ReadOnlySpan<byte> keyUtf8, ReadOnlySpan<byte> valueBytes)
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        using var writer = new Utf8JsonWriter(buffer);
+        writer.WriteStartObject();
+        writer.WritePropertyName(keyUtf8);
+        writer.WriteRawValue(valueBytes, skipInputValidation: true);
+        writer.WriteEndObject();
+        writer.Flush();
+        return buffer.WrittenMemory;
+    }
+}

--- a/src/Engine/IO/DrillDown/KeyPathTraverser.cs
+++ b/src/Engine/IO/DrillDown/KeyPathTraverser.cs
@@ -1,4 +1,3 @@
-using System.Buffers;
 using System.Text.Json;
 using Refedle.Engine.IO.Json;
 using Refedle.Engine.Types;
@@ -6,10 +5,11 @@ using Refedle.Engine.Types;
 namespace Refedle.Engine.IO.DrillDown;
 
 /// <summary>
-/// Stateless helpers that traverse a KeyPath through a single record's bytes and collect the
-/// leaf row(s) reached, accumulating schema information along the way. Shared implementation
-/// detail of <see cref="FullAggregationScanner"/>, split out to keep both classes under the
-/// project's per-class line limit.
+/// Traverses a KeyPath through a single record's bytes with an explicit-stack DFS, collecting leaf
+/// rows via <see cref="KeyPathLeafCollector"/>. Descent depth is bounded by the heap, not the call
+/// stack, so a keyPath whose length is driven by untrusted input cannot overflow the stack. Leaf
+/// collection and value lookup live in <see cref="KeyPathLeafCollector"/> to keep both classes under
+/// the per-class line limit and the dependency one-way (this class calls the collector, never back).
 /// </summary>
 internal static class KeyPathTraverser
 {
@@ -30,9 +30,23 @@ internal static class KeyPathTraverser
         Dictionary<string, ColumnType> columnTypes,
         Dictionary<string, int> keyObservedCount)
     {
-        TraverseKeyPath(
-            recordBytes, keyPath, 0, posHash, colName, colNameUtf8,
-            rows, keyOrder, keySet, columnTypes, keyObservedCount);
+        Stack<TraversalFrame> stack = [];
+        stack.Push(TraversalFrame.Descend(recordBytes, 0, posHash));
+        while (stack.TryPop(out var frame))
+        {
+            var (next, deferred) = ProcessFrame(
+                frame, keyPath, colName, colNameUtf8,
+                rows, keyOrder, keySet, columnTypes, keyObservedCount);
+            if (deferred is { } d)
+            {
+                stack.Push(d);
+            }
+
+            if (next is { } n)
+            {
+                stack.Push(n);
+            }
+        }
     }
 
     /// <summary>
@@ -53,11 +67,32 @@ internal static class KeyPathTraverser
         return "value";
     }
 
-    private static void TraverseKeyPath(
-        JsonRawBytes currentBytes,
+    private enum FrameKind { Descend, ContinueArray }
+
+    /// <summary>
+    /// Pending descent work. <see cref="FrameKind.Descend"/> applies the segment at
+    /// <see cref="SegmentIndex"/> to <see cref="Bytes"/>. <see cref="FrameKind.ContinueArray"/>
+    /// resumes an index segment's array scan from <see cref="ReaderState"/>; it is returned as the
+    /// deferred frame after each element so only O(depth) frames stay live, never one per sibling.
+    /// </summary>
+    private readonly record struct TraversalFrame(
+        FrameKind Kind,
+        JsonRawBytes Bytes,
+        int SegmentIndex,
+        int ElementIndex,
+        string PosHash,
+        JsonReaderState ReaderState)
+    {
+        public static TraversalFrame Descend(JsonRawBytes bytes, int segmentIndex, string posHash) =>
+            new(FrameKind.Descend, bytes, segmentIndex, 0, posHash, default);
+    }
+
+    // Returns the frame to descend next (its subtree processed first) and the frame to resume
+    // afterward (an array scan continuation). The caller pushes deferred, then next, so the LIFO
+    // stack finishes next's subtree before resuming deferred — preserving forward DFS order.
+    private static (TraversalFrame? next, TraversalFrame? deferred) ProcessFrame(
+        TraversalFrame frame,
         IReadOnlyList<KeyPathSegment> keyPath,
-        int segmentIndex,
-        string posHash,
         string colName,
         byte[] colNameUtf8,
         List<FocusedTableRow> rows,
@@ -66,67 +101,74 @@ internal static class KeyPathTraverser
         Dictionary<string, ColumnType> columnTypes,
         Dictionary<string, int> keyObservedCount)
     {
-        if (segmentIndex == keyPath.Count)
+        if (frame.Kind == FrameKind.ContinueArray)
         {
-            CollectLeafRows(currentBytes, posHash, colName, colNameUtf8, rows, keyOrder, keySet, columnTypes, keyObservedCount);
-            return;
+            var reader = new Utf8JsonReader(frame.Bytes.Span, isFinalBlock: true, frame.ReaderState);
+            return ScanOneArrayElement(ref reader, frame.Bytes, frame.SegmentIndex, frame.ElementIndex, frame.PosHash);
         }
 
-        var segment = keyPath[segmentIndex];
+        if (frame.SegmentIndex == keyPath.Count)
+        {
+            KeyPathLeafCollector.CollectLeafRows(
+                frame.Bytes, frame.PosHash, colName, colNameUtf8, rows, keyOrder, keySet, columnTypes, keyObservedCount);
+            return (null, null);
+        }
 
+        var segment = keyPath[frame.SegmentIndex];
         if (segment.Kind == KeyPathSegmentKind.Index)
         {
-            TraverseIndexSegment(
-                currentBytes, keyPath, segmentIndex, posHash, colName, colNameUtf8,
-                rows, keyOrder, keySet, columnTypes, keyObservedCount);
-            return;
+            return ExpandIndexSegment(frame, keyPath, rows, keyOrder, keySet, columnTypes, keyObservedCount);
         }
 
-        var valueBytes = FindValueByKey(currentBytes, segment.Value);
+        var valueBytes = KeyPathLeafCollector.FindValueByKey(frame.Bytes, segment.Value);
         if (valueBytes is null)
         {
-            return; // Key absent, or current value is not an object — skip record silently.
+            return (null, null); // Key absent, or current value is not an object — skip record silently.
         }
 
-        TraverseKeyPath(
-            valueBytes.Value, keyPath, segmentIndex + 1, posHash, colName, colNameUtf8,
-            rows, keyOrder, keySet, columnTypes, keyObservedCount);
+        return (TraversalFrame.Descend(valueBytes.Value, frame.SegmentIndex + 1, frame.PosHash), null);
     }
 
-    private static void TraverseIndexSegment(
-        JsonRawBytes currentBytes,
+    private static (TraversalFrame? next, TraversalFrame? deferred) ExpandIndexSegment(
+        TraversalFrame frame,
         IReadOnlyList<KeyPathSegment> keyPath,
+        List<FocusedTableRow> rows,
+        List<string> keyOrder,
+        HashSet<string> keySet,
+        Dictionary<string, ColumnType> columnTypes,
+        Dictionary<string, int> keyObservedCount)
+    {
+        var reader = new Utf8JsonReader(frame.Bytes.Span);
+        if (!reader.Read() || reader.TokenType != JsonTokenType.StartArray)
+        {
+            return (null, null); // Wrong type at this path position — skip record silently.
+        }
+
+        if (frame.SegmentIndex == keyPath.Count - 1)
+        {
+            // A trailing index segment expands the same array that would be reached by selecting
+            // it directly as the leaf (e.g. "tags" and "tags[0]" must produce identical output).
+            KeyPathLeafCollector.CollectArrayLeafRows(frame.Bytes, frame.PosHash, rows, keyOrder, keySet, columnTypes, keyObservedCount);
+            return (null, null);
+        }
+
+        return ScanOneArrayElement(ref reader, frame.Bytes, frame.SegmentIndex, 0, frame.PosHash);
+    }
+
+    // Reads the next depth-1 element and returns it as the next frame to descend, plus the
+    // ContinueArray continuation for the remaining siblings as the deferred frame.
+    private static (TraversalFrame? next, TraversalFrame? deferred) ScanOneArrayElement(
+        ref Utf8JsonReader reader,
+        JsonRawBytes arrayBytes,
         int segmentIndex,
-        string posHash,
-        string colName,
-        byte[] colNameUtf8,
-        List<FocusedTableRow> rows,
-        List<string> keyOrder,
-        HashSet<string> keySet,
-        Dictionary<string, ColumnType> columnTypes,
-        Dictionary<string, int> keyObservedCount)
+        int elementIndex,
+        string posHash)
     {
-        var reader = new Utf8JsonReader(currentBytes.Span);
-        if (!reader.Read() || reader.TokenType != JsonTokenType.StartArray)
-        {
-            return; // Wrong type at this path position — skip record silently.
-        }
-
-        if (segmentIndex == keyPath.Count - 1)
-        {
-            // A trailing index segment expands the same array that would be reached by
-            // selecting it directly as the leaf (e.g. "tags" and "tags[0]" must produce
-            // identical output, including the "value" column for primitive elements).
-            CollectArrayLeafRows(currentBytes, posHash, rows, keyOrder, keySet, columnTypes, keyObservedCount);
-            return;
-        }
-
-        var elementIndex = 0;
         while (reader.Read())
         {
             if (reader.TokenType == JsonTokenType.EndArray)
             {
-                break;
+                return (null, null);
             }
 
             if (reader.CurrentDepth != 1)
@@ -134,165 +176,14 @@ internal static class KeyPathTraverser
                 continue;
             }
 
-            var elementBytes = ExtractElementBytes(ref reader, currentBytes);
-            TraverseKeyPath(
-                elementBytes, keyPath, segmentIndex + 1, $"{posHash}:{elementIndex}", colName, colNameUtf8,
-                rows, keyOrder, keySet, columnTypes, keyObservedCount);
-            elementIndex++;
-        }
-    }
-
-    private static void CollectLeafRows(
-        JsonRawBytes leafBytes,
-        string posHash,
-        string colName,
-        byte[] colNameUtf8,
-        List<FocusedTableRow> rows,
-        List<string> keyOrder,
-        HashSet<string> keySet,
-        Dictionary<string, ColumnType> columnTypes,
-        Dictionary<string, int> keyObservedCount)
-    {
-        var reader = new Utf8JsonReader(leafBytes.Span);
-        if (!reader.Read())
-        {
-            return;
+            var elementBytes = JsonByteExtractor.ExtractValueBytes(ref reader, arrayBytes);
+            var remainder = arrayBytes.Slice((int)reader.BytesConsumed);
+            var next = TraversalFrame.Descend(elementBytes, segmentIndex + 1, $"{posHash}:{elementIndex}");
+            var deferred = new TraversalFrame(
+                FrameKind.ContinueArray, remainder, segmentIndex, elementIndex + 1, posHash, reader.CurrentState);
+            return (next, deferred);
         }
 
-        if (reader.TokenType == JsonTokenType.StartObject)
-        {
-            rows.Add(new FocusedTableRow(leafBytes, posHash));
-            var observedKeys = new HashSet<string>(StringComparer.Ordinal);
-            SchemaScanner.ScanObject(leafBytes.Span, keyOrder, keySet, columnTypes, observedKeys);
-            SchemaScanner.IncrementObservationCounts(observedKeys, keyObservedCount);
-            return;
-        }
-
-        if (reader.TokenType == JsonTokenType.StartArray)
-        {
-            CollectArrayLeafRows(leafBytes, posHash, rows, keyOrder, keySet, columnTypes, keyObservedCount);
-            return;
-        }
-
-        // Primitive leaf (including null) — synthesize a single-key object so
-        // JsonObjectCellExtractor can extract it without modification.
-        // Note: ScanObject is NOT called here, so no type inference is performed;
-        // the synthesized column always receives ColumnType.Text (Phase 2 limitation).
-        var synthBytes = SynthesizeObject(colNameUtf8, leafBytes.Span);
-        rows.Add(new FocusedTableRow(synthBytes, posHash));
-        SchemaScanner.RegisterKeyIfNew(colName, keyOrder, keySet);
-        SchemaScanner.IncrementObservationCounts([colName], keyObservedCount);
-    }
-
-    private static void CollectArrayLeafRows(
-        JsonRawBytes leafBytes,
-        string posHash,
-        List<FocusedTableRow> rows,
-        List<string> keyOrder,
-        HashSet<string> keySet,
-        Dictionary<string, ColumnType> columnTypes,
-        Dictionary<string, int> keyObservedCount)
-    {
-        var reader = new Utf8JsonReader(leafBytes.Span);
-        if (!reader.Read() || reader.TokenType != JsonTokenType.StartArray)
-        {
-            return;
-        }
-
-        var elementIndex = 0;
-        while (reader.Read())
-        {
-            if (reader.TokenType == JsonTokenType.EndArray)
-            {
-                break;
-            }
-
-            if (reader.CurrentDepth != 1)
-            {
-                continue;
-            }
-
-            var isObjectElement = reader.TokenType == JsonTokenType.StartObject;
-            var elementBytes = ExtractElementBytes(ref reader, leafBytes);
-            var elementHash = $"{posHash}:{elementIndex}";
-
-            if (isObjectElement)
-            {
-                rows.Add(new FocusedTableRow(elementBytes, elementHash));
-                var observedKeys = new HashSet<string>(StringComparer.Ordinal);
-                SchemaScanner.ScanObject(elementBytes.Span, keyOrder, keySet, columnTypes, observedKeys);
-                SchemaScanner.IncrementObservationCounts(observedKeys, keyObservedCount);
-                elementIndex++;
-                continue;
-            }
-
-            // Primitive element (including null) — synthesize {"value": element}.
-            var synthBytes = SynthesizeObject("value"u8, elementBytes.Span);
-            rows.Add(new FocusedTableRow(synthBytes, elementHash));
-            SchemaScanner.RegisterKeyIfNew("value", keyOrder, keySet);
-            SchemaScanner.IncrementObservationCounts(["value"], keyObservedCount);
-            elementIndex++;
-        }
-    }
-
-    private static JsonRawBytes ExtractElementBytes(ref Utf8JsonReader reader, JsonRawBytes containingBytes)
-    {
-        if (reader.TokenType is JsonTokenType.StartObject or JsonTokenType.StartArray)
-        {
-            return JsonByteExtractor.ExtractNestedBytes(ref reader, containingBytes);
-        }
-
-        var start = (int)reader.TokenStartIndex;
-        var end = (int)reader.BytesConsumed;
-        return containingBytes.Slice(start, end - start);
-    }
-
-    private static JsonRawBytes? FindValueByKey(JsonRawBytes objectBytes, string key)
-    {
-        var reader = new Utf8JsonReader(objectBytes.Span);
-        if (!reader.Read() || reader.TokenType != JsonTokenType.StartObject)
-        {
-            return null;
-        }
-
-        while (reader.Read())
-        {
-            if (reader.TokenType == JsonTokenType.EndObject)
-            {
-                return null;
-            }
-
-            if (reader.TokenType != JsonTokenType.PropertyName)
-            {
-                continue;
-            }
-
-            if (!reader.ValueTextEquals(key))
-            {
-                reader.Skip();
-                continue;
-            }
-
-            if (!reader.Read())
-            {
-                return null;
-            }
-
-            return ExtractElementBytes(ref reader, objectBytes);
-        }
-
-        return null;
-    }
-
-    private static JsonRawBytes SynthesizeObject(ReadOnlySpan<byte> keyUtf8, ReadOnlySpan<byte> valueBytes)
-    {
-        var buffer = new ArrayBufferWriter<byte>();
-        using var writer = new Utf8JsonWriter(buffer);
-        writer.WriteStartObject();
-        writer.WritePropertyName(keyUtf8);
-        writer.WriteRawValue(valueBytes, skipInputValidation: true);
-        writer.WriteEndObject();
-        writer.Flush();
-        return buffer.WrittenMemory;
+        return (null, null);
     }
 }

--- a/src/Engine/IO/Json/JsonByteExtractor.cs
+++ b/src/Engine/IO/Json/JsonByteExtractor.cs
@@ -45,6 +45,23 @@ public static class JsonByteExtractor
     }
 
     /// <summary>
+    /// Returns the raw bytes of the value at the reader's current token. Nested structures
+    /// (Object/Array) are read through <see cref="ExtractNestedBytes"/>; primitives are sliced
+    /// directly from <paramref name="containingBytes"/> between the token start and consumed offset.
+    /// </summary>
+    public static JsonRawBytes ExtractValueBytes(ref Utf8JsonReader reader, JsonRawBytes containingBytes)
+    {
+        if (reader.TokenType is JsonTokenType.StartObject or JsonTokenType.StartArray)
+        {
+            return ExtractNestedBytes(ref reader, containingBytes);
+        }
+
+        var start = (int)reader.TokenStartIndex;
+        var end = (int)reader.BytesConsumed;
+        return containingBytes.Slice(start, end - start);
+    }
+
+    /// <summary>
     /// Counts the top-level properties of a JSON object by tracking brace/bracket depth.
     /// The reader must be positioned at a <see cref="JsonTokenType.StartObject"/> token; on return
     /// the reader has consumed the entire object, ending at its matching EndObject token.

--- a/tests/Refedle.Tests/Engine/IO/DrillDown/KeyPathTraverserTests.cs
+++ b/tests/Refedle.Tests/Engine/IO/DrillDown/KeyPathTraverserTests.cs
@@ -20,6 +20,61 @@ public sealed class KeyPathTraverserTests
         return doc.RootElement.GetProperty(propertyName).Clone();
     }
 
+    // Builds {"k0":{"k1":...{"k{depth-1}":"leafValue"}...}} — `depth` single-key objects,
+    // exercising key-segment descent to a primitive leaf.
+    private static string BuildNestedObjects(int depth, string leafValue)
+    {
+        var sb = new StringBuilder();
+        for (var i = 0; i < depth; i++)
+        {
+            sb.Append("{\"k").Append(i).Append("\":");
+        }
+
+        sb.Append('"').Append(leafValue).Append('"');
+        sb.Append(new string('}', depth));
+        return sb.ToString();
+    }
+
+    // Builds [[["leafValue"]]] — `depth` single-element arrays; each "[0]" descends one level.
+    private static string BuildNestedArrays(int depth, string leafValue)
+    {
+        var sb = new StringBuilder();
+        for (var i = 0; i < depth; i++)
+        {
+            sb.Append('[');
+        }
+
+        sb.Append('"').Append(leafValue).Append('"');
+        for (var i = 0; i < depth; i++)
+        {
+            sb.Append(']');
+        }
+
+        return sb.ToString();
+    }
+
+    private static List<KeyPathSegment> BuildKeySegments(int depth)
+    {
+        List<KeyPathSegment> segments = [];
+        for (var i = 0; i < depth; i++)
+        {
+            segments.Add(Key($"k{i}"));
+        }
+
+        return segments;
+    }
+
+    private static List<KeyPathSegment> BuildIndexSegments(int depth)
+    {
+        List<KeyPathSegment> segments = [];
+        for (var i = 0; i < depth; i++)
+        {
+            segments.Add(Index("[0]"));
+        }
+
+        return segments;
+    }
+
     private static TraverseResult Traverse(
         JsonRawBytes recordBytes, IReadOnlyList<KeyPathSegment> keyPath, string posHash = "1")
     {
@@ -271,6 +326,65 @@ public sealed class KeyPathTraverserTests
         resultWithoutIndex.Rows.Select(r => GetProperty(r.Bytes, "value").GetString())
             .Should().Equal(resultWithIndex.Rows.Select(r => GetProperty(r.Bytes, "value").GetString()));
         resultWithoutIndex.KeyOrder.Should().Equal(resultWithIndex.KeyOrder);
+    }
+
+    [Fact]
+    public void ExtractRows_DeeplyNestedKeySegments_ReachesLeafWithExpectedAggregate()
+    {
+        // Arrange — depth 25 stays under Utf8JsonReader's default MaxDepth (64); the recursive
+        // implementation must reach the leaf. Pins behavior the iterative rewrite must preserve.
+        const int depth = 25;
+        var bytes = Bytes(BuildNestedObjects(depth, "leafKey"));
+        var keyPath = BuildKeySegments(depth);
+
+        // Act
+        var result = Traverse(bytes, keyPath);
+
+        // Assert
+        result.Rows.Should().HaveCount(1);
+        result.Rows[0].HashValue.Should().Be("1");
+        GetProperty(result.Rows[0].Bytes, $"k{depth - 1}").GetString().Should().Be("leafKey");
+        result.KeyOrder.Should().Equal($"k{depth - 1}");
+        result.KeyObservedCount[$"k{depth - 1}"].Should().Be(1);
+    }
+
+    [Fact]
+    public void ExtractRows_DeeplyNestedIndexSegments_ReachesLeafWithExpectedAggregate()
+    {
+        // Arrange — each "[0]" descends one array level; the leaf hash accumulates ":0" per
+        // segment. The iterative rewrite must reproduce this hash and aggregation exactly.
+        const int depth = 25;
+        var expectedLeafHash = "1" + string.Concat(Enumerable.Repeat(":0", depth));
+        var bytes = Bytes(BuildNestedArrays(depth, "leafIndex"));
+        var keyPath = BuildIndexSegments(depth);
+
+        // Act
+        var result = Traverse(bytes, keyPath);
+
+        // Assert
+        result.Rows.Should().HaveCount(1);
+        result.Rows[0].HashValue.Should().Be(expectedLeafHash);
+        GetProperty(result.Rows[0].Bytes, "value").GetString().Should().Be("leafIndex");
+        result.KeyOrder.Should().Equal("value");
+        result.KeyObservedCount["value"].Should().Be(1);
+    }
+
+    [Fact]
+    public void ExtractRows_BranchingIndexSegments_VisitsLeavesInForwardDfsOrder()
+    {
+        // Arrange — orders[*].items[*].id: two index levels, each with more than one sibling,
+        // pins the iterative DFS to fully visit element 0's subtree before element 1's.
+        var bytes = Bytes("""{"orders":[{"items":[{"id":"a1"},{"id":"a2"}]},{"items":[{"id":"b1"}]}]}""");
+        IReadOnlyList<KeyPathSegment> keyPath = [Key("orders"), Index("[0]"), Key("items"), Index("[0]"), Key("id")];
+
+        // Act
+        var result = Traverse(bytes, keyPath);
+
+        // Assert
+        result.Rows.Should().HaveCount(3);
+        result.Rows.Select(r => r.HashValue).Should().Equal("1:0:0", "1:0:1", "1:1:0");
+        result.Rows.Select(r => GetProperty(r.Bytes, "id").GetString()).Should().Equal("a1", "a2", "b1");
+        result.KeyOrder.Should().Equal("id");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Replaces `KeyPathTraverser`'s mutual recursion with an explicit-stack iterative DFS, so traversal depth is bounded by the heap instead of the call stack.
- Splits responsibilities across three files to keep each under the project's 300-line limit and avoid circular dependencies: `KeyPathTraverser` (traversal entry point + iterative descent), `KeyPathLeafCollector` (leaf row collection / extraction / synthesis), and `JsonByteExtractor` (shared value-byte extraction primitive). Dependencies flow one-directionally: `FullAggregationScanner → KeyPathTraverser → KeyPathLeafCollector`, both depending on `JsonByteExtractor`.
- Adds depth-25 and branching-index regression tests pinning the pre-refactor aggregation behavior.

Closes #253

## Test plan
- [x] `dotnet format` clean
- [x] `dotnet build` — 0 warnings / 0 errors
- [x] `dotnet test` — 1533/1533 passing (`KeyPathTraverserTests` 21/21)
- [x] Two rounds of CodeReviewer review (Approved)