### PR TITLE
fix: emit real JSON values for CLI batch Object/Array/Number cells

### DIFF
--- a/docs/design_batch_cell_typed_channel.md
+++ b/docs/design_batch_cell_typed_channel.md
@@ -1,0 +1,547 @@
+# Design: Typed Cell Channel for CLI Batch Processing
+
+## Requirements
+
+`JsonLinesRecordReader.GetCellSpan()` currently reuses
+`JsonObjectCellExtractor.ExtractCell()` — an extractor built for TUI
+table/tree display. For JSON Object/Array values it returns display-only
+preview strings (`{Object: N properties}`, `[Array: N items]`), and CLI batch
+output (CSV/JSON Lines writers) passes that preview straight through, losing
+the real data for any Object/Array column.
+
+`ExtractCell` is shared with `JsonLinesTableSource`/`FocusedTableSource` and
+must **not change** — its preview behavior is correct for the TUI.
+
+Goals for the CLI batch path only:
+
+- Preserve the original JSON text for Number/Object/Array values (no
+  preview strings, no numeric reformatting), including large integers and
+  exponent notation.
+- Resolve JSON string escapes correctly (the shared extractor currently does
+  not — accepted as an in-scope side effect for the CLI batch path only, see
+  Decision Record).
+- Never let a JSON string value be reinterpreted as a JSON number/boolean in
+  output just because its text looks like one (e.g. a JSON string `"5"` or
+  `"true"` must stay a JSON string).
+- Replace the `"<null>"`/`"<error>"` string-sentinel convention (used by both
+  `JsonLinesRecordReader.GetCellSpan` output and `WriteCellSpan`/`WriteJsonValue`
+  input) with an explicit, non-string-based signal, so a genuine JSON string
+  value of `"<null>"` is never misinterpreted as null.
+- Distinguish a JSON property that is genuinely absent from one that is
+  explicitly `null`, so JSON Lines → JSON Lines is a true structural
+  round-trip and does not gain properties it didn't have.
+- Never emit syntactically invalid JSON, regardless of source format.
+- No behavior change for CSV → CSV or CSV → JSON Lines, and no behavior
+  change for transformed columns (`FillSpec`/`TimestampFormatSpec`) either.
+  JSON Lines → JSON Lines becomes a true structural round-trip; JSON Lines →
+  CSV embeds the raw JSON text of Object/Array cells as a CSV string.
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `src/App/Cli/CellData.cs` | **New.** `CellPresence` enum, `CellEncoding` enum, `CellData` readonly `ref struct` |
+| `src/App/Cli/CellEncodingClassifier.cs` | **New.** Shared `bool`/`long`/`double` text heuristic, used by CSV reads and by transformed-column output |
+| `src/App/Cli/IRecordReader.cs` | `GetCellSpan(int) : ReadOnlySpan<char>` → `GetCellData(int) : CellData` |
+| `src/App/Cli/IRecordWriter.cs` | `WriteCellSpan(int, ReadOnlySpan<char>)` → `WriteCellData(int, CellData)` |
+| `src/App/Cli/CsvRecordReader.cs` | `GetCellData` calls `CellEncodingClassifier.Classify` inline (`Presence` always `Value`) |
+| `src/App/Cli/JsonLinesRecordReader.cs` | `GetCellData` scans with a local `Utf8JsonReader` and derives `Presence`/`Encoding` directly from `JsonTokenType`, instead of calling `ExtractCell` |
+| `src/App/Cli/CsvRecordWriter.cs` | `WriteCellData` — same output behavior, now branches on `Presence` instead of matching `"<null>"`/`"<error>"` text; `Encoding` is not read (CSV output is always plain text) |
+| `src/App/Cli/JsonLinesRecordWriter.cs` | `WriteCellData` replaces `WriteJsonValue`; branches on `Presence`/`Encoding` instead of re-parsing every `ReadOnlySpan<char>` unconditionally |
+| `src/App/Cli/RecordProcessor.cs` | Passes `CellData` through for untransformed columns; wraps `FillSpec`/`TimestampFormatSpec` output via `CellEncodingClassifier.Classify` (not a hardcoded encoding) |
+| `tests/Refedle.Tests/App/Cli/RecordProcessorTests.TestRecordReader.cs` | `GetCellSpan` → `GetCellData` (test double) |
+| `tests/Refedle.Tests/App/Cli/RecordProcessorTests.TestRecordWriter.cs` | `WriteCellSpan` → `WriteCellData` (test double), captures `Presence`/`Encoding` for assertions |
+| `tests/Refedle.Tests/App/Cli/RunnerTests.cs` | Add end-to-end cases (see "Test Plan" below) |
+
+No changes to `JsonObjectCellExtractor.cs`, `JsonByteExtractor.cs`,
+`ColumnType.cs`, or `TypeInferrer.cs`. This design does not read or produce a
+`ColumnType` anywhere in the batch path.
+
+---
+
+## Implementation Approach
+
+### 1. New types (`CellData.cs`)
+
+```csharp
+internal enum CellPresence
+{
+    Value,
+    Null,
+    Missing,
+    Invalid,
+}
+
+internal enum CellEncoding
+{
+    PlainText,
+    Raw,
+    Numeric,
+    Boolean,
+}
+
+internal readonly ref struct CellData(
+    ReadOnlySpan<char> value,
+    CellPresence presence,
+    CellEncoding encoding = CellEncoding.PlainText)
+{
+    public ReadOnlySpan<char> Value { get; } = value;
+    public CellPresence Presence { get; } = presence;
+    public CellEncoding Encoding { get; } = encoding;
+}
+```
+
+`CellPresence` has four states:
+
+- `Value` — a usable value is present.
+- `Null` — the JSON value is explicitly `null` (JSON Lines only).
+- `Missing` — the property does not exist in the source at all (JSON Lines
+  only; distinct from `Null` so the writer can omit rather than nullify it).
+- `Invalid` — the source could not be read (malformed JSON).
+
+`CellEncoding` says how the writer must turn `Value` into JSON — a purely
+mechanical/syntactic decision, independent of the cell's domain type
+(`ColumnType` is not involved anywhere in this design; see Decision Record):
+
+- `Raw` — `Value` is already valid JSON syntax (a genuine JSON Number,
+  Object, or Array token) and must be written verbatim via `WriteRawValue`.
+  Never used for CSV.
+- `Numeric` — `Value` looks numeric (CSV heuristic, or a transformed value
+  that looks numeric) but is not guaranteed to be valid JSON number syntax
+  (`007`, `1,234`); must be re-parsed and re-serialized via
+  `WriteNumberValue`.
+- `Boolean` — `Value` is `"true"`/`"false"` (any casing); re-parsed via
+  `bool.Parse` and written via `WriteBooleanValue`.
+- `PlainText` — write `Value` unconditionally via `WriteStringValue`, no
+  heuristic, no exceptions. This is what makes a JSON string `"5"` or
+  `"true"` stay a JSON string in output.
+
+### 2. `IRecordReader` / `IRecordWriter`
+
+```csharp
+CellData GetCellData(int outputColumnIndex);
+void WriteCellData(int outputColumnIndex, CellData cell);
+```
+
+replace `GetCellSpan`/`WriteCellSpan` one-for-one.
+
+### 3. `CellEncodingClassifier` (new, shared)
+
+```csharp
+internal static class CellEncodingClassifier
+{
+    public static CellEncoding Classify(ReadOnlySpan<char> value)
+    {
+        if (bool.TryParse(value, out _))
+        {
+            return CellEncoding.Boolean;
+        }
+
+        if (long.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out _))
+        {
+            return CellEncoding.Numeric;
+        }
+
+        if (double.TryParse(value, NumberStyles.Any, CultureInfo.InvariantCulture, out _))
+        {
+            return CellEncoding.Numeric;
+        }
+
+        return CellEncoding.PlainText;
+    }
+}
+```
+
+This is exactly today's `WriteJsonValue` detection order, extracted so both
+`CsvRecordReader` and `RecordProcessor` (for transformed columns) can call it
+— see step 7 for why transformed columns need it too, not a hardcoded
+`PlainText`.
+
+### 4. `CsvRecordReader.GetCellData`
+
+`Presence` is always `Value` — CSV has no structural null/missing/invalid
+concept; an empty column is an empty span, which the writer's `PlainText`
+branch already handles correctly (`WriteStringValue("")`).
+
+`Encoding` is `CellEncodingClassifier.Classify(value)`. Classification
+now happens on the read side for every cell, not only when the destination
+is JSON Lines (that was implicit before, since `WriteJsonValue` used to run
+this same heuristic in the writer). The extra CPU cost when writing CSV →
+CSV, where `CsvRecordWriter` never reads `Encoding`, is an accepted
+trade-off — it is small (no allocation, a few `TryParse` calls) and
+`Encoding` is required for CSV → JSON Lines regardless, plus any future
+CSV → JSON Object/Array-typed output.
+
+No `TableSchema` or pre-scan is used. The `Unescape` option on the Sep
+reader stays `false` (unrelated to this fix — tracked separately, see
+"Out of Scope" below).
+
+### 5. `JsonLinesRecordReader.GetCellData`
+
+A new local `Utf8JsonReader` scans `_currentLineBytes.Span` for the target
+column's property (same per-call scan strategy as `ExtractCell` — the
+existing extractor is left untouched, so its reader is not shared, and this
+new scan does **not** call `ExtractCell`/`FormatValue`/`FormatNumber` at
+all — those exist to build TUI preview/display strings, which is exactly
+the behavior this fix must avoid).
+
+- **Presence**: property not found → `Missing`; JSON `null` → `Null`;
+  unreadable/malformed JSON (root is not `StartObject`, or a `JsonException`
+  is thrown, or `reader.Read()` fails after the property name) → `Invalid`;
+  otherwise `Value`. No more `"<null>"`/`"<error>"` string sentinels, and
+  `Missing` is now distinct from `Null`.
+- **Number**: `Encoding = Raw`, `Value = Encoding.UTF8.GetString(reader.ValueSpan)`
+  — for a `Number` token, `ValueSpan` is the literal digits of the token, so
+  this is a direct, lossless UTF-8 decode with no semantic
+  re-interpretation. `Raw` is correct here regardless of magnitude or
+  exponent form: `Utf8JsonReader` only ever produces a `Number` token for
+  text that is already syntactically valid per JSON's number grammar
+  (arbitrary precision, no `Int64` limit — see Decision Record), so there is
+  no size/form check to get wrong. This is a deliberate difference from
+  `JsonObjectCellExtractor.FormatNumber`, which parses the number and calls
+  `ToString()`, silently rewriting `1.50` to `1.5` and losing precision for
+  integers beyond what `double` can represent exactly.
+- **Object / Array**: `Encoding = Raw`, `Value =
+  Encoding.UTF8.GetString(JsonByteExtractor.ExtractValueBytes(ref reader, _currentLineBytes).Span)`.
+  `Utf8JsonReader.ValueSpan` is *empty* at `StartObject`/`StartArray` — it
+  does not contain the nested content — so `JsonByteExtractor`'s existing
+  depth-tracking byte-range extractor (already used elsewhere in the Engine
+  for exactly this purpose) is reused to slice the full nested JSON text
+  first.
+- **String**: `Encoding = PlainText`, `Value = reader.GetString()` — the
+  standard escape-resolving API. `JsonObjectCellExtractor.FormatValue` uses
+  `Encoding.UTF8.GetString(reader.ValueSpan)` instead, which leaves escapes
+  unresolved (a known, separate issue on the TUI extractor); using
+  `reader.GetString()` here is the ordinary, correct way to read a JSON
+  string with `Utf8JsonReader` and, as an accepted side effect, means CLI
+  batch output no longer exhibits that unresolved-escape symptom (the TUI
+  path is untouched and its issue remains open there).
+- **Boolean**: `Encoding = Boolean`, `Value` is the static literal `"true"`
+  or `"false"` selected by `reader.TokenType == JsonTokenType.True` — no
+  allocation.
+
+### 6. `JsonLinesRecordWriter.WriteCellData`
+
+Replaces `WriteJsonValue`. Branch order:
+
+1. `Presence == Missing` → omit the property entirely (no
+   `WritePropertyName` call for this column).
+2. `Presence == Null` → JSON `null`.
+3. `Presence == Invalid` → empty string.
+4. `Presence == Value` → dispatch on `Encoding`:
+   - `Raw` → `WriteRawValue(value)` (verbatim; always valid JSON syntax by
+     construction — see step 5).
+   - `Numeric` → re-parse with the same
+     `long.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, ...)`
+     / `double.TryParse(value, NumberStyles.Any, CultureInfo.InvariantCulture, ...)`
+     order and overloads as `CellEncodingClassifier`, then
+     `WriteNumberValue` — this is the exact reformat `WriteJsonValue`
+     performs today, so CSV numeric output is byte-for-byte unchanged, and
+     pathological CSV text (`007`, `1,234`, `(5)`) is normalized into a
+     valid JSON number instead of being spliced in verbatim.
+   - `Boolean` → `WriteBooleanValue(bool.Parse(value))`.
+   - `PlainText` → `WriteStringValue(value)` unconditionally — no
+     `TryParse` fallbacks. An empty `Value` falls here too
+     (`WriteStringValue("")`), so no separate empty-value branch is needed.
+
+`WriteRawValue(ReadOnlySpan<char>, bool)` is used for the `Raw` branch
+instead of `WriteNumberValue`, because `WriteNumberValue` only accepts
+numeric CLR types (`long`, `double`, etc.) and would force re-parsing,
+re-collapsing `1.50` back to `1.5` — the exact loss the reader side was
+changed to avoid. `WriteRawValue` is confirmed present on `Utf8JsonWriter` in
+the .NET 10 reference assembly.
+
+The old `"<null>"`/`"<error>"` string-sentinel comparison is removed
+entirely, which also fixes a latent bug where a genuine JSON string cell
+containing the literal text `<null>` or `<error>` was misclassified.
+
+### 7. `CsvRecordWriter.WriteCellData`
+
+Only `Presence`/`Value` are read (`Encoding` is not needed — CSV output is
+always plain text regardless of encoding):
+
+- `Null`, `Missing`, or `Invalid` → write nothing (same as today's
+  `"<null>"`/`"<error>"` → empty behavior, now also covering `Missing`)
+- `Value` → CSV-escape `Value` and write it (unchanged)
+
+### 8. `RecordProcessor`
+
+- Pass-through columns: `writer.WriteCellData(i, reader.GetCellData(i))`
+- Transformed columns (`FillSpec`, `TimestampFormatSpec`): build
+  `new CellData(formattedValue, CellPresence.Value, CellEncodingClassifier.Classify(formattedValue))`.
+  A hardcoded `PlainText` here would be a behavior change: today,
+  transformed text flows through `WriteJsonValue`'s heuristic exactly like
+  any other cell, so a numeric-looking fill value (e.g. a `FillSpec`
+  default of `"0"`) is currently emitted as a JSON number. Reusing the same
+  classifier preserves that.
+
+### Behavior Matrix
+
+| Input | Output | Object/Array column |
+|---|---|---|
+| CSV | CSV | Unchanged |
+| CSV | JSON Lines | Unchanged (CSV never produces `Raw`; numeric-looking cells are still reformatted through `WriteNumberValue` exactly as today) |
+| JSON Lines | CSV | Raw JSON text placed in the CSV cell as a string |
+| JSON Lines | JSON Lines | Structurally identical to the input, including properties that were absent (no longer gain a `null`); string values are no longer misclassified as numbers/booleans |
+
+---
+
+## Decision Record
+
+### Rationale
+
+**Introduce `GetCellData`/`WriteCellData` instead of patching
+`GetCellSpan`'s extraction logic in place:** An early proposal was to keep
+returning `ReadOnlySpan<char>` but swap `ExtractCell` for a raw-byte
+extractor. That does not carry presence/encoding information, so the writer
+would still need to guess (via string-sentinel matching or ad hoc parsing)
+whether a span is null, invalid, already-valid JSON, or plain text — which
+is the root cause of the current bug and of the `"<null>"`/`"<error>"`
+sentinel fragility. Making the reader the single source of truth for
+presence and encoding removes all guessing from the writer.
+
+**No `ColumnType` anywhere in this design:** `WriteJsonValue` today does not
+consult `ColumnType` at all — it runs its own `bool`/`long`/`double` text
+heuristic directly, regardless of source. An earlier revision of this design
+carried `ColumnType` in `CellData` "for type information" alongside a
+representational flag, but nothing in the batch read/write path actually
+consumes a domain-type classification; the only question the writer ever
+needs answered is the mechanical one `CellEncoding` answers ("how do I turn
+this text into JSON"). Carrying `ColumnType` as well would be unused state.
+`TypeInferrer.InferType`'s known imprecision for `Int64`-overflowing or
+exponent-form numbers (it falls back to `Text`) is therefore irrelevant to
+this design, not merely "worked around" — it is never called.
+
+**Why `CellEncoding` has exactly four values, not two and not more:**
+
+- `Raw` and `Numeric` cannot be merged. CSV's numeric heuristic uses
+  permissive `NumberStyles` (to match today's `WriteJsonValue` exactly) that
+  accept text which is not valid JSON number *syntax* — leading zeros, a
+  leading `+`, thousands separators, parenthesized negatives. If CSV
+  numeric-looking values were `Raw`, `WriteRawValue` would splice
+  non-conforming text directly into JSON output, producing invalid JSON.
+  `Numeric` routes them through the existing re-parse + `WriteNumberValue`
+  step instead, which normalizes them into valid JSON exactly as today's
+  code does. (Two alternatives were considered and rejected for this
+  specific point — see "Alternatives Considered" F and G below.)
+- `Raw` cannot absorb JSON Number by re-parsing it either (i.e. treating
+  JSON numbers as `Numeric` instead of `Raw`): unlike CSV text, a JSON
+  `Number` token is guaranteed by `Utf8JsonReader` itself to already be
+  valid JSON number syntax, so re-parsing it buys nothing and actively
+  loses the original lexical form (`1.50` → `1.5`) and precision for
+  integers beyond `Int64`/`double` range.
+- `PlainText` and `Boolean` cannot be merged. `PlainText` is defined as
+  "always `WriteStringValue`, no heuristic" specifically so a JSON string
+  `"5"` or `"true"` is never reinterpreted — but a genuine JSON `Boolean`
+  token (or CSV text like `TRUE`) must still become a real JSON boolean, not
+  the string `"true"`. Keeping `Boolean` separate lets `PlainText` be
+  unconditional while `Boolean` still gets `WriteBooleanValue`.
+- `PlainText` and `Numeric` cannot be merged for the same reason in the CSV
+  direction: merging them would mean CSV `007`/`1,234` are emitted as JSON
+  strings, a regression from today's normalized `WriteNumberValue` output.
+
+**Classification moves from the writer into the reader for CSV and for
+transformed columns:** Today, `WriteJsonValue`'s heuristic runs once, in the
+writer, on whatever text arrives, regardless of source. Because `PlainText`
+is now unconditional (no heuristic in the writer at all), any text that
+should still be recognized as numeric/boolean must be classified before it
+reaches the writer. `CellEncodingClassifier` is extracted as a shared
+helper (step 3) so `CsvRecordReader` and `RecordProcessor`'s
+`FillSpec`/`TimestampFormatSpec` output both classify identically to how
+`WriteJsonValue` classifies today — this is what keeps CSV → JSON Lines and
+transformed-column output byte-for-byte unchanged. The cost is that this
+classification now runs on every CSV cell even when the destination is CSV
+(where `CsvRecordWriter` ignores `Encoding` entirely); this is accepted as
+minor (no allocation) and unavoidable in general, since the same reader
+output is also used for CSV → JSON Lines.
+
+**`reader.GetString()` for String, not `ExtractCell`/`FormatValue`:**
+`FormatValue`'s `String` branch uses `Encoding.UTF8.GetString(reader.ValueSpan)`,
+which leaves JSON escape sequences unresolved (a known, separate issue on
+the TUI extractor). `reader.GetString()` is the standard, escape-resolving
+way to read a JSON string with `Utf8JsonReader`. Using it here is not a
+deliberate fix of that issue (the TUI extractor itself is untouched and its
+issue remains open there) — it is simply the correct API for newly-written
+extraction code; deliberately reimplementing the unresolved-escape behavior
+to match `ExtractCell` would mean writing more fragile code to
+intentionally reproduce a bug.
+
+**`CellPresence.Missing` distinct from `CellPresence.Null`:** The writer
+must be able to omit a property versus explicitly null it, or a sparse JSON
+Lines input would gain a `null`-valued property for every output column it
+didn't originally have — breaking the "true structural round-trip" goal.
+
+**Per-cell heap-allocated `string`, not an `ArrayPool<char>`-backed buffer:**
+A pooled-buffer version would make `GetCellData` effectively
+zero-allocation, but requires buffer lifecycle management (`Return` on
+dispose), an implicit "value valid only until the next `GetCellData` call"
+constraint, and re-rent handling on overflow. None of that is needed to fix
+the correctness bug, and the current baseline (`ExtractCell`) already
+allocates a `string` per cell, so this is not a regression. Deferred as a
+distinct performance investment (see "Out of Scope").
+
+**Byte (JSON) and char (CSV) cell values unified on `ReadOnlySpan<char>`:**
+Sep's public reader API (`SepReader.Row.Col.Span`) is `ReadOnlySpan<char>`
+only — there is no byte-span variant to unify toward instead. Standardizing
+on `char` keeps `CsvRecordReader`/`CsvRecordWriter` untouched on the type
+level and keeps `RecordProcessor.ProcessAsync<TReader, TWriter>` a single
+generic pipeline across all four format combinations. The cost is that
+`JsonLinesRecordReader` must UTF-8-decode (byte → char) for every non-`Boolean`
+value; there was no alternative that avoided this without giving up the
+single generic pipeline (see "Alternatives Considered").
+
+### Alternatives Considered
+
+**A — Make `CsvRecordReader` byte-native (`ReadOnlySpan<byte>`) instead of
+JSON Lines going char-native.** Rejected: Sep does not expose a byte-based
+read API at all (byte spans only appear on the *write* side,
+`SepWriter`). Not achievable without replacing the CSV library.
+
+**B — Decode the whole JSON Lines line to `char` up front, then scan.**
+Rejected: `Utf8JsonReader` is byte-only; there is no char-based
+equivalent, so the scan itself would still operate on bytes regardless.
+Worse, if the line contains non-ASCII characters, `Utf8JsonReader`'s byte
+offsets stop lining up with the pre-decoded char buffer's offsets, making
+this approach actively incorrect, not just redundant.
+
+**C — Split CSV and JSON Lines into separate, non-unified pipelines
+(abandon the single `ReadOnlySpan<char>` contract).** Rejected for this
+fix: a JSON Lines → JSON Lines-only path could stay byte-native end to end
+and skip the byte→char conversion entirely, but that would require a second
+`RecordProcessor` entry point and a source-generator dispatch branch limited
+to one format pair, in exchange for avoiding a conversion cost that has not
+been measured. Kept as a possible future optimization, not adopted now
+(`Utf8JsonWriter.WriteRawValue(ReadOnlySpan<byte>, bool)` exists, confirming
+it would be technically possible later).
+
+**D — `ArrayPool<char>` buffer reuse in `GetCellData` for zero-allocation
+byte→char conversion.** Rejected for this fix; see rationale above. Revisit
+first if a future benchmark shows the per-cell allocation is a real
+bottleneck.
+
+**E — Whole-value JSON-parse attempt in the writer to detect
+Object/Array/Number (instead of the reader carrying `Encoding`).**
+Considered and dropped: a CSV cell whose text happens to be syntactically
+valid JSON (e.g. a CSV value of `123`) would be wrongly promoted to a JSON
+number/object in JSON Lines output — a correctness regression, not a fix.
+
+**F — Have `CsvRecordReader` normalize numeric `Value` at extraction time
+(store the parsed `long`/`double`'s canonical string instead of the raw CSV
+span) and set `Encoding = Raw`.** Rejected: `GetCellData` is called once
+per cell and its `CellData` is consumed by whichever writer is active.
+Normalizing `Value` would fix JSON Lines output but corrupt CSV → CSV output
+(e.g. an input CSV cell `TRUE` or `007` would come back out as `True` or
+`7`, since there is no way to hand back two different representations to
+two different writers from one call). CSV's `Value` must stay the original
+span unconditionally to preserve CSV → CSV fidelity; only the *decision of
+how to write it* may vary by target format, which is exactly what
+`Encoding` (interpreted only by the JSON Lines writer) achieves.
+
+**G — Tighten the CSV numeric heuristic itself to strict JSON-number
+grammar (reject leading zeros, `+`, thousands separators, parentheses) and
+set `Encoding = Raw` from that stricter check.** Rejected: this would
+change classification for those edge-case inputs from `Numeric` to
+`PlainText`, which changes CSV → JSON Lines output for them (e.g. `1,234`
+would become the JSON string `"1,234"` instead of today's normalized JSON
+number `1234`) — a needless behavior change when the simpler fix (keeping
+`Numeric` and its re-parse step) reaches the identical
+`WriteNumberValue`-normalized output that CSV → JSON Lines already produces
+today, with no grammar-tightening required.
+
+### Consequences
+
+- `CellPresence`/`CellEncoding`/`CellData` are internal to `src/App/Cli/`;
+  TUI code paths (`ExtractCell` and its callers) and the Engine-wide
+  `ColumnType`/`TypeInferrer` vocabulary are completely unaffected.
+- The `"<null>"`/`"<error>"` sentinel convention is removed from the batch
+  write path; a JSON string cell whose literal content is `<null>` or
+  `<error>` is no longer misclassified.
+- JSON Lines → JSON Lines becomes a genuine structural round-trip for
+  Object/Array/Number/String values, including large integers and exponent
+  notation, and including properties that were absent rather than `null`;
+  a JSON string is never reinterpreted as a number/boolean regardless of its
+  text content; JSON Lines → CSV places the exact source JSON text into the
+  CSV cell for Object/Array columns instead of a display preview.
+- As an accepted side effect (not a goal in itself), CLI batch output for
+  JSON string values with escape sequences is now correct
+  (`reader.GetString()`); the TUI display path (`JsonObjectCellExtractor`)
+  is untouched and its equivalent unresolved-escape issue remains open
+  there.
+- CSV cell classification (`CellEncodingClassifier`) now runs on every
+  read regardless of output format, not only when writing JSON Lines as
+  today. No output behavior changes; the cost is a per-cell classification
+  pass that is wasted work for CSV → CSV.
+- Per-cell `string` allocation for JSON Lines Number/Object/Array/String
+  values is unchanged from the current baseline (not a regression); a
+  follow-up `ArrayPool<char>`-based optimization is possible but out of
+  scope here.
+- `RecordProcessor`'s generic `ProcessAsync<TReader, TWriter>` pipeline,
+  and the `FormatDispatcherGenerator`-generated dispatch matrix, are
+  unaffected in shape — only the per-cell payload type changes.
+- `IRecordReader`/`IRecordWriter` implementations remain single-consumer,
+  sequential-access structs (as today): a `CellData` returned by
+  `GetCellData` borrows from state owned by that specific reader/writer
+  instance (a GC-managed `string`, or a buffer the writer itself owns) and
+  is only valid for the duration of the current record; instances are not
+  safe to share across concurrent calls, matching the existing sequential
+  `RecordProcessor.ProcessAsync` contract.
+
+### Test Plan
+
+In addition to reader/writer unit tests for each `CellPresence`/`CellEncoding`
+combination (including `CellEncodingClassifier` unit tests for
+`007`/`1,234`/`TRUE`/plain text), `RunnerTests.cs` end-to-end cases (JSON
+Lines input, asserted by parsing output with `JsonDocument` for JSON Lines
+targets and by raw cell-text comparison for CSV targets) must cover:
+
+- A nested Object and a nested Array value, including non-ASCII characters.
+- `1.50` (trailing zero preserved), `1e10` (exponent), and an integer beyond
+  `Int64` range — all three must round-trip as JSON numbers, not strings.
+  Assert on `JsonElement.GetRawText()` equaling the exact original literal,
+  not just `ValueKind == JsonValueKind.Number` — numeric accessors (e.g.
+  `GetDouble()`) normalize the value and cannot prove the original lexical
+  representation (trailing zero, exponent form) survived.
+- A JSON string value containing JSON escape sequences (e.g. embedded quotes
+  or `\n`), asserting the resolved text, not the raw escape sequence.
+- A JSON string value whose content looks numeric/boolean (`"5"`, `"true"`)
+  — must round-trip as a JSON string, not a number/boolean.
+- A string value whose literal content is exactly `<null>` or `<error>`
+  (must be written as that literal string, not treated as null/invalid).
+- A property that is missing from the source line versus one explicitly set
+  to `null` (must be distinguishable in the output).
+- CSV `007` → JSON number `7` (existing behavior, regression guard — see
+  "Out of Scope").
+- A `FillSpec`/`TimestampFormatSpec`-transformed column whose output text
+  looks numeric (e.g. a numeric fill default) still round-trips as a JSON
+  number, matching current behavior.
+
+### Out of Scope
+
+Filed as separate issues, not addressed by this change:
+
+- TableSchema pre-scan limited to the first 200 rows/lines.
+- Filter/FormatTimestamp trusting a single type resolved at pre-scan time.
+- Whether to unify `WholeNumber`/`FloatingPoint` into a single `Number` type
+  in `ColumnType` (unaffected by this design either way, since `ColumnType`
+  is not used here).
+- CSV's permissive numeric grammar (`007`, `1,234`, `(5)`) being normalized
+  into different JSON number text (`7`, `1234`, `-5`) rather than preserved
+  verbatim or rejected as text — this is existing, unchanged behavior (see
+  Alternatives F and G), the same class of representation-loss limitation
+  as `JsonObjectCellExtractor.FormatNumber`'s known numeric-reformatting
+  bug. A future column-level output-encoding override (e.g. a
+  `CastColumnAction` extension or a new `CellTransformSpec` subtype to
+  force a column to always be emitted as text) is a possible follow-up but
+  is not designed or implemented here.
+- Sep's `Unescape` option left `false`, so quoted-empty CSV cells (`,"",`)
+  retain their quote characters as literal text.
+- `JsonObjectCellExtractor.FormatValue`'s unresolved-escape bug (TUI path;
+  left as-is deliberately — this fix does not touch `ExtractCell`, and only
+  incidentally avoids the same symptom in the unrelated CLI batch code path
+  it replaces).
+- `JsonObjectCellExtractor.FormatNumber`'s numeric-reformatting bug (TUI
+  path; same reasoning).
+- A JSON Lines → JSON Lines byte-native pipeline that skips the byte→char
+  conversion entirely (see Alternative C) — unlikely to be pursued, since
+  `ArrayPool<char>` pooling alone can reach zero-allocation without
+  splitting the pipeline.

