### PR TITLE
chore: harden analyzer enforcement

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -42,6 +42,9 @@ dotnet_diagnostic.CA1303.severity = none
 # CA2012: Use ValueTasks correctly.
 dotnet_diagnostic.CA2012.severity = warning
 
+# CA2016: Forward the CancellationToken parameter to methods that take one.
+dotnet_diagnostic.CA2016.severity = warning
+
 # IDE0005: Using directive is unnecessary.
 dotnet_diagnostic.IDE0005.severity = warning
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -42,6 +42,9 @@ dotnet_diagnostic.CA1303.severity = none
 # CA1854: Prefer the IDictionary.TryGetValue method.
 dotnet_diagnostic.CA1854.severity = warning
 
+# CA1851: Possible multiple enumerations of IEnumerable collection.
+dotnet_diagnostic.CA1851.severity = warning
+
 # CA2012: Use ValueTasks correctly.
 dotnet_diagnostic.CA2012.severity = warning
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -39,6 +39,9 @@ trim_trailing_whitespace = false
 # Disabling this as the project uses English-only strings and doesn't require .resx localization.
 dotnet_diagnostic.CA1303.severity = none
 
+# CA2012: Use ValueTasks correctly.
+dotnet_diagnostic.CA2012.severity = warning
+
 # IDE0005: Using directive is unnecessary.
 dotnet_diagnostic.IDE0005.severity = warning
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -39,6 +39,9 @@ trim_trailing_whitespace = false
 # Disabling this as the project uses English-only strings and doesn't require .resx localization.
 dotnet_diagnostic.CA1303.severity = none
 
+# CA1854: Prefer the IDictionary.TryGetValue method.
+dotnet_diagnostic.CA1854.severity = warning
+
 # CA2012: Use ValueTasks correctly.
 dotnet_diagnostic.CA2012.severity = warning
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -166,6 +166,7 @@ csharp_style_expression_bodied_local_functions = when_on_single_line:suggestion
 # Pattern matching preferences
 csharp_style_pattern_matching_over_is_with_cast_check = true:warning
 csharp_style_pattern_matching_over_as_with_null_check = true:warning
+dotnet_diagnostic.IDE0260.severity = warning
 csharp_style_prefer_switch_expression = true:suggestion
 csharp_style_prefer_pattern_matching = true:suggestion
 csharp_style_prefer_not_pattern = true:suggestion
@@ -323,7 +324,6 @@ dotnet_naming_style.begins_with_underscore.capitalization = camel_case
 # CA2007: Consider calling ConfigureAwait on awaited task
 # Application code doesn't need ConfigureAwait in modern .NET (no synchronization context in CLI apps)
 dotnet_diagnostic.CA2007.severity = none
-
 # Test files
 [tests/**/*.cs]
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -48,6 +48,9 @@ dotnet_diagnostic.CA2012.severity = warning
 # CA2016: Forward the CancellationToken parameter to methods that take one.
 dotnet_diagnostic.CA2016.severity = warning
 
+# CA2021: Do not call Enumerable.Cast<T> or Enumerable.OfType<T> with incompatible types.
+dotnet_diagnostic.CA2021.severity = warning
+
 # IDE0005: Using directive is unnecessary.
 dotnet_diagnostic.IDE0005.severity = warning
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -340,6 +340,7 @@ dotnet_naming_style.begins_with_underscore.capitalization = camel_case
 # CA2007: Consider calling ConfigureAwait on awaited task
 # Application code doesn't need ConfigureAwait in modern .NET (no synchronization context in CLI apps)
 dotnet_diagnostic.CA2007.severity = none
+
 # Test files
 [tests/**/*.cs]
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -166,6 +166,7 @@ csharp_style_expression_bodied_local_functions = when_on_single_line:suggestion
 # Pattern matching preferences
 csharp_style_pattern_matching_over_is_with_cast_check = true:warning
 csharp_style_pattern_matching_over_as_with_null_check = true:warning
+dotnet_diagnostic.IDE0019.severity = warning
 dotnet_diagnostic.IDE0260.severity = warning
 csharp_style_prefer_switch_expression = true:suggestion
 csharp_style_prefer_pattern_matching = true:suggestion

--- a/SonarAnalyzer.globalconfig
+++ b/SonarAnalyzer.globalconfig
@@ -19,3 +19,4 @@ dotnet_diagnostic.S6618.severity = warning
 dotnet_diagnostic.S1905.severity = warning
 dotnet_diagnostic.S3358.severity = warning
 dotnet_diagnostic.S1118.severity = warning
+dotnet_diagnostic.S4136.severity = warning

--- a/SonarAnalyzer.globalconfig
+++ b/SonarAnalyzer.globalconfig
@@ -18,3 +18,4 @@ dotnet_diagnostic.S6966.severity = warning
 dotnet_diagnostic.S6618.severity = warning
 dotnet_diagnostic.S1905.severity = warning
 dotnet_diagnostic.S3358.severity = warning
+dotnet_diagnostic.S1118.severity = warning

--- a/src/Engine/IO/JsonObject/TopLevelScanner.cs
+++ b/src/Engine/IO/JsonObject/TopLevelScanner.cs
@@ -7,7 +7,7 @@ namespace Refedle.Engine.IO.JsonObject;
 /// <summary>
 /// Scans a JSON Object file and extracts all top-level key-value pairs in a single pass.
 /// </summary>
