### PR TITLE
chore: enforce unused code analyzers

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -51,6 +51,11 @@ dotnet_diagnostic.IDE0330.severity = warning
 dotnet_diagnostic.IDE0052.severity = warning
 dotnet_diagnostic.IDE0010.severity = warning
 
+# Detect unused code and unnecessary nullable suppression.
+dotnet_diagnostic.IDE0051.severity = warning
+dotnet_diagnostic.IDE0060.severity = warning
+dotnet_diagnostic.IDE0370.severity = warning
+
 # IDE0072: Populate switch (switch expressions). Left at its default (silent) — every
 # switch expression over an enum already requires a discard arm to satisfy the compiler's
 # own exhaustiveness check (CS8509/CS8524) regardless of this rule, and IDE0072 does not

--- a/tests/Refedle.Tests/App/AppKeyHandlerTests.cs
+++ b/tests/Refedle.Tests/App/AppKeyHandlerTests.cs
@@ -381,10 +381,10 @@ public sealed class AppKeyHandlerTests
             set { }
         }
 
-        public static void AddColumn(string name) { }
+        public static void AddColumn(string _) { }
         public static void AddRow() { }
-        public static void RemoveColumn(int index) { }
-        public static void RemoveRow(int index) { }
+        public static void RemoveColumn(int _) { }
+        public static void RemoveRow(int _) { }
         public static void Clear() { }
     }
 }

--- a/tests/Refedle.Tests/App/Views/ColumnActionHandlerTests.cs
+++ b/tests/Refedle.Tests/App/Views/ColumnActionHandlerTests.cs
@@ -94,10 +94,10 @@ public sealed class ColumnActionHandlerTests
             set { }
         }
 
-        public static void AddColumn(string name) { }
+        public static void AddColumn(string _) { }
         public static void AddRow() { }
-        public static void RemoveColumn(int index) { }
-        public static void RemoveRow(int index) { }
+        public static void RemoveColumn(int _) { }
+        public static void RemoveRow(int _) { }
         public static void Clear() { }
     }
 }


### PR DESCRIPTION
## Summary

- Enforce diagnostics for unused private members, unused parameters, and redundant null-forgiving operators.
- Mark intentionally unused test-double parameters with `_`.

## Validation

- `dotnet format`
- `dotnet build`
- `dotnet test` (1,533 passed)