--- a/src/App/Cli/CellData.cs
+++ b/src/App/Cli/CellData.cs
@@ -1,0 +1,45 @@
+namespace Refedle.App.Cli;
+
+/// <summary>
+///  Whether a CLI batch cell carries a usable value and, when it does not, why
+///  (explicit null, an absent property, or an unreadable source). Replaces the
+///  former "&lt;null&gt;"/"&lt;error&gt;" string sentinels with an explicit signal.
+/// </summary>
+internal enum CellPresence
+{
+    Value,
+    Null,
+    Missing,
+    Invalid,
+}
+
+/// <summary>
+///  How an <see cref="IRecordWriter"/> must serialize a <see cref="CellData"/>'s
+///  <see cref="CellData.Value"/> — a purely syntactic decision, independent of the
+///  cell's domain type (ColumnType is not involved anywhere in the batch path).
+/// </summary>
+internal enum CellEncoding
+{
+    PlainText,
+    Raw,
+    Numeric,
+    Boolean,
+}
+
+/// <summary>
+///  A single CLI batch cell: its text plus the presence/encoding signals the
+///  writer needs to emit it correctly. Passed between <see cref="IRecordReader"/>
+///  and <see cref="IRecordWriter"/> in place of the former bare
+///  <see cref="ReadOnlySpan{T}"/> of <see langword="char"/>.
+/// </summary>
+internal readonly ref struct CellData(
+    ReadOnlySpan<char> value,
+    CellPresence presence,
+    CellEncoding encoding = CellEncoding.PlainText)
+{
+    public ReadOnlySpan<char> Value { get; } = value;
+
+    public CellPresence Presence { get; } = presence;
+
+    public CellEncoding Encoding { get; } = encoding;
+}