-public sealed class TopLevelScanner
+public static class TopLevelScanner
 {
     private const int InitialBufferSize = 1024 * 1024; // 1 MB
     private const int MaxBufferSize = 16 * 1024 * 1024; // 16 MB

--- a/src/Engine/Recipes/MorphActionParser.cs
+++ b/src/Engine/Recipes/MorphActionParser.cs
@@ -7,7 +7,7 @@ namespace Refedle.Engine.Recipes;
 /// Constructs <see cref="MorphAction"/> instances from parsed field dictionaries.
 /// Field values are expected to be already unquoted.
 /// </summary>
-internal sealed class MorphActionParser
+internal static class MorphActionParser
 {
     /// <summary>
     /// Parses a field dictionary into a <see cref="MorphAction"/>.

--- a/src/Engine/Recipes/RecipeYamlSerializer.cs
+++ b/src/Engine/Recipes/RecipeYamlSerializer.cs
@@ -10,7 +10,7 @@ namespace Refedle.Engine.Recipes;
 /// Serializes and deserializes <see cref="Recipe"/> objects to and from YAML.
 /// AOT-safe: no reflection is used.
 /// </summary>
-internal sealed class RecipeYamlSerializer
+internal static class RecipeYamlSerializer
 {
     /// <summary>
     /// Serializes a recipe to a YAML string.

--- a/src/Engine/Results.cs
+++ b/src/Engine/Results.cs
@@ -12,20 +12,20 @@ public static class Results
     public static Result Success() => new(true, default);
 
     /// <summary>
-    /// Creates a failed result with an error message.
-    /// </summary>
-    /// <param name="error">The error message describing why the operation failed.</param>
-    /// <returns>A Result representing a failed operation.</returns>
-    /// <exception cref="ArgumentException">Thrown when error is null, empty, or whitespace.</exception>
-    public static Result Failure(string error) => new(false, new ErrorMessage(error));
-
-    /// <summary>
     /// Creates a successful result with a value.
     /// </summary>
     /// <typeparam name="T">The type of the value.</typeparam>
     /// <param name="value">The value returned by the successful operation.</param>
     /// <returns>A Result{T} representing a successful operation with a value.</returns>
     public static Result<T> Success<T>(T value) => new(true, value);
+
+    /// <summary>
+    /// Creates a failed result with an error message.
+    /// </summary>
+    /// <param name="error">The error message describing why the operation failed.</param>
+    /// <returns>A Result representing a failed operation.</returns>
+    /// <exception cref="ArgumentException">Thrown when error is null, empty, or whitespace.</exception>
+    public static Result Failure(string error) => new(false, new ErrorMessage(error));
 
     /// <summary>
     /// Creates a failed result with an error message.

--- a/src/Generators/FormatDispatcherGenerator.cs
+++ b/src/Generators/FormatDispatcherGenerator.cs
@@ -6,9 +6,11 @@ using Microsoft.CodeAnalysis.Text;
 
 namespace Refedle.Generators;
 
+/// <summary>Generates dispatch code for record readers and writers.</summary>
 [Generator]
 public class FormatDispatcherGenerator : IIncrementalGenerator
 {
+    /// <summary>Initializes the incremental generation pipeline.</summary>
     public void Initialize(IncrementalGeneratorInitializationContext context)
     {
         // Collect all reader and writer declarations in a single pass
@@ -95,7 +97,7 @@ public class FormatDispatcherGenerator : IIncrementalGenerator
         if (arg is not null)
         {
             var formatValue = arg; // e.g. "DataFormat.Csv"
-            if (formatValue.StartsWith("DataFormat."))
+            if (formatValue.StartsWith("DataFormat.", StringComparison.Ordinal))
             {
                 formatValue = formatValue.Substring("DataFormat.".Length);
             }

--- a/src/Generators/FormatDispatcherGenerator.cs
+++ b/src/Generators/FormatDispatcherGenerator.cs
@@ -104,9 +104,9 @@ public class FormatDispatcherGenerator : IIncrementalGenerator
 
             var createdType = ExtractCreatedType(typeDecl);
 
-            var declaredSymbol =
-                context.SemanticModel.GetDeclaredSymbol(typeDecl) as INamedTypeSymbol;
-            var typeName = declaredSymbol?.Name ?? string.Empty;
+            var typeName = context.SemanticModel.GetDeclaredSymbol(typeDecl) is INamedTypeSymbol declaredSymbol
+                ? declaredSymbol.Name
+                : string.Empty;
             var isReader = name.Contains("RecordReader");
 
             if (!string.IsNullOrEmpty(typeName) && !string.IsNullOrEmpty(createdType))

--- a/src/Generators/Refedle.Generators.csproj
+++ b/src/Generators/Refedle.Generators.csproj
@@ -6,6 +6,12 @@
     <LangVersion>12.0</LangVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+
+    <!-- Zero-Warning Policy -->
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <AnalysisLevel>latest-all</AnalysisLevel>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

- align generator projects with the zero-warning analyzer policy
- enforce pattern matching, utility-class, and overload-order rules
- add targeted .NET analyzer checks for ValueTask usage, cancellation forwarding, dictionary lookups, incompatible LINQ casts, and multiple enumeration

## Validation

- `dotnet format --no-restore`
- `dotnet build --no-restore` (0 warnings)
- `dotnet test --no-build --no-restore` (1577 passed)

No issue.