--- a/src/App/Cli/CellEncodingClassifier.cs
+++ b/src/App/Cli/CellEncodingClassifier.cs
@@ -1,0 +1,19 @@
+namespace Refedle.App.Cli;
+
+/// <summary>
+///  Shared text-to-<see cref="CellEncoding"/> heuristic used by CSV reads and by
+///  transformed-column output. Mirrors the historical <c>WriteJsonValue</c>
+///  detection order (bool → long → double → text) so CSV→JSON Lines and
+///  transformed-column output stay byte-for-byte unchanged.
+/// </summary>
+internal static class CellEncodingClassifier
+{
+    /// <summary>
+    ///  Classifies plain cell text into the encoding the JSON Lines writer needs.
+    ///  Step 2 implements the exact bool/long/double heuristic.
+    /// </summary>
+    public static CellEncoding Classify(ReadOnlySpan<char> value)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/src/App/Cli/CellEncodingClassifier.cs
+++ b/src/App/Cli/CellEncodingClassifier.cs
@@ -1,3 +1,5 @@
+using System.Globalization;
+
 namespace Refedle.App.Cli;
 
 /// <summary>
@@ -10,10 +12,24 @@ internal static class CellEncodingClassifier
 {
     /// <summary>
     ///  Classifies plain cell text into the encoding the JSON Lines writer needs.
-    ///  Step 2 implements the exact bool/long/double heuristic.
     /// </summary>
     public static CellEncoding Classify(ReadOnlySpan<char> value)
     {
-        throw new NotImplementedException();
+        if (bool.TryParse(value, out _))
+        {
+            return CellEncoding.Boolean;
+        }
+
+        if (long.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out _))
+        {
+            return CellEncoding.Numeric;
+        }
+
+        if (double.TryParse(value, NumberStyles.Any, CultureInfo.InvariantCulture, out _))
+        {
+            return CellEncoding.Numeric;
+        }
+
+        return CellEncoding.PlainText;
     }
 }

--- a/src/App/Cli/CsvRecordReader.cs
+++ b/src/App/Cli/CsvRecordReader.cs
@@ -6,9 +6,7 @@ namespace Refedle.App.Cli;
 
 internal struct CsvRecordReader : IRecordReader
 {
-#pragma warning disable IDE0052, S1450 // Read in Step 2 (GetCellData source-index lookup); restored then.
     private readonly int[] _outputToSourceIndexMap;
-#pragma warning restore IDE0052, S1450
     private readonly IReadOnlyList<FilterSpec> _filters;
     private SepReader? _reader;
     private bool _disposed;
@@ -65,9 +63,14 @@ internal struct CsvRecordReader : IRecordReader
     public readonly CellData GetCellData(int outputColumnIndex)
     {
         ThrowIfDisposed();
-        // Step 2: read the CSV cell via _outputToSourceIndexMap and build a CellData
-        // (Presence is always Value; encoding via CellEncodingClassifier).
-        throw new NotImplementedException();
+        if (_reader is null)
+        {
+            return new CellData([], CellPresence.Value);
+        }
+
+        var sourceIndex = _outputToSourceIndexMap[outputColumnIndex];
+        var value = sourceIndex < 0 ? [] : _reader.Current[sourceIndex].Span;
+        return new CellData(value, CellPresence.Value, CellEncodingClassifier.Classify(value));
     }
 
     public void Dispose()

--- a/src/App/Cli/CsvRecordReader.cs
+++ b/src/App/Cli/CsvRecordReader.cs
@@ -6,7 +6,9 @@ namespace Refedle.App.Cli;
 
 internal struct CsvRecordReader : IRecordReader
 {
+#pragma warning disable IDE0052, S1450 // Read in Step 2 (GetCellData source-index lookup); restored then.
     private readonly int[] _outputToSourceIndexMap;
+#pragma warning restore IDE0052, S1450
     private readonly IReadOnlyList<FilterSpec> _filters;
     private SepReader? _reader;
     private bool _disposed;
@@ -60,21 +62,12 @@ internal struct CsvRecordReader : IRecordReader
         return FilterEvaluator.EvaluateCsvFilters(_reader.Current, _filters);
     }
 
-    public readonly ReadOnlySpan<char> GetCellSpan(int outputColumnIndex)
+    public readonly CellData GetCellData(int outputColumnIndex)
     {
         ThrowIfDisposed();
-        if (_reader is null)
-        {
-            return [];
-        }
-
-        var sourceIndex = _outputToSourceIndexMap[outputColumnIndex];
-        if (sourceIndex >= 0 && sourceIndex < _reader.Current.ColCount)
-        {
-            return _reader.Current[sourceIndex].Span;
-        }
-
-        return [];
+        // Step 2: read the CSV cell via _outputToSourceIndexMap and build a CellData
+        // (Presence is always Value; encoding via CellEncodingClassifier).
+        throw new NotImplementedException();
     }
 
     public void Dispose()

--- a/src/App/Cli/CsvRecordWriter.cs
+++ b/src/App/Cli/CsvRecordWriter.cs
@@ -51,9 +51,17 @@ internal struct CsvRecordWriter : IRecordWriter
     public readonly void WriteCellData(int outputColumnIndex, CellData cell)
     {
         ThrowIfDisposed();
-        // Step 2: append the column separator and branch on cell.Presence
-        // (Null/Missing/Invalid → empty; Value → CSV-escape cell.Value).
-        throw new NotImplementedException();
+        if (outputColumnIndex > 0)
+        {
+            _sb.Append(',');
+        }
+
+        if (cell.Presence != CellPresence.Value)
+        {
+            return;
+        }
+
+        CsvEscaper.EscapeCsvValueToBuilder(cell.Value, _sb);
     }
 
     public async readonly ValueTask WriteEndRecordAsync(CancellationToken ct)

--- a/src/App/Cli/CsvRecordWriter.cs
+++ b/src/App/Cli/CsvRecordWriter.cs
@@ -48,22 +48,12 @@ internal struct CsvRecordWriter : IRecordWriter
         return default;
     }
 
-    public readonly void WriteCellSpan(int outputColumnIndex, ReadOnlySpan<char> value)
+    public readonly void WriteCellData(int outputColumnIndex, CellData cell)
     {
         ThrowIfDisposed();
-        if (outputColumnIndex > 0)
-        {
-            _sb.Append(',');
-        }
-
-        if (value.SequenceEqual("<null>") || value.SequenceEqual("<error>"))
-        {
-            // Empty
-        }
-        else if (value.Length > 0)
-        {
-            CsvEscaper.EscapeCsvValueToBuilder(value, _sb);
-        }
+        // Step 2: append the column separator and branch on cell.Presence
+        // (Null/Missing/Invalid → empty; Value → CSV-escape cell.Value).
+        throw new NotImplementedException();
     }
 
     public async readonly ValueTask WriteEndRecordAsync(CancellationToken ct)

--- a/src/App/Cli/IRecordReader.cs
+++ b/src/App/Cli/IRecordReader.cs
@@ -4,5 +4,5 @@ internal interface IRecordReader : IDisposable
 {
     ValueTask<bool> MoveNextAsync(CancellationToken ct);
     bool EvaluateFilters();
-    ReadOnlySpan<char> GetCellSpan(int outputColumnIndex);
+    CellData GetCellData(int outputColumnIndex);
 }

--- a/src/App/Cli/IRecordWriter.cs
+++ b/src/App/Cli/IRecordWriter.cs
@@ -4,7 +4,7 @@ internal interface IRecordWriter : IDisposable, IAsyncDisposable
 {
     ValueTask WriteHeaderAsync(CancellationToken ct);
     ValueTask WriteStartRecordAsync(CancellationToken ct);
-    void WriteCellSpan(int outputColumnIndex, ReadOnlySpan<char> value);
+    void WriteCellData(int outputColumnIndex, CellData cell);
     ValueTask WriteEndRecordAsync(CancellationToken ct);
     ValueTask FlushAsync(CancellationToken ct);
 }

--- a/src/App/Cli/JsonLinesRecordReader.cs
+++ b/src/App/Cli/JsonLinesRecordReader.cs
@@ -138,6 +138,9 @@ internal struct JsonLinesRecordReader : IRecordReader
         }
     }
 
+    // Split out to stay under the Sonar cyclomatic-complexity limit (S1541). Passed by value,
+    // not by ref, so it owns a copy isolated from the caller's state (ref also fails to
+    // compile: CS8168/CS8347); the resulting small, stack-only copy per call is an accepted cost.
     private static CellData ReadPropertyValue(Utf8JsonReader reader, JsonRawBytes containingBytes)
     {
         return reader.TokenType switch

--- a/src/App/Cli/JsonLinesRecordReader.cs
+++ b/src/App/Cli/JsonLinesRecordReader.cs
@@ -1,5 +1,7 @@
 using System.Text;
+using System.Text.Json;
 using Refedle.Engine;
+using Refedle.Engine.IO.Json;
 using Refedle.Engine.IO.JsonLines;
 using Refedle.Engine.Models;
 
@@ -8,9 +10,7 @@ namespace Refedle.App.Cli;
 internal struct JsonLinesRecordReader : IRecordReader
 {
     private readonly RowIndexer _rowIndexer;
-#pragma warning disable IDE0052, S1450 // Read in Step 2 (GetCellData property-name lookup); restored then.
     private readonly Memory<byte>[] _columnNameUtf8Bytes;
-#pragma warning restore IDE0052, S1450
     private readonly Dictionary<int, ReadOnlyMemory<byte>> _filterIndexToNameBytes;
     private readonly IReadOnlyList<Engine.Filtering.FilterSpec> _filters;
     private RowReader? _rowReader;
@@ -92,9 +92,70 @@ internal struct JsonLinesRecordReader : IRecordReader
     public readonly CellData GetCellData(int outputColumnIndex)
     {
         ThrowIfDisposed();
-        // Step 2: scan _currentLineBytes with a local Utf8JsonReader for the property named
-        // _columnNameUtf8Bytes[outputColumnIndex]; derive Presence/Encoding/Value from JsonTokenType.
-        throw new NotImplementedException();
+
+        var columnNameUtf8 = _columnNameUtf8Bytes[outputColumnIndex].Span;
+
+        try
+        {
+            var reader = new Utf8JsonReader(_currentLineBytes.Span);
+
+            if (!reader.Read() || reader.TokenType != JsonTokenType.StartObject)
+            {
+                return new CellData([], CellPresence.Invalid);
+            }
+
+            while (reader.Read())
+            {
+                if (reader.TokenType == JsonTokenType.EndObject)
+                {
+                    break;
+                }
+
+                if (reader.TokenType != JsonTokenType.PropertyName)
+                {
+                    continue;
+                }
+
+                if (!reader.ValueTextEquals(columnNameUtf8))
+                {
+                    reader.Skip();
+                    continue;
+                }
+
+                if (!reader.Read())
+                {
+                    return new CellData([], CellPresence.Invalid);
+                }
+
+                return ReadPropertyValue(reader, _currentLineBytes);
+            }
+
+            return new CellData([], CellPresence.Missing);
+        }
+        catch (JsonException)
+        {
+            return new CellData([], CellPresence.Invalid);
+        }
+    }
+
+    private static CellData ReadPropertyValue(Utf8JsonReader reader, JsonRawBytes containingBytes)
+    {
+        return reader.TokenType switch
+        {
+            JsonTokenType.Null => new CellData([], CellPresence.Null),
+            JsonTokenType.Number =>
+                new CellData(Encoding.UTF8.GetString(reader.ValueSpan), CellPresence.Value, CellEncoding.Raw),
+            JsonTokenType.StartObject or JsonTokenType.StartArray =>
+                new CellData(
+                    Encoding.UTF8.GetString(JsonByteExtractor.ExtractValueBytes(ref reader, containingBytes).Span),
+                    CellPresence.Value,
+                    CellEncoding.Raw),
+            JsonTokenType.String =>
+                new CellData(reader.GetString(), CellPresence.Value, CellEncoding.PlainText),
+            JsonTokenType.True => new CellData("true", CellPresence.Value, CellEncoding.Boolean),
+            JsonTokenType.False => new CellData("false", CellPresence.Value, CellEncoding.Boolean),
+            _ => new CellData([], CellPresence.Invalid),
+        };
     }
 
     public void Dispose()

--- a/src/App/Cli/JsonLinesRecordReader.cs
+++ b/src/App/Cli/JsonLinesRecordReader.cs
@@ -1,6 +1,5 @@
 using System.Text;
 using Refedle.Engine;
-using Refedle.Engine.IO.Json;
 using Refedle.Engine.IO.JsonLines;
 using Refedle.Engine.Models;
 
@@ -9,7 +8,9 @@ namespace Refedle.App.Cli;
 internal struct JsonLinesRecordReader : IRecordReader
 {
     private readonly RowIndexer _rowIndexer;
+#pragma warning disable IDE0052, S1450 // Read in Step 2 (GetCellData property-name lookup); restored then.
     private readonly Memory<byte>[] _columnNameUtf8Bytes;
+#pragma warning restore IDE0052, S1450
     private readonly Dictionary<int, ReadOnlyMemory<byte>> _filterIndexToNameBytes;
     private readonly IReadOnlyList<Engine.Filtering.FilterSpec> _filters;
     private RowReader? _rowReader;
@@ -88,12 +89,12 @@ internal struct JsonLinesRecordReader : IRecordReader
         return FilterEvaluator.EvaluateJsonFilters(_currentLineBytes, _filters, _filterIndexToNameBytes);
     }
 
-    public readonly ReadOnlySpan<char> GetCellSpan(int outputColumnIndex)
+    public readonly CellData GetCellData(int outputColumnIndex)
     {
         ThrowIfDisposed();
-        var columnNameSpan = _columnNameUtf8Bytes[outputColumnIndex].Span;
-        var value = JsonObjectCellExtractor.ExtractCell(_currentLineBytes.Span, columnNameSpan);
-        return value.AsSpan();
+        // Step 2: scan _currentLineBytes with a local Utf8JsonReader for the property named
+        // _columnNameUtf8Bytes[outputColumnIndex]; derive Presence/Encoding/Value from JsonTokenType.
+        throw new NotImplementedException();
     }
 
     public void Dispose()

--- a/src/App/Cli/JsonLinesRecordWriter.cs
+++ b/src/App/Cli/JsonLinesRecordWriter.cs
@@ -1,4 +1,3 @@
-using System.Globalization;
 using System.Text.Encodings.Web;
 using System.Text.Json;
 using Refedle.Engine;
@@ -8,7 +7,9 @@ namespace Refedle.App.Cli;
 internal partial struct JsonLinesRecordWriter : IRecordWriter
 {
     private const int InitialBufferSize = 1024 * 64; // 64 KB
+#pragma warning disable IDE0052, S1450 // Read in Step 2 (WriteCellData property-name lookup); restored then.
     private readonly BatchOutputSchema _outputSchema;
+#pragma warning restore IDE0052, S1450
     private Stream? _stream;
     private PooledBufferWriter? _bufferWriter;
     private Utf8JsonWriter? _jsonWriter;
@@ -52,17 +53,12 @@ internal partial struct JsonLinesRecordWriter : IRecordWriter
         return default;
     }
 
-    public readonly void WriteCellSpan(int outputColumnIndex, ReadOnlySpan<char> value)
+    public readonly void WriteCellData(int outputColumnIndex, CellData cell)
     {
         ThrowIfDisposed();
-        if (_jsonWriter is null)
-        {
-            return;
-        }
-
-        var colName = _outputSchema.Columns[outputColumnIndex].OutputName;
-        _jsonWriter.WritePropertyName(colName);
-        WriteJsonValue(_jsonWriter, value);
+        // Step 2: omit the property name for Presence.Missing and dispatch the value on
+        // cell.Presence/cell.Encoding (replacing the removed WriteJsonValue heuristic).
+        throw new NotImplementedException();
     }
 
     public async readonly ValueTask WriteEndRecordAsync(CancellationToken ct)
@@ -99,47 +95,6 @@ internal partial struct JsonLinesRecordWriter : IRecordWriter
         }
 
         await _stream.FlushAsync(ct).ConfigureAwait(false);
-    }
-
-    private static void WriteJsonValue(Utf8JsonWriter writer, ReadOnlySpan<char> value)
-    {
-        if (value.IsEmpty)
-        {
-            writer.WriteStringValue(string.Empty);
-            return;
-        }
-
-        if (value.SequenceEqual("<null>"))
-        {
-            writer.WriteNullValue();
-            return;
-        }
-
-        if (value.SequenceEqual("<error>"))
-        {
-            writer.WriteStringValue(string.Empty);
-            return;
-        }
-
-        if (bool.TryParse(value, out var boolValue))
-        {
-            writer.WriteBooleanValue(boolValue);
-            return;
-        }
-
-        if (long.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var longValue))
-        {
-            writer.WriteNumberValue(longValue);
-            return;
-        }
-
-        if (double.TryParse(value, NumberStyles.Any, CultureInfo.InvariantCulture, out var doubleValue))
-        {
-            writer.WriteNumberValue(doubleValue);
-            return;
-        }
-
-        writer.WriteStringValue(value);
     }
 
     public readonly void ThrowIfDisposed()

--- a/src/App/Cli/JsonLinesRecordWriter.cs
+++ b/src/App/Cli/JsonLinesRecordWriter.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics;
+using System.Globalization;
 using System.Text.Encodings.Web;
 using System.Text.Json;
 using Refedle.Engine;
@@ -7,9 +9,7 @@ namespace Refedle.App.Cli;
 internal partial struct JsonLinesRecordWriter : IRecordWriter
 {
     private const int InitialBufferSize = 1024 * 64; // 64 KB
-#pragma warning disable IDE0052, S1450 // Read in Step 2 (WriteCellData property-name lookup); restored then.
     private readonly BatchOutputSchema _outputSchema;
-#pragma warning restore IDE0052, S1450
     private Stream? _stream;
     private PooledBufferWriter? _bufferWriter;
     private Utf8JsonWriter? _jsonWriter;
@@ -56,9 +56,72 @@ internal partial struct JsonLinesRecordWriter : IRecordWriter
     public readonly void WriteCellData(int outputColumnIndex, CellData cell)
     {
         ThrowIfDisposed();
-        // Step 2: omit the property name for Presence.Missing and dispatch the value on
-        // cell.Presence/cell.Encoding (replacing the removed WriteJsonValue heuristic).
-        throw new NotImplementedException();
+        if (_jsonWriter is null)
+        {
+            return;
+        }
+
+        if (cell.Presence == CellPresence.Missing)
+        {
+            return;
+        }
+
+        _jsonWriter.WritePropertyName(_outputSchema.Columns[outputColumnIndex].OutputName);
+
+        if (cell.Presence == CellPresence.Null)
+        {
+            _jsonWriter.WriteNullValue();
+            return;
+        }
+
+        if (cell.Presence == CellPresence.Invalid)
+        {
+            _jsonWriter.WriteStringValue(string.Empty);
+            return;
+        }
+
+        if (cell.Encoding == CellEncoding.Raw)
+        {
+            _jsonWriter.WriteRawValue(cell.Value, skipInputValidation: true);
+            return;
+        }
+
+        if (cell.Encoding == CellEncoding.Numeric)
+        {
+            writeNumericValue(_jsonWriter, cell.Value);
+            return;
+        }
+
+        if (cell.Encoding == CellEncoding.Boolean)
+        {
+            _jsonWriter.WriteBooleanValue(bool.Parse(cell.Value));
+            return;
+        }
+
+        if (cell.Encoding == CellEncoding.PlainText)
+        {
+            _jsonWriter.WriteStringValue(cell.Value);
+            return;
+        }
+
+        throw new UnreachableException($"Unhandled CellEncoding: {cell.Encoding}");
+
+        static void writeNumericValue(Utf8JsonWriter writer, ReadOnlySpan<char> value)
+        {
+            if (long.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var longValue))
+            {
+                writer.WriteNumberValue(longValue);
+                return;
+            }
+
+            if (double.TryParse(value, NumberStyles.Any, CultureInfo.InvariantCulture, out var doubleValue))
+            {
+                writer.WriteNumberValue(doubleValue);
+                return;
+            }
+
+            throw new UnreachableException("CellEncoding.Numeric guarantees the value re-parses as long or double.");
+        }
     }
 
     public async readonly ValueTask WriteEndRecordAsync(CancellationToken ct)

--- a/src/App/Cli/RecordProcessor.cs
+++ b/src/App/Cli/RecordProcessor.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics;
 using System.Globalization;
 using Refedle.Engine;
 using Refedle.Engine.Models;
@@ -30,19 +29,15 @@ internal static class RecordProcessor
 
             for (var i = 0; i < columns.Count; i++)
             {
-                if (columns[i].Transform is not { } transform)
+                if (columns[i].Transform is null)
                 {
-                    writer.WriteCellSpan(i, reader.GetCellSpan(i));
+                    writer.WriteCellData(i, reader.GetCellData(i));
                     continue;
                 }
 
-                var span = transform switch
-                {
-                    FillSpec fill => fill.Value.AsSpan(),
-                    TimestampFormatSpec fmt => ApplyTimestampFormat(reader.GetCellSpan(i), fmt).AsSpan(),
-                    _ => throw new UnreachableException($"Unhandled CellTransformSpec: {transform.GetType().Name}"),
-                };
-                writer.WriteCellSpan(i, span);
+                // Step 2: format via the transform (FillSpec/TimestampFormatSpec), classify the
+                // result via CellEncodingClassifier, and wrap it in a CellData for WriteCellData.
+                throw new NotImplementedException();
             }
 
             await writer.WriteEndRecordAsync(ct).ConfigureAwait(false);
@@ -52,6 +47,7 @@ internal static class RecordProcessor
         return ExitCode.Success;
     }
 
+#pragma warning disable IDE0051 // Called from Step 2 transform wiring; restored then.
     private static string ApplyTimestampFormat(ReadOnlySpan<char> raw, TimestampFormatSpec fmt)
     {
         if (!DateTime.TryParse(raw, CultureInfo.InvariantCulture, DateTimeStyles.None, out var parsed))
@@ -61,4 +57,5 @@ internal static class RecordProcessor
 
         return parsed.ToString(fmt.TargetFormat, CultureInfo.InvariantCulture);
     }
+#pragma warning restore IDE0051
 }

--- a/src/App/Cli/RecordProcessor.cs
+++ b/src/App/Cli/RecordProcessor.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Globalization;
 using Refedle.Engine;
 using Refedle.Engine.Models;
@@ -29,15 +30,20 @@ internal static class RecordProcessor
 
             for (var i = 0; i < columns.Count; i++)
             {
-                if (columns[i].Transform is null)
+                if (columns[i].Transform is not { } transform)
                 {
                     writer.WriteCellData(i, reader.GetCellData(i));
                     continue;
                 }
 
-                // Step 2: format via the transform (FillSpec/TimestampFormatSpec), classify the
-                // result via CellEncodingClassifier, and wrap it in a CellData for WriteCellData.
-                throw new NotImplementedException();
+                var formatted = transform switch
+                {
+                    FillSpec fill => fill.Value,
+                    TimestampFormatSpec fmt => ApplyTimestampFormat(reader.GetCellData(i).Value, fmt),
+                    _ => throw new UnreachableException($"Unhandled CellTransformSpec: {transform.GetType().Name}"),
+                };
+
+                writer.WriteCellData(i, new CellData(formatted, CellPresence.Value, CellEncodingClassifier.Classify(formatted)));
             }
 
             await writer.WriteEndRecordAsync(ct).ConfigureAwait(false);
@@ -47,7 +53,6 @@ internal static class RecordProcessor
         return ExitCode.Success;
     }
 
-#pragma warning disable IDE0051 // Called from Step 2 transform wiring; restored then.
     private static string ApplyTimestampFormat(ReadOnlySpan<char> raw, TimestampFormatSpec fmt)
     {
         if (!DateTime.TryParse(raw, CultureInfo.InvariantCulture, DateTimeStyles.None, out var parsed))
@@ -57,5 +62,4 @@ internal static class RecordProcessor
 
         return parsed.ToString(fmt.TargetFormat, CultureInfo.InvariantCulture);
     }
-#pragma warning restore IDE0051
 }

--- a/tests/Refedle.Tests/App/Cli/CellEncodingClassifierTests.cs
+++ b/tests/Refedle.Tests/App/Cli/CellEncodingClassifierTests.cs
@@ -1,0 +1,21 @@
+using Refedle.App.Cli;
+
+namespace Refedle.Tests.App.Cli;
+
+public sealed class CellEncodingClassifierTests
+{
+    [Theory]
+    [InlineData("007", CellEncoding.Numeric)]
+    [InlineData("1,234", CellEncoding.Numeric)]
+    [InlineData("TRUE", CellEncoding.Boolean)]
+    [InlineData("plain text", CellEncoding.PlainText)]
+    internal void Classify_VariousText_ReturnsExpectedEncoding(string input, CellEncoding expectedEncoding)
+    {
+        // Arrange
+
+        // Act
+
+        // Assert
+        Assert.Fail($"Not implemented: Classify(\"{input}\") -> {expectedEncoding}");
+    }
+}

--- a/tests/Refedle.Tests/App/Cli/CellEncodingClassifierTests.cs
+++ b/tests/Refedle.Tests/App/Cli/CellEncodingClassifierTests.cs
@@ -1,3 +1,4 @@
+using AwesomeAssertions;
 using Refedle.App.Cli;
 
 namespace Refedle.Tests.App.Cli;
@@ -14,8 +15,9 @@ public sealed class CellEncodingClassifierTests
         // Arrange
 
         // Act
+        var actual = CellEncodingClassifier.Classify(input);
 
         // Assert
-        Assert.Fail($"Not implemented: Classify(\"{input}\") -> {expectedEncoding}");
+        actual.Should().Be(expectedEncoding);
     }
 }

--- a/tests/Refedle.Tests/App/Cli/CsvRecordReaderTests.cs
+++ b/tests/Refedle.Tests/App/Cli/CsvRecordReaderTests.cs
@@ -1,0 +1,22 @@
+using Refedle.App.Cli;
+
+namespace Refedle.Tests.App.Cli;
+
+public sealed class CsvRecordReaderTests
+{
+    // CSV cells always carry Value presence; the encoding is heuristically classified.
+    [Theory]
+    [InlineData("007", CellEncoding.Numeric)]
+    [InlineData("TRUE", CellEncoding.Boolean)]
+    [InlineData("hello", CellEncoding.PlainText)]
+    [InlineData("", CellEncoding.PlainText)]
+    internal void GetCellData_CsvText_ReturnsValuePresenceAndClassifiedEncoding(string input, CellEncoding expectedEncoding)
+    {
+        // Arrange
+
+        // Act
+
+        // Assert
+        Assert.Fail($"Not implemented: \"{input}\" -> Value/{expectedEncoding}");
+    }
+}

--- a/tests/Refedle.Tests/App/Cli/CsvRecordReaderTests.cs
+++ b/tests/Refedle.Tests/App/Cli/CsvRecordReaderTests.cs
@@ -1,4 +1,7 @@
+using AwesomeAssertions;
+using nietras.SeparatedValues;
 using Refedle.App.Cli;
+using Refedle.Engine;
 
 namespace Refedle.Tests.App.Cli;
 
@@ -10,13 +13,29 @@ public sealed class CsvRecordReaderTests
     [InlineData("TRUE", CellEncoding.Boolean)]
     [InlineData("hello", CellEncoding.PlainText)]
     [InlineData("", CellEncoding.PlainText)]
-    internal void GetCellData_CsvText_ReturnsValuePresenceAndClassifiedEncoding(string input, CellEncoding expectedEncoding)
+    internal async Task GetCellData_CsvText_ReturnsValuePresenceAndClassifiedEncoding(string input, CellEncoding expectedEncoding)
     {
         // Arrange
+        var filePath = Path.GetTempFileName();
+        try
+        {
+            await File.WriteAllTextAsync(filePath, $"value,filler\n{input},x\n");
+            var sepReader = await Sep.New(',').Reader().FromFileAsync(filePath);
+            var outputSchema = new BatchOutputSchema([new BatchOutputColumn("value", "value")], []);
+            using var recordReader = new CsvRecordReader(sepReader, outputSchema);
+            await recordReader.MoveNextAsync(default);
 
-        // Act
+            // Act
+            var cell = recordReader.GetCellData(0);
 
-        // Assert
-        Assert.Fail($"Not implemented: \"{input}\" -> Value/{expectedEncoding}");
+            // Assert
+            cell.Presence.Should().Be(CellPresence.Value);
+            cell.Encoding.Should().Be(expectedEncoding);
+            cell.Value.ToString().Should().Be(input);
+        }
+        finally
+        {
+            File.Delete(filePath);
+        }
     }
 }

--- a/tests/Refedle.Tests/App/Cli/CsvRecordWriterTests.cs
+++ b/tests/Refedle.Tests/App/Cli/CsvRecordWriterTests.cs
@@ -1,0 +1,50 @@
+namespace Refedle.Tests.App.Cli;
+
+public sealed class CsvRecordWriterTests
+{
+    // CSV output is always plain text, so Encoding is ignored; only Presence matters.
+    // CellPresence is internal, so each case is standalone.
+    [Fact]
+    public void WriteCellData_Value_WritesEscapedValue()
+    {
+        // Arrange
+
+        // Act
+
+        // Assert
+        Assert.Fail("Not implemented");
+    }
+
+    [Fact]
+    public void WriteCellData_Null_WritesEmpty()
+    {
+        // Arrange
+
+        // Act
+
+        // Assert
+        Assert.Fail("Not implemented");
+    }
+
+    [Fact]
+    public void WriteCellData_Missing_WritesEmpty()
+    {
+        // Arrange
+
+        // Act
+
+        // Assert
+        Assert.Fail("Not implemented");
+    }
+
+    [Fact]
+    public void WriteCellData_Invalid_WritesEmpty()
+    {
+        // Arrange
+
+        // Act
+
+        // Assert
+        Assert.Fail("Not implemented");
+    }
+}

--- a/tests/Refedle.Tests/App/Cli/CsvRecordWriterTests.cs
+++ b/tests/Refedle.Tests/App/Cli/CsvRecordWriterTests.cs
@@ -1,50 +1,98 @@
+using System.Text;
+using AwesomeAssertions;
+using Refedle.App.Cli;
+using Refedle.Engine;
+
 namespace Refedle.Tests.App.Cli;
 
 public sealed class CsvRecordWriterTests
 {
+    private static readonly BatchOutputSchema _outputSchema = new(
+        [new BatchOutputColumn("value", "value")],
+        []);
+
     // CSV output is always plain text, so Encoding is ignored; only Presence matters.
     // CellPresence is internal, so each case is standalone.
     [Fact]
-    public void WriteCellData_Value_WritesEscapedValue()
+    public async Task WriteCellData_Value_WritesEscapedValue()
     {
         // Arrange
+        const string value = "hello, world";
 
         // Act
+        var output = await WriteSingleCellAndReadAsync(CellPresence.Value, value);
 
         // Assert
-        Assert.Fail("Not implemented");
+        output.Should().Be("\"hello, world\"\n");
     }
 
     [Fact]
-    public void WriteCellData_Null_WritesEmpty()
+    public async Task WriteCellData_Null_WritesEmpty()
     {
         // Arrange
+        const CellPresence presence = CellPresence.Null;
 
         // Act
+        var output = await WriteSingleCellAndReadAsync(presence);
 
         // Assert
-        Assert.Fail("Not implemented");
+        output.Should().Be("\n");
     }
 
     [Fact]
-    public void WriteCellData_Missing_WritesEmpty()
+    public async Task WriteCellData_Missing_WritesEmpty()
     {
         // Arrange
+        const CellPresence presence = CellPresence.Missing;
 
         // Act
+        var output = await WriteSingleCellAndReadAsync(presence);
 
         // Assert
-        Assert.Fail("Not implemented");
+        output.Should().Be("\n");
     }
 
     [Fact]
-    public void WriteCellData_Invalid_WritesEmpty()
+    public async Task WriteCellData_Invalid_WritesEmpty()
+    {
+        // Arrange
+        const CellPresence presence = CellPresence.Invalid;
+
+        // Act
+        var output = await WriteSingleCellAndReadAsync(presence);
+
+        // Assert
+        output.Should().Be("\n");
+    }
+
+    // CsvRecordWriter never reads Encoding for a Value cell — the CSV text is written as-is
+    // regardless of how the reader classified it.
+    [Theory]
+    [InlineData("007", CellEncoding.Numeric)]
+    [InlineData("TRUE", CellEncoding.Boolean)]
+    [InlineData("[1]", CellEncoding.Raw)]
+    internal async Task WriteCellData_ValueWithEncoding_PreservesCsvText(string value, CellEncoding encoding)
     {
         // Arrange
 
         // Act
+        var output = await WriteSingleCellAndReadAsync(CellPresence.Value, value, encoding);
 
         // Assert
-        Assert.Fail("Not implemented");
+        output.Should().Be($"{value}\n");
+    }
+
+    private static async Task<string> WriteSingleCellAndReadAsync(CellPresence presence, string value = "", CellEncoding encoding = CellEncoding.PlainText)
+    {
+        using var stream = new MemoryStream();
+        using var streamWriter = new StreamWriter(stream, new UTF8Encoding(false), leaveOpen: true) { NewLine = "\n" };
+        using var writer = new CsvRecordWriter(streamWriter, _outputSchema);
+
+        await writer.WriteStartRecordAsync(default);
+        writer.WriteCellData(0, new CellData(value, presence, encoding));
+        await writer.WriteEndRecordAsync(default);
+        await writer.FlushAsync(default);
+
+        return Encoding.UTF8.GetString(stream.ToArray());
     }
 }

--- a/tests/Refedle.Tests/App/Cli/JsonLinesRecordReaderTests.cs
+++ b/tests/Refedle.Tests/App/Cli/JsonLinesRecordReaderTests.cs
@@ -1,92 +1,279 @@
+using AwesomeAssertions;
+using Refedle.App.Cli;
+using Refedle.Engine;
+using Refedle.Engine.IO.JsonLines;
+using Refedle.Engine.Models;
+using Refedle.Engine.Types;
+
 namespace Refedle.Tests.App.Cli;
 
 public sealed class JsonLinesRecordReaderTests
 {
+    private const string ColumnName = "value";
+
     [Fact]
-    public void GetCellData_NumberToken_ReturnsValueRaw()
+    public async Task GetCellData_NumberToken_ReturnsValueRaw()
     {
         // Arrange
+        var filePath = Path.GetTempFileName();
+        try
+        {
+            File.WriteAllText(filePath, """{"value":1.50}""");
+            var rowIndexer = new RowIndexer(filePath);
+            rowIndexer.BuildIndex();
+            using var rowReader = new RowReader(filePath);
+            var (inputSchema, outputSchema) = BuildSchemas();
+            using var reader = new JsonLinesRecordReader(rowIndexer, rowReader, inputSchema, outputSchema);
+            await reader.MoveNextAsync(default);
 
-        // Act
+            // Act
+            var cell = reader.GetCellData(0);
 
-        // Assert
-        Assert.Fail("Not implemented");
+            // Assert
+            cell.Presence.Should().Be(CellPresence.Value);
+            cell.Encoding.Should().Be(CellEncoding.Raw);
+            cell.Value.ToString().Should().Be("1.50");
+        }
+        finally
+        {
+            File.Delete(filePath);
+        }
     }
 
     [Fact]
-    public void GetCellData_ObjectToken_ReturnsValueRaw()
+    public async Task GetCellData_ObjectToken_ReturnsValueRaw()
     {
         // Arrange
+        var filePath = Path.GetTempFileName();
+        try
+        {
+            File.WriteAllText(filePath, """{"value":{"a":1}}""");
+            var rowIndexer = new RowIndexer(filePath);
+            rowIndexer.BuildIndex();
+            using var rowReader = new RowReader(filePath);
+            var (inputSchema, outputSchema) = BuildSchemas();
+            using var reader = new JsonLinesRecordReader(rowIndexer, rowReader, inputSchema, outputSchema);
+            await reader.MoveNextAsync(default);
 
-        // Act
+            // Act
+            var cell = reader.GetCellData(0);
 
-        // Assert
-        Assert.Fail("Not implemented");
+            // Assert
+            cell.Presence.Should().Be(CellPresence.Value);
+            cell.Encoding.Should().Be(CellEncoding.Raw);
+            cell.Value.ToString().Should().Be("""{"a":1}""");
+        }
+        finally
+        {
+            File.Delete(filePath);
+        }
     }
 
     [Fact]
-    public void GetCellData_ArrayToken_ReturnsValueRaw()
+    public async Task GetCellData_ArrayToken_ReturnsValueRaw()
     {
         // Arrange
+        var filePath = Path.GetTempFileName();
+        try
+        {
+            File.WriteAllText(filePath, """{"value":[1,2,3]}""");
+            var rowIndexer = new RowIndexer(filePath);
+            rowIndexer.BuildIndex();
+            using var rowReader = new RowReader(filePath);
+            var (inputSchema, outputSchema) = BuildSchemas();
+            using var reader = new JsonLinesRecordReader(rowIndexer, rowReader, inputSchema, outputSchema);
+            await reader.MoveNextAsync(default);
 
-        // Act
+            // Act
+            var cell = reader.GetCellData(0);
 
-        // Assert
-        Assert.Fail("Not implemented");
+            // Assert
+            cell.Presence.Should().Be(CellPresence.Value);
+            cell.Encoding.Should().Be(CellEncoding.Raw);
+            cell.Value.ToString().Should().Be("[1,2,3]");
+        }
+        finally
+        {
+            File.Delete(filePath);
+        }
     }
 
     [Fact]
-    public void GetCellData_StringToken_ReturnsValuePlainText()
+    public async Task GetCellData_StringToken_ReturnsValuePlainText()
     {
         // Arrange
+        var filePath = Path.GetTempFileName();
+        try
+        {
+            File.WriteAllText(filePath, """{"value":"hello"}""");
+            var rowIndexer = new RowIndexer(filePath);
+            rowIndexer.BuildIndex();
+            using var rowReader = new RowReader(filePath);
+            var (inputSchema, outputSchema) = BuildSchemas();
+            using var reader = new JsonLinesRecordReader(rowIndexer, rowReader, inputSchema, outputSchema);
+            await reader.MoveNextAsync(default);
 
-        // Act
+            // Act
+            var cell = reader.GetCellData(0);
 
-        // Assert
-        Assert.Fail("Not implemented");
+            // Assert
+            cell.Presence.Should().Be(CellPresence.Value);
+            cell.Encoding.Should().Be(CellEncoding.PlainText);
+            cell.Value.ToString().Should().Be("hello");
+        }
+        finally
+        {
+            File.Delete(filePath);
+        }
     }
 
     [Fact]
-    public void GetCellData_BooleanToken_ReturnsValueBoolean()
+    public async Task GetCellData_BooleanToken_ReturnsValueBoolean()
     {
         // Arrange
+        var filePath = Path.GetTempFileName();
+        try
+        {
+            File.WriteAllText(filePath, """{"value":true}""");
+            var rowIndexer = new RowIndexer(filePath);
+            rowIndexer.BuildIndex();
+            using var rowReader = new RowReader(filePath);
+            var (inputSchema, outputSchema) = BuildSchemas();
+            using var reader = new JsonLinesRecordReader(rowIndexer, rowReader, inputSchema, outputSchema);
+            await reader.MoveNextAsync(default);
 
-        // Act
+            // Act
+            var cell = reader.GetCellData(0);
 
-        // Assert
-        Assert.Fail("Not implemented");
+            // Assert
+            cell.Presence.Should().Be(CellPresence.Value);
+            cell.Encoding.Should().Be(CellEncoding.Boolean);
+            cell.Value.ToString().Should().Be("true");
+        }
+        finally
+        {
+            File.Delete(filePath);
+        }
     }
 
     [Fact]
-    public void GetCellData_NullToken_ReturnsNullPresence()
+    public async Task GetCellData_FalseToken_ReturnsValueBoolean()
     {
         // Arrange
+        var filePath = Path.GetTempFileName();
+        try
+        {
+            File.WriteAllText(filePath, """{"value":false}""");
+            var rowIndexer = new RowIndexer(filePath);
+            rowIndexer.BuildIndex();
+            using var rowReader = new RowReader(filePath);
+            var (inputSchema, outputSchema) = BuildSchemas();
+            using var reader = new JsonLinesRecordReader(rowIndexer, rowReader, inputSchema, outputSchema);
+            await reader.MoveNextAsync(default);
 
-        // Act
+            // Act
+            var cell = reader.GetCellData(0);
 
-        // Assert
-        Assert.Fail("Not implemented");
+            // Assert
+            cell.Presence.Should().Be(CellPresence.Value);
+            cell.Encoding.Should().Be(CellEncoding.Boolean);
+            cell.Value.ToString().Should().Be("false");
+        }
+        finally
+        {
+            File.Delete(filePath);
+        }
     }
 
     [Fact]
-    public void GetCellData_MissingProperty_ReturnsMissingPresence()
+    public async Task GetCellData_NullToken_ReturnsNullPresence()
     {
         // Arrange
+        var filePath = Path.GetTempFileName();
+        try
+        {
+            File.WriteAllText(filePath, """{"value":null}""");
+            var rowIndexer = new RowIndexer(filePath);
+            rowIndexer.BuildIndex();
+            using var rowReader = new RowReader(filePath);
+            var (inputSchema, outputSchema) = BuildSchemas();
+            using var reader = new JsonLinesRecordReader(rowIndexer, rowReader, inputSchema, outputSchema);
+            await reader.MoveNextAsync(default);
 
-        // Act
+            // Act
+            var cell = reader.GetCellData(0);
 
-        // Assert
-        Assert.Fail("Not implemented");
+            // Assert
+            cell.Presence.Should().Be(CellPresence.Null);
+        }
+        finally
+        {
+            File.Delete(filePath);
+        }
     }
 
     [Fact]
-    public void GetCellData_MalformedJson_ReturnsInvalidPresence()
+    public async Task GetCellData_MissingProperty_ReturnsMissingPresence()
     {
         // Arrange
+        var filePath = Path.GetTempFileName();
+        try
+        {
+            File.WriteAllText(filePath, """{"other":1}""");
+            var rowIndexer = new RowIndexer(filePath);
+            rowIndexer.BuildIndex();
+            using var rowReader = new RowReader(filePath);
+            var (inputSchema, outputSchema) = BuildSchemas();
+            using var reader = new JsonLinesRecordReader(rowIndexer, rowReader, inputSchema, outputSchema);
+            await reader.MoveNextAsync(default);
 
-        // Act
+            // Act
+            var cell = reader.GetCellData(0);
 
-        // Assert
-        Assert.Fail("Not implemented");
+            // Assert
+            cell.Presence.Should().Be(CellPresence.Missing);
+        }
+        finally
+        {
+            File.Delete(filePath);
+        }
+    }
+
+    [Fact]
+    public async Task GetCellData_MalformedJson_ReturnsInvalidPresence()
+    {
+        // Arrange
+        var filePath = Path.GetTempFileName();
+        try
+        {
+            File.WriteAllText(filePath, "not valid json");
+            var rowIndexer = new RowIndexer(filePath);
+            rowIndexer.BuildIndex();
+            using var rowReader = new RowReader(filePath);
+            var (inputSchema, outputSchema) = BuildSchemas();
+            using var reader = new JsonLinesRecordReader(rowIndexer, rowReader, inputSchema, outputSchema);
+            await reader.MoveNextAsync(default);
+
+            // Act
+            var cell = reader.GetCellData(0);
+
+            // Assert
+            cell.Presence.Should().Be(CellPresence.Invalid);
+        }
+        finally
+        {
+            File.Delete(filePath);
+        }
+    }
+
+    private static (TableSchema InputSchema, BatchOutputSchema OutputSchema) BuildSchemas()
+    {
+        var inputSchema = new TableSchema
+        {
+            SourceFormat = DataFormat.JsonLines,
+            Columns = [new ColumnSchema { Name = ColumnName, Type = ColumnType.Text, ColumnIndex = 0 }],
+        };
+        var outputSchema = new BatchOutputSchema([new BatchOutputColumn(ColumnName, ColumnName)], []);
+        return (inputSchema, outputSchema);
     }
 }

--- a/tests/Refedle.Tests/App/Cli/JsonLinesRecordReaderTests.cs
+++ b/tests/Refedle.Tests/App/Cli/JsonLinesRecordReaderTests.cs
@@ -1,0 +1,92 @@
+namespace Refedle.Tests.App.Cli;
+
+public sealed class JsonLinesRecordReaderTests
+{
+    [Fact]
+    public void GetCellData_NumberToken_ReturnsValueRaw()
+    {
+        // Arrange
+
+        // Act
+
+        // Assert
+        Assert.Fail("Not implemented");
+    }
+
+    [Fact]
+    public void GetCellData_ObjectToken_ReturnsValueRaw()
+    {
+        // Arrange
+
+        // Act
+
+        // Assert
+        Assert.Fail("Not implemented");
+    }
+
+    [Fact]
+    public void GetCellData_ArrayToken_ReturnsValueRaw()
+    {
+        // Arrange
+
+        // Act
+
+        // Assert
+        Assert.Fail("Not implemented");
+    }
+
+    [Fact]
+    public void GetCellData_StringToken_ReturnsValuePlainText()
+    {
+        // Arrange
+
+        // Act
+
+        // Assert
+        Assert.Fail("Not implemented");
+    }
+
+    [Fact]
+    public void GetCellData_BooleanToken_ReturnsValueBoolean()
+    {
+        // Arrange
+
+        // Act
+
+        // Assert
+        Assert.Fail("Not implemented");
+    }
+
+    [Fact]
+    public void GetCellData_NullToken_ReturnsNullPresence()
+    {
+        // Arrange
+
+        // Act
+
+        // Assert
+        Assert.Fail("Not implemented");
+    }
+
+    [Fact]
+    public void GetCellData_MissingProperty_ReturnsMissingPresence()
+    {
+        // Arrange
+
+        // Act
+
+        // Assert
+        Assert.Fail("Not implemented");
+    }
+
+    [Fact]
+    public void GetCellData_MalformedJson_ReturnsInvalidPresence()
+    {
+        // Arrange
+
+        // Act
+
+        // Assert
+        Assert.Fail("Not implemented");
+    }
+}

--- a/tests/Refedle.Tests/App/Cli/JsonLinesRecordWriterTests.cs
+++ b/tests/Refedle.Tests/App/Cli/JsonLinesRecordWriterTests.cs
@@ -1,0 +1,83 @@
+namespace Refedle.Tests.App.Cli;
+
+public sealed class JsonLinesRecordWriterTests
+{
+    // CellPresence/CellEncoding are internal, so each Presence x Encoding combination
+    // is a standalone case (the enums are constructed inside the test body in Step 2).
+    [Fact]
+    public void WriteCellData_ValuePlainText_WritesJsonString()
+    {
+        // Arrange
+
+        // Act
+
+        // Assert
+        Assert.Fail("Not implemented");
+    }
+
+    [Fact]
+    public void WriteCellData_ValueRaw_WritesRawJson()
+    {
+        // Arrange
+
+        // Act
+
+        // Assert
+        Assert.Fail("Not implemented");
+    }
+
+    [Fact]
+    public void WriteCellData_ValueNumeric_WritesJsonNumber()
+    {
+        // Arrange
+
+        // Act
+
+        // Assert
+        Assert.Fail("Not implemented");
+    }
+
+    [Fact]
+    public void WriteCellData_ValueBoolean_WritesJsonBoolean()
+    {
+        // Arrange
+
+        // Act
+
+        // Assert
+        Assert.Fail("Not implemented");
+    }
+
+    [Fact]
+    public void WriteCellData_Null_WritesJsonNull()
+    {
+        // Arrange
+
+        // Act
+
+        // Assert
+        Assert.Fail("Not implemented");
+    }
+
+    [Fact]
+    public void WriteCellData_Missing_OmitsProperty()
+    {
+        // Arrange
+
+        // Act
+
+        // Assert
+        Assert.Fail("Not implemented");
+    }
+
+    [Fact]
+    public void WriteCellData_Invalid_WritesEmptyString()
+    {
+        // Arrange
+
+        // Act
+
+        // Assert
+        Assert.Fail("Not implemented");
+    }
+}

--- a/tests/Refedle.Tests/App/Cli/JsonLinesRecordWriterTests.cs
+++ b/tests/Refedle.Tests/App/Cli/JsonLinesRecordWriterTests.cs
@@ -1,83 +1,141 @@
+using System.Text;
+using AwesomeAssertions;
+using Refedle.App.Cli;
+using Refedle.Engine;
+
 namespace Refedle.Tests.App.Cli;
 
 public sealed class JsonLinesRecordWriterTests
 {
+    private static readonly BatchOutputSchema _outputSchema = new(
+        [new BatchOutputColumn("value", "value")],
+        []);
+
     // CellPresence/CellEncoding are internal, so each Presence x Encoding combination
     // is a standalone case (the enums are constructed inside the test body in Step 2).
     [Fact]
-    public void WriteCellData_ValuePlainText_WritesJsonString()
+    public async Task WriteCellData_ValuePlainText_WritesJsonString()
     {
         // Arrange
+        using var stream = new MemoryStream();
+        using var writer = new JsonLinesRecordWriter(stream, _outputSchema);
+        await writer.WriteStartRecordAsync(default);
 
         // Act
+        writer.WriteCellData(0, new CellData("hello", CellPresence.Value, CellEncoding.PlainText));
+        await writer.WriteEndRecordAsync(default);
+        await writer.FlushAsync(default);
 
         // Assert
-        Assert.Fail("Not implemented");
+        var output = Encoding.UTF8.GetString(stream.ToArray());
+        output.Should().Be("{\"value\":\"hello\"}\n");
     }
 
     [Fact]
-    public void WriteCellData_ValueRaw_WritesRawJson()
+    public async Task WriteCellData_ValueRaw_WritesRawJson()
     {
         // Arrange
+        using var stream = new MemoryStream();
+        using var writer = new JsonLinesRecordWriter(stream, _outputSchema);
+        await writer.WriteStartRecordAsync(default);
 
         // Act
+        writer.WriteCellData(0, new CellData("""{"nested":1}""", CellPresence.Value, CellEncoding.Raw));
+        await writer.WriteEndRecordAsync(default);
+        await writer.FlushAsync(default);
 
         // Assert
-        Assert.Fail("Not implemented");
+        var output = Encoding.UTF8.GetString(stream.ToArray());
+        output.Should().Be("{\"value\":{\"nested\":1}}\n");
     }
 
     [Fact]
-    public void WriteCellData_ValueNumeric_WritesJsonNumber()
+    public async Task WriteCellData_ValueNumeric_WritesJsonNumber()
     {
         // Arrange
+        using var stream = new MemoryStream();
+        using var writer = new JsonLinesRecordWriter(stream, _outputSchema);
+        await writer.WriteStartRecordAsync(default);
 
         // Act
+        writer.WriteCellData(0, new CellData("007", CellPresence.Value, CellEncoding.Numeric));
+        await writer.WriteEndRecordAsync(default);
+        await writer.FlushAsync(default);
 
         // Assert
-        Assert.Fail("Not implemented");
+        var output = Encoding.UTF8.GetString(stream.ToArray());
+        output.Should().Be("{\"value\":7}\n");
     }
 
     [Fact]
-    public void WriteCellData_ValueBoolean_WritesJsonBoolean()
+    public async Task WriteCellData_ValueBoolean_WritesJsonBoolean()
     {
         // Arrange
+        using var stream = new MemoryStream();
+        using var writer = new JsonLinesRecordWriter(stream, _outputSchema);
+        await writer.WriteStartRecordAsync(default);
 
         // Act
+        writer.WriteCellData(0, new CellData("TRUE", CellPresence.Value, CellEncoding.Boolean));
+        await writer.WriteEndRecordAsync(default);
+        await writer.FlushAsync(default);
 
         // Assert
-        Assert.Fail("Not implemented");
+        var output = Encoding.UTF8.GetString(stream.ToArray());
+        output.Should().Be("{\"value\":true}\n");
     }
 
     [Fact]
-    public void WriteCellData_Null_WritesJsonNull()
+    public async Task WriteCellData_Null_WritesJsonNull()
     {
         // Arrange
+        using var stream = new MemoryStream();
+        using var writer = new JsonLinesRecordWriter(stream, _outputSchema);
+        await writer.WriteStartRecordAsync(default);
 
         // Act
+        writer.WriteCellData(0, new CellData([], CellPresence.Null));
+        await writer.WriteEndRecordAsync(default);
+        await writer.FlushAsync(default);
 
         // Assert
-        Assert.Fail("Not implemented");
+        var output = Encoding.UTF8.GetString(stream.ToArray());
+        output.Should().Be("{\"value\":null}\n");
     }
 
     [Fact]
-    public void WriteCellData_Missing_OmitsProperty()
+    public async Task WriteCellData_Missing_OmitsProperty()
     {
         // Arrange
+        using var stream = new MemoryStream();
+        using var writer = new JsonLinesRecordWriter(stream, _outputSchema);
+        await writer.WriteStartRecordAsync(default);
 
         // Act
+        writer.WriteCellData(0, new CellData([], CellPresence.Missing));
+        await writer.WriteEndRecordAsync(default);
+        await writer.FlushAsync(default);
 
         // Assert
-        Assert.Fail("Not implemented");
+        var output = Encoding.UTF8.GetString(stream.ToArray());
+        output.Should().Be("{}\n");
     }
 
     [Fact]
-    public void WriteCellData_Invalid_WritesEmptyString()
+    public async Task WriteCellData_Invalid_WritesEmptyString()
     {
         // Arrange
+        using var stream = new MemoryStream();
+        using var writer = new JsonLinesRecordWriter(stream, _outputSchema);
+        await writer.WriteStartRecordAsync(default);
 
         // Act
+        writer.WriteCellData(0, new CellData([], CellPresence.Invalid));
+        await writer.WriteEndRecordAsync(default);
+        await writer.FlushAsync(default);
 
         // Assert
-        Assert.Fail("Not implemented");
+        var output = Encoding.UTF8.GetString(stream.ToArray());
+        output.Should().Be("{\"value\":\"\"}\n");
     }
 }

--- a/tests/Refedle.Tests/App/Cli/RecordProcessorTests.TestRecordReader.cs
+++ b/tests/Refedle.Tests/App/Cli/RecordProcessorTests.TestRecordReader.cs
@@ -76,8 +76,7 @@ public sealed partial class RecordProcessorTests
 
         public readonly CellData GetCellData(int outputColumnIndex)
         {
-            // Step 2: wrap Records[_currentIndex][outputColumnIndex] text in a CellData.
-            throw new NotImplementedException();
+            return new CellData(Records[_currentIndex][outputColumnIndex], CellPresence.Value);
         }
     }
 }

--- a/tests/Refedle.Tests/App/Cli/RecordProcessorTests.TestRecordReader.cs
+++ b/tests/Refedle.Tests/App/Cli/RecordProcessorTests.TestRecordReader.cs
@@ -74,21 +74,10 @@ public sealed partial class RecordProcessorTests
             return true;
         }
 
-        public readonly ReadOnlySpan<char> GetCellSpan(int outputColumnIndex)
+        public readonly CellData GetCellData(int outputColumnIndex)
         {
-            if (_currentIndex < 0 || _currentIndex >= Records.Length)
-            {
-                return [];
-            }
-
-            var currentRecord = Records[_currentIndex];
-
-            if (outputColumnIndex >= currentRecord.Length)
-            {
-                return [];
-            }
-
-            return currentRecord[outputColumnIndex].AsSpan();
+            // Step 2: wrap Records[_currentIndex][outputColumnIndex] text in a CellData.
+            throw new NotImplementedException();
         }
     }
 }

--- a/tests/Refedle.Tests/App/Cli/RecordProcessorTests.TestRecordWriter.cs
+++ b/tests/Refedle.Tests/App/Cli/RecordProcessorTests.TestRecordWriter.cs
@@ -34,9 +34,10 @@ public sealed partial class RecordProcessorTests
             return ValueTask.CompletedTask;
         }
 
-        public readonly void WriteCellSpan(int outputColumnIndex, ReadOnlySpan<char> value)
+        public readonly void WriteCellData(int outputColumnIndex, CellData cell)
         {
-            _cells.Add(value.ToString());
+            // Step 2: capture cell.Value (and Presence/Encoding) into _cells for assertions.
+            throw new NotImplementedException();
         }
 
         public readonly ValueTask WriteEndRecordAsync(CancellationToken ct)

--- a/tests/Refedle.Tests/App/Cli/RecordProcessorTests.TestRecordWriter.cs
+++ b/tests/Refedle.Tests/App/Cli/RecordProcessorTests.TestRecordWriter.cs
@@ -36,8 +36,7 @@ public sealed partial class RecordProcessorTests
 
         public readonly void WriteCellData(int outputColumnIndex, CellData cell)
         {
-            // Step 2: capture cell.Value (and Presence/Encoding) into _cells for assertions.
-            throw new NotImplementedException();
+            _cells.Add(cell.Value.ToString());
         }
 
         public readonly ValueTask WriteEndRecordAsync(CancellationToken ct)

--- a/tests/Refedle.Tests/App/Cli/RunnerTests.BatchCellTypedChannel.cs
+++ b/tests/Refedle.Tests/App/Cli/RunnerTests.BatchCellTypedChannel.cs
@@ -1,9 +1,15 @@
+using System.Text.Json;
+using AwesomeAssertions;
+using Refedle.App.Cli;
+
 namespace Refedle.Tests.App.Cli;
 
-// End-to-end coverage for the typed CellData channel. Skeleton only: bodies are
-// filled in Step 2. These exercise the real readers/writers via Runner.RunAsync.
+// End-to-end coverage for the typed CellData channel. These exercise the real readers/writers
+// via Runner.RunAsync.
 public sealed partial class RunnerTests
 {
+    private const string EmptyRecipeYaml = "name: Empty\nactions: []";
+
     // -------------------------------------------------------------------------
     // JSON Lines → JSON Lines — Object/Array raw JSON preservation
     // -------------------------------------------------------------------------
@@ -12,12 +18,23 @@ public sealed partial class RunnerTests
     public async Task RunAsync_JsonLinesToJsonLines_WithObjectAndArrayContainingNonAscii_PreservesRawJson()
     {
         // Arrange
+        const string line = """{"id":1,"data":{"city":"café","nested":{"count":2}},"tags":["a","café","b"]}""";
+        var inputFile = CreateTestFile("input.jsonl", line);
+        var recipeFile = CreateTestFile("recipe.yaml", EmptyRecipeYaml);
+        var outputFile = Path.Combine(_testDir, "output.jsonl");
+        var args = new Arguments { InputFile = inputFile, RecipeFile = recipeFile, OutputFile = outputFile };
+        var logger = new TestAppLogger();
 
         // Act
+        var exitCode = await Runner.RunAsync(args, logger);
 
         // Assert
-        await Task.CompletedTask;
-        Assert.Fail("Not implemented");
+        exitCode.Should().Be(ExitCode.Success);
+        var outputLine = (await File.ReadAllLinesAsync(outputFile)).Single();
+        using var inputDoc = JsonDocument.Parse(line);
+        using var outputDoc = JsonDocument.Parse(outputLine);
+        outputDoc.RootElement.GetProperty("data").GetRawText().Should().Be(inputDoc.RootElement.GetProperty("data").GetRawText());
+        outputDoc.RootElement.GetProperty("tags").GetRawText().Should().Be(inputDoc.RootElement.GetProperty("tags").GetRawText());
     }
 
     // -------------------------------------------------------------------------
@@ -31,12 +48,21 @@ public sealed partial class RunnerTests
     public async Task RunAsync_JsonLinesToJsonLines_WithNumberToken_PreservesLexicalForm(string numberLiteral)
     {
         // Arrange
+        var line = $$"""{"value":{{numberLiteral}}}""";
+        var inputFile = CreateTestFile("input.jsonl", line);
+        var recipeFile = CreateTestFile("recipe.yaml", EmptyRecipeYaml);
+        var outputFile = Path.Combine(_testDir, "output.jsonl");
+        var args = new Arguments { InputFile = inputFile, RecipeFile = recipeFile, OutputFile = outputFile };
+        var logger = new TestAppLogger();
 
         // Act
+        var exitCode = await Runner.RunAsync(args, logger);
 
         // Assert
-        await Task.CompletedTask;
-        Assert.Fail($"Not implemented: {numberLiteral}");
+        exitCode.Should().Be(ExitCode.Success);
+        var outputLine = (await File.ReadAllLinesAsync(outputFile)).Single();
+        using var outputDoc = JsonDocument.Parse(outputLine);
+        outputDoc.RootElement.GetProperty("value").GetRawText().Should().Be(numberLiteral);
     }
 
     // -------------------------------------------------------------------------
@@ -47,12 +73,22 @@ public sealed partial class RunnerTests
     public async Task RunAsync_JsonLinesToJsonLines_WithStringEscapes_ResolvesToPlain()
     {
         // Arrange
+        const string line = """{"text":"line1\nline2 \"quoted\""}""";
+        var inputFile = CreateTestFile("input.jsonl", line);
+        var recipeFile = CreateTestFile("recipe.yaml", EmptyRecipeYaml);
+        var outputFile = Path.Combine(_testDir, "output.jsonl");
+        var args = new Arguments { InputFile = inputFile, RecipeFile = recipeFile, OutputFile = outputFile };
+        var logger = new TestAppLogger();
 
         // Act
+        var exitCode = await Runner.RunAsync(args, logger);
 
         // Assert
-        await Task.CompletedTask;
-        Assert.Fail("Not implemented");
+        exitCode.Should().Be(ExitCode.Success);
+        var outputLine = (await File.ReadAllLinesAsync(outputFile)).Single();
+        using var inputDoc = JsonDocument.Parse(line);
+        using var outputDoc = JsonDocument.Parse(outputLine);
+        outputDoc.RootElement.GetProperty("text").GetString().Should().Be(inputDoc.RootElement.GetProperty("text").GetString());
     }
 
     [Theory]
@@ -61,12 +97,23 @@ public sealed partial class RunnerTests
     public async Task RunAsync_JsonLinesToJsonLines_WithStringLookingNumericOrBoolean_StaysJsonString(string stringLiteral)
     {
         // Arrange
+        var line = $$"""{"value":"{{stringLiteral}}"}""";
+        var inputFile = CreateTestFile("input.jsonl", line);
+        var recipeFile = CreateTestFile("recipe.yaml", EmptyRecipeYaml);
+        var outputFile = Path.Combine(_testDir, "output.jsonl");
+        var args = new Arguments { InputFile = inputFile, RecipeFile = recipeFile, OutputFile = outputFile };
+        var logger = new TestAppLogger();
 
         // Act
+        var exitCode = await Runner.RunAsync(args, logger);
 
         // Assert
-        await Task.CompletedTask;
-        Assert.Fail($"Not implemented: {stringLiteral}");
+        exitCode.Should().Be(ExitCode.Success);
+        var outputLine = (await File.ReadAllLinesAsync(outputFile)).Single();
+        using var outputDoc = JsonDocument.Parse(outputLine);
+        var value = outputDoc.RootElement.GetProperty("value");
+        value.ValueKind.Should().Be(JsonValueKind.String);
+        value.GetString().Should().Be(stringLiteral);
     }
 
     [Theory]
@@ -75,24 +122,53 @@ public sealed partial class RunnerTests
     public async Task RunAsync_JsonLinesToJsonLines_WithSentinelLookingString_StaysLiteral(string stringLiteral)
     {
         // Arrange
+        var line = $$"""{"value":"{{stringLiteral}}"}""";
+        var inputFile = CreateTestFile("input.jsonl", line);
+        var recipeFile = CreateTestFile("recipe.yaml", EmptyRecipeYaml);
+        var outputFile = Path.Combine(_testDir, "output.jsonl");
+        var args = new Arguments { InputFile = inputFile, RecipeFile = recipeFile, OutputFile = outputFile };
+        var logger = new TestAppLogger();
 
         // Act
+        var exitCode = await Runner.RunAsync(args, logger);
 
         // Assert
-        await Task.CompletedTask;
-        Assert.Fail($"Not implemented: {stringLiteral}");
+        exitCode.Should().Be(ExitCode.Success);
+        var outputLine = (await File.ReadAllLinesAsync(outputFile)).Single();
+        using var outputDoc = JsonDocument.Parse(outputLine);
+        var value = outputDoc.RootElement.GetProperty("value");
+        value.ValueKind.Should().Be(JsonValueKind.String);
+        value.GetString().Should().Be(stringLiteral);
     }
 
     [Fact]
     public async Task RunAsync_JsonLinesToJsonLines_MissingVersusExplicitNull_Distinguishes()
     {
         // Arrange
+        const string content = """
+            {"a":1,"b":2}
+            {"a":3}
+            {"a":4,"b":null}
+            """;
+        var inputFile = CreateTestFile("input.jsonl", content);
+        var recipeFile = CreateTestFile("recipe.yaml", EmptyRecipeYaml);
+        var outputFile = Path.Combine(_testDir, "output.jsonl");
+        var args = new Arguments { InputFile = inputFile, RecipeFile = recipeFile, OutputFile = outputFile };
+        var logger = new TestAppLogger();
 
         // Act
+        var exitCode = await Runner.RunAsync(args, logger);
 
         // Assert
-        await Task.CompletedTask;
-        Assert.Fail("Not implemented");
+        exitCode.Should().Be(ExitCode.Success);
+        var outputLines = await File.ReadAllLinesAsync(outputFile);
+        outputLines.Should().HaveCount(3);
+
+        using var missingDoc = JsonDocument.Parse(outputLines[1]);
+        missingDoc.RootElement.TryGetProperty("b", out _).Should().BeFalse();
+
+        using var nullDoc = JsonDocument.Parse(outputLines[2]);
+        nullDoc.RootElement.GetProperty("b").ValueKind.Should().Be(JsonValueKind.Null);
     }
 
     // -------------------------------------------------------------------------
@@ -103,35 +179,70 @@ public sealed partial class RunnerTests
     public async Task RunAsync_CsvToJsonLines_WithLeadingZeroNumber_NormalizesToJsonNumber()
     {
         // Arrange
+        const string content = "id,code\n1,007\n";
+        var inputFile = CreateTestFile("input.csv", content);
+        var recipeFile = CreateTestFile("recipe.yaml", EmptyRecipeYaml);
+        var outputFile = Path.Combine(_testDir, "output.jsonl");
+        var args = new Arguments { InputFile = inputFile, RecipeFile = recipeFile, OutputFile = outputFile };
+        var logger = new TestAppLogger();
 
         // Act
+        var exitCode = await Runner.RunAsync(args, logger);
 
         // Assert
-        await Task.CompletedTask;
-        Assert.Fail("Not implemented");
+        exitCode.Should().Be(ExitCode.Success);
+        var outputLine = (await File.ReadAllLinesAsync(outputFile)).Single();
+        using var outputDoc = JsonDocument.Parse(outputLine);
+        var code = outputDoc.RootElement.GetProperty("code");
+        code.ValueKind.Should().Be(JsonValueKind.Number);
+        code.GetRawText().Should().Be("7");
     }
 
     [Fact]
     public async Task RunAsync_CsvToJsonLines_WithNumericLookingFill_EmitsJsonNumber()
     {
         // Arrange
+        const string content = "name,status\nAlice,active\n";
+        const string recipeYaml = "name: Fill status\nactions:\n  - type: fill\n    columnName: status\n    value: 0";
+        var inputFile = CreateTestFile("input.csv", content);
+        var recipeFile = CreateTestFile("recipe.yaml", recipeYaml);
+        var outputFile = Path.Combine(_testDir, "output.jsonl");
+        var args = new Arguments { InputFile = inputFile, RecipeFile = recipeFile, OutputFile = outputFile };
+        var logger = new TestAppLogger();
 
         // Act
+        var exitCode = await Runner.RunAsync(args, logger);
 
         // Assert
-        await Task.CompletedTask;
-        Assert.Fail("Not implemented");
+        exitCode.Should().Be(ExitCode.Success);
+        var outputLine = (await File.ReadAllLinesAsync(outputFile)).Single();
+        using var outputDoc = JsonDocument.Parse(outputLine);
+        var status = outputDoc.RootElement.GetProperty("status");
+        status.ValueKind.Should().Be(JsonValueKind.Number);
+        status.GetRawText().Should().Be("0");
     }
 
     [Fact]
     public async Task RunAsync_CsvToJsonLines_WithNumericLookingTimestampFormat_EmitsJsonNumber()
     {
         // Arrange
+        const string content = "date\n2024-03-15\n";
+        const string recipeYaml = "name: Format date\nactions:\n  - type: format_timestamp\n    columnName: date\n    targetFormat: yyyyMMdd";
+        var inputFile = CreateTestFile("input.csv", content);
+        var recipeFile = CreateTestFile("recipe.yaml", recipeYaml);
+        var outputFile = Path.Combine(_testDir, "output.jsonl");
+        var args = new Arguments { InputFile = inputFile, RecipeFile = recipeFile, OutputFile = outputFile };
+        var logger = new TestAppLogger();
 
         // Act
+        var exitCode = await Runner.RunAsync(args, logger);
 
         // Assert
-        await Task.CompletedTask;
-        Assert.Fail("Not implemented");
+        exitCode.Should().Be(ExitCode.Success);
+        var outputLine = (await File.ReadAllLinesAsync(outputFile)).Single();
+        using var outputDoc = JsonDocument.Parse(outputLine);
+        var date = outputDoc.RootElement.GetProperty("date");
+        date.ValueKind.Should().Be(JsonValueKind.Number);
+        date.GetRawText().Should().Be("20240315");
     }
 }

--- a/tests/Refedle.Tests/App/Cli/RunnerTests.BatchCellTypedChannel.cs
+++ b/tests/Refedle.Tests/App/Cli/RunnerTests.BatchCellTypedChannel.cs
@@ -1,0 +1,137 @@
+namespace Refedle.Tests.App.Cli;
+
+// End-to-end coverage for the typed CellData channel. Skeleton only: bodies are
+// filled in Step 2. These exercise the real readers/writers via Runner.RunAsync.
+public sealed partial class RunnerTests
+{
+    // -------------------------------------------------------------------------
+    // JSON Lines → JSON Lines — Object/Array raw JSON preservation
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task RunAsync_JsonLinesToJsonLines_WithObjectAndArrayContainingNonAscii_PreservesRawJson()
+    {
+        // Arrange
+
+        // Act
+
+        // Assert
+        await Task.CompletedTask;
+        Assert.Fail("Not implemented");
+    }
+
+    // -------------------------------------------------------------------------
+    // JSON Lines → JSON Lines — Number lexical form preservation
+    // -------------------------------------------------------------------------
+
+    [Theory]
+    [InlineData("1.50")]
+    [InlineData("1e10")]
+    [InlineData("9223372036854775808")] // Int64.MaxValue + 1, beyond Int64 range
+    public async Task RunAsync_JsonLinesToJsonLines_WithNumberToken_PreservesLexicalForm(string numberLiteral)
+    {
+        // Arrange
+
+        // Act
+
+        // Assert
+        await Task.CompletedTask;
+        Assert.Fail($"Not implemented: {numberLiteral}");
+    }
+
+    // -------------------------------------------------------------------------
+    // JSON Lines → JSON Lines — String value handling
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task RunAsync_JsonLinesToJsonLines_WithStringEscapes_ResolvesToPlain()
+    {
+        // Arrange
+
+        // Act
+
+        // Assert
+        await Task.CompletedTask;
+        Assert.Fail("Not implemented");
+    }
+
+    [Theory]
+    [InlineData("5")]
+    [InlineData("true")]
+    public async Task RunAsync_JsonLinesToJsonLines_WithStringLookingNumericOrBoolean_StaysJsonString(string stringLiteral)
+    {
+        // Arrange
+
+        // Act
+
+        // Assert
+        await Task.CompletedTask;
+        Assert.Fail($"Not implemented: {stringLiteral}");
+    }
+
+    [Theory]
+    [InlineData("<null>")]
+    [InlineData("<error>")]
+    public async Task RunAsync_JsonLinesToJsonLines_WithSentinelLookingString_StaysLiteral(string stringLiteral)
+    {
+        // Arrange
+
+        // Act
+
+        // Assert
+        await Task.CompletedTask;
+        Assert.Fail($"Not implemented: {stringLiteral}");
+    }
+
+    [Fact]
+    public async Task RunAsync_JsonLinesToJsonLines_MissingVersusExplicitNull_Distinguishes()
+    {
+        // Arrange
+
+        // Act
+
+        // Assert
+        await Task.CompletedTask;
+        Assert.Fail("Not implemented");
+    }
+
+    // -------------------------------------------------------------------------
+    // CSV → JSON Lines — numeric normalization (regression guards)
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task RunAsync_CsvToJsonLines_WithLeadingZeroNumber_NormalizesToJsonNumber()
+    {
+        // Arrange
+
+        // Act
+
+        // Assert
+        await Task.CompletedTask;
+        Assert.Fail("Not implemented");
+    }
+
+    [Fact]
+    public async Task RunAsync_CsvToJsonLines_WithNumericLookingFill_EmitsJsonNumber()
+    {
+        // Arrange
+
+        // Act
+
+        // Assert
+        await Task.CompletedTask;
+        Assert.Fail("Not implemented");
+    }
+
+    [Fact]
+    public async Task RunAsync_CsvToJsonLines_WithNumericLookingTimestampFormat_EmitsJsonNumber()
+    {
+        // Arrange
+
+        // Act
+
+        // Assert
+        await Task.CompletedTask;
+        Assert.Fail("Not implemented");
+    }
+}

--- a/tests/Refedle.Tests/App/Cli/RunnerTests.cs
+++ b/tests/Refedle.Tests/App/Cli/RunnerTests.cs
@@ -4,7 +4,7 @@ using Refedle.App.Cli;
 
 namespace Refedle.Tests.App.Cli;
 
-public sealed class RunnerTests : IDisposable
+public sealed partial class RunnerTests : IDisposable
 {
     private const string TestCsvContent = """
         name,age


### PR DESCRIPTION
## Summary
- Replace `GetCellSpan`/`WriteCellSpan` with a typed `CellData` (`CellPresence`/`CellEncoding`) channel across CSV and JSON Lines readers/writers, so CLI batch output no longer reuses the TUI's display-preview strings for Object/Array/Number values.
- `JsonLinesRecordReader` now derives presence/encoding directly from `Utf8JsonReader` tokens instead of the `"<null>"`/`"<error>"` string-sentinel convention, making `Missing` distinct from `Null` and JSON Lines → JSON Lines a true structural round-trip.
- CSV behavior (CSV → CSV, CSV → JSON Lines, transformed columns) is unchanged; classification is centralized in the new `CellEncodingClassifier`.

See `docs/design_batch_cell_typed_channel.md` for the full design and decision record.

## Test plan
- [x] `dotnet build` — 0 warnings, 0 errors
- [x] `dotnet format --verify-no-changes` — no diff
- [x] `dotnet test` — 1577/1577 passing, including new reader/writer/classifier unit tests and end-to-end `RunnerTests` covering Object/Array with non-ASCII, numeric lexical forms (`1.50`, `1e10`, `Int64`-overflow), string escapes, sentinel-looking strings, Missing vs Null, CSV `007` normalization, and FillSpec/TimestampFormatSpec numeric output

Closes #267