### PR TITLE
perf: eliminate per-cell allocation in JSON Lines GetCellData

### DIFF
--- a/docs/design_jsonlines_cell_value_zero_alloc.md
+++ b/docs/design_jsonlines_cell_value_zero_alloc.md
@@ -1,0 +1,481 @@
+# Design: JSON Lines Cell Value Zero-Allocation
+
+## In Scope
+
+- Replace the per-cell heap-allocated `string` in
+  `JsonLinesRecordReader.GetCellData`/`ReadPropertyValue` (Number, Object,
+  Array, String branches) with an `ArrayPool<char>`-backed buffer reused
+  across calls, using `Encoding.UTF8.GetChars` (Number/Object/Array) and
+  `Utf8JsonReader.CopyString` (String).
+- Buffer lifecycle management: lazy rent on first use, grow-and-return-old
+  on overflow (rent at least `Math.Max(MinimumSize, minimumLength)`, where
+  `MinimumSize` is 256 chars), and `Return` in `Dispose()`.
+- Formalize the resulting "`CellData.Value` is valid only until the next
+  `GetCellData` call" contract in XML documentation (`CellData.cs` and/or
+  `IRecordReader.GetCellData`). Existing call sites
+  (`RecordProcessor`, `JsonLinesRecordWriter`, `CsvRecordWriter`) already
+  consume the value synchronously and immediately, so this is a
+  documentation change backed by an already-verified invariant, not a
+  behavior change to those call sites.
+- Unit tests covering buffer reuse across consecutive cells in the same
+  row, growth beyond the initial buffer size, escape-sequence resolution,
+  and the empty-string boundary.
+- A `BenchmarkDotNet` benchmark (`[MemoryDiagnoser]`), following the
+  existing `JsonObjectCellExtractorBenchmarks.cs` pattern, to measure the
+  resulting allocation count for `GetCellData`.
+
+## Out of Scope
+
+- **`CsvRecordReader`/`CsvRecordWriter`**: unchanged. Sep already returns
+  `ReadOnlySpan<char>` directly with no per-cell allocation; the issue this
+  design addresses is JSON Lines–specific.
+- **`JsonLinesRecordWriter`**: unchanged. It only consumes `CellData.Value`
+  and has no reason to distinguish a pooled-buffer-backed span from a
+  `string`-backed one.
+- **`Boolean`/`Null`/`Missing`/`Invalid` branches of `GetCellData`**:
+  unchanged. These already carry no per-cell allocation today.
+- **`JsonObjectCellExtractor`/`JsonByteExtractor`** (shared Engine-layer
+  code also used by the TUI table/tree views): unchanged.
+  `JsonByteExtractor.ExtractValueBytes` was confirmed to already be
+  allocation-free (it only slices `ReadOnlyMemory<byte>`), so it needs no
+  changes for this design to reach zero allocation. The known, separately
+  tracked TUI-side bugs in `FormatValue`/`FormatNumber` are not addressed
+  here.
+- **`RecordProcessor`**: unchanged. `CellData`'s shape is not changing, so
+  no caller-side code needs to change.
+- **`ColumnType`/`TypeInferrer`**: unrelated, unchanged.
+- **`IRecordReader`/`IRecordWriter` interface signatures**: unchanged.
+  `GetCellData` still returns `CellData`; only the implementing struct's
+  `readonly` modifier changes.
+- **A byte-native JSON Lines → JSON Lines pipeline** (Alternative C in
+  `docs/design_batch_cell_typed_channel.md`): still not pursued.
+  `ArrayPool<char>` pooling alone reaches zero allocation without the added
+  complexity of a second, format-pair-specific pipeline.
+- **Wiring the new benchmark into CI**: it is a manually-run diagnostic,
+  matching every other `BenchmarkDotNet` class already in this repository.
+
+---
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `src/App/Cli/JsonLinesRecordReader.cs` | Main change — see "Implementation Approach" below |
+| `src/App/Cli/IRecordReader.cs` | XML doc update only: document on `GetCellData` that the returned `CellData.Value` is valid only until the next `GetCellData` call, and becomes invalid once the reader is `Dispose()`d |
+| `tests/Refedle.Tests/App/Cli/JsonLinesRecordReaderTests.cs` | Add cases for buffer reuse across cells, growth beyond the initial size, escape-sequence resolution, and the empty-string boundary |
+| `tests/Refedle.Tests/App/Cli/JsonLinesRecordReaderBenchmarks.cs` | **New.** `[MemoryDiagnoser]` benchmark for `GetCellData`, following the `JsonObjectCellExtractorBenchmarks.cs` pattern |
+
+No changes to `CsvRecordReader.cs`, `CsvRecordWriter.cs`, `JsonLinesRecordWriter.cs`, `CellData.cs`, `IRecordWriter.cs`, `RecordProcessor.cs`, `JsonByteExtractor.cs`, `JsonObjectCellExtractor.cs`, `ColumnType.cs`, or `TypeInferrer.cs` — see "Out of Scope" above.
+
+---
+
+## Implementation Approach
+
+### 1. `PooledValueBuffer`: a reference-type wrapper around the pooled buffer
+
+`JsonLinesRecordReader` is a `struct` implementing `IRecordReader`, and
+`RecordProcessor.ProcessAsync<TReader, TWriter>` (`where TReader : struct,
+IRecordReader`) takes it **by value**. The generated dispatcher does:
+
+```csharp
+using var reader = await readerFactory.CreateAsync(...);
+return await RecordProcessor.ProcessAsync<TReader, TWriter>(reader, writer, ...);
+```
+
+The `reader` passed into `ProcessAsync` is a **copy** of the dispatcher's
+`reader`. `Dispose()` is only ever called on the dispatcher's original (the
+`using var reader`) — never on the copy that `ProcessAsync` actually uses to
+call `GetCellData` in its loop.
+
+A plain `char[]?` field directly on `JsonLinesRecordReader` would break
+under this copying: each struct copy has its own independent field slot, so
+the copy inside `ProcessAsync` would rent a buffer into its own slot, while
+the copy that gets `Dispose()`d (the dispatcher's original) has a slot that
+was never touched. The actually-rented array would never be returned to
+`ArrayPool<char>.Shared` — a real leak. (This was flagged in code review
+against an earlier draft of this design that used exactly that plain-field
+shape.)
+
+The existing `_rowReader` field already avoids this problem for a different
+piece of state: it's a **reference-type** field (`RowReader?`), assigned
+once in the constructor. Every struct copy's `_rowReader` field holds a
+reference to the *same* `RowReader` instance, so it doesn't matter which
+copy's `Dispose()` runs — they all release the same underlying object.
+`PooledValueBuffer` applies the identical pattern to the pooled buffer:
+wrapping it in a small reference type, assigned once in the constructor, so
+every struct copy shares the same buffer identity and the same disposal
+responsibility.
+
+(An intermediate alternative — changing `ProcessAsync`'s `reader` parameter
+to `ref TReader` to avoid the copy at its source, rather than working around
+it — was considered and ruled out: `ProcessAsync` is `async` and `await`s
+inside a `while` loop, and C# does not allow `ref`/`out`/`in` parameters on
+`async` methods, since the compiler cannot keep a byref alive across an
+`await` suspension point. This is a hard language constraint, not a design
+choice. See "Decision Record" for the other alternatives considered.)
+
+```csharp
+private sealed class PooledValueBuffer : IDisposable
+{
+    private const int MinimumSize = 256;
+
+    private char[]? _buffer;
+    private bool _disposed;
+
+    public char[] Reserve(int minimumLength)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+
+        if (_buffer is not null && _buffer.Length >= minimumLength)
+        {
+            return _buffer;
+        }
+
+        if (_buffer is not null)
+        {
+            ArrayPool<char>.Shared.Return(_buffer);
+        }
+
+        _buffer = ArrayPool<char>.Shared.Rent(Math.Max(MinimumSize, minimumLength));
+        return _buffer;
+    }
+
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        if (_buffer is not null)
+        {
+            ArrayPool<char>.Shared.Return(_buffer);
+            _buffer = null;
+        }
+
+        _disposed = true;
+    }
+}
+
+private readonly PooledValueBuffer _valueBuffer = new();
+```
+
+`Reserve` is the only access path to the wrapped `char[]` — the backing
+array stays `private` to `PooledValueBuffer`. The wrapper tracks its own
+`_disposed` flag rather than relying on `JsonLinesRecordReader`'s: since any
+struct copy could in principle call `Dispose()`, the wrapper's idempotency
+must not depend on which copy calls it or in what order. `Reserve` throws
+`ObjectDisposedException` if already disposed, so a rent after disposal
+fails loudly instead of silently renting a buffer nothing will ever return.
+
+`minimumLength` is always sized as an upper bound on the resulting char
+count *before* the write happens (UTF-8 byte count for Number/Object/Array,
+raw escaped byte count for String — see step 2), so the underlying
+`Encoding.UTF8.GetChars`/`Utf8JsonReader.CopyString` call never hits its
+buffer-too-small path. `Reserve` is therefore the only place buffer sizing
+decisions are made; no exception-driven retry is needed (consistent with
+the project's "no exceptions for flow control" rule).
+
+### 2. Per-token-type extraction helpers, replacing `ReadPropertyValue`'s inline expressions
+
+`ReadPropertyValue` changes from `private static` to a `private` instance
+method (still taking `Utf8JsonReader reader` by value — the existing
+comment explaining that choice, and the `S1541`/`CS8168`/`CS8347` reasoning
+behind it, remains valid and unchanged; only the enclosing method stops
+being `static` so it can reach `_valueBuffer` through `this`). Its `Number`
+and `StartObject`/`StartArray`/`String` arms are extracted into three small
+instance helpers so the switch expression stays a single dispatch and each
+helper stays under the nesting/complexity limits:
+
+```csharp
+private readonly CellData NumberToCellData(Utf8JsonReader reader)
+{
+    var bytes = reader.ValueSpan;
+    var buffer = _valueBuffer.Reserve(bytes.Length);
+    var charsWritten = Encoding.UTF8.GetChars(bytes, buffer);
+    return new CellData(buffer.AsSpan(0, charsWritten), CellPresence.Value, CellEncoding.Raw);
+}
+
+private readonly CellData ObjectOrArrayToCellData(Utf8JsonReader reader, JsonRawBytes containingBytes)
+{
+    var bytes = JsonByteExtractor.ExtractValueBytes(ref reader, containingBytes).Span;
+    var buffer = _valueBuffer.Reserve(bytes.Length);
+    var charsWritten = Encoding.UTF8.GetChars(bytes, buffer);
+    return new CellData(buffer.AsSpan(0, charsWritten), CellPresence.Value, CellEncoding.Raw);
+}
+
+private readonly CellData StringToCellData(Utf8JsonReader reader)
+{
+    var buffer = _valueBuffer.Reserve(reader.ValueSpan.Length);
+    var charsWritten = reader.CopyString(buffer);
+    return new CellData(buffer.AsSpan(0, charsWritten), CellPresence.Value, CellEncoding.PlainText);
+}
+```
+
+`reader.ValueSpan.Length` (raw UTF-8 byte count) is a safe upper bound for
+the decoded char count in both cases: a multi-byte UTF-8 sequence always
+decodes to fewer chars than its byte count, and every JSON escape sequence
+(`\n`, `\uXXXX`, …) occupies more source bytes than the character(s) it
+resolves to. `ReadPropertyValue`'s switch expression then becomes:
+
+```csharp
+private readonly CellData ReadPropertyValue(Utf8JsonReader reader, JsonRawBytes containingBytes)
+{
+    return reader.TokenType switch
+    {
+        JsonTokenType.Null => new CellData([], CellPresence.Null),
+        JsonTokenType.Number => NumberToCellData(reader),
+        JsonTokenType.StartObject or JsonTokenType.StartArray => ObjectOrArrayToCellData(reader, containingBytes),
+        JsonTokenType.String => StringToCellData(reader),
+        JsonTokenType.True => new CellData("true", CellPresence.Value, CellEncoding.Boolean),
+        JsonTokenType.False => new CellData("false", CellPresence.Value, CellEncoding.Boolean),
+        _ => new CellData([], CellPresence.Invalid),
+    };
+}
+```
+
+### 3. `GetCellData` keeps its `readonly` modifier
+
+Unlike an earlier draft of this design (which used a plain `char[]?` field
+reassigned directly on the struct, and so needed to drop `readonly` from
+`GetCellData`), `_valueBuffer` here is a `readonly PooledValueBuffer` field
+— assigned once via its field initializer, never reassigned. Calling
+`_valueBuffer.Reserve(...)` from inside a `readonly` struct member is legal:
+`readonly` on a struct method only forbids reassigning the struct's *own*
+fields, not calling mutating methods on the reference-type objects those
+fields point to (a `readonly` struct method invoking a mutating method
+through a `readonly` reference-type field was confirmed to compile cleanly).
+`GetCellData`, `ReadPropertyValue`, and the three new helper methods
+(`NumberToCellData`/`ObjectOrArrayToCellData`/`StringToCellData`) are all
+`readonly`. This mirrors why `EvaluateFilters`/`ThrowIfDisposed` are already
+`readonly` today despite the struct holding other mutable reference-type
+state (`_rowReader`).
+
+### 4. `Dispose()`
+
+```csharp
+public void Dispose()
+{
+    if (_disposed)
+    {
+        return;
+    }
+
+    _rowReader?.Dispose();
+    _rowReader = null;
+
+    _valueBuffer.Dispose();
+
+    _disposed = true;
+}
+```
+
+### 5. `GetCellData` documentation
+
+Add an XML doc remark on `IRecordReader.GetCellData` — moved here from
+`CellData.Value` per code review, since this is a contract of the *reader*
+implementation, not of the data struct itself — stating that the returned
+`CellData.Value` span is valid only until the reader's next `GetCellData`
+call, and becomes invalid once the reader is `Dispose()`d. This validity
+guarantee must hold for every `IRecordReader` implementation, so the
+interface doc says nothing about how the storage is backed —
+`CsvRecordReader` returns Sep-provided spans directly and never pools
+anything.
+
+The `ArrayPool<char>` detail — the buffer is pooled and reused, not
+freshly allocated per cell — is `JsonLinesRecordReader`-specific and goes
+on that struct's own XML doc (or `_valueBuffer`'s), not on the interface
+member.
+
+---
+
+## Decision Record
+
+### Rationale
+
+**`ArrayPool<char>` buffer reuse, not a per-cell `string`:** This is
+exactly the performance investment `docs/design_batch_cell_typed_channel.md`
+deferred ("Alternative D" in its Decision Record) rather than bundling into
+a correctness fix. That design's stated blockers — buffer lifecycle
+management, the "valid only until next call" constraint, and re-rent
+handling on overflow — are what this design resolves.
+
+**`Utf8JsonReader.CopyString`, not a hand-rolled unescape:** `CopyString`
+is the standard, escape-resolving API for copying a JSON string's decoded
+characters into a caller-owned buffer without allocating (confirmed via a
+scratch program: it returns the number of characters written as `int`, and
+throws `ArgumentException` if the destination is too small). Re-implementing
+JSON string unescaping by hand would be strictly worse: more code, and a new
+opportunity to diverge from `Utf8JsonReader`'s own (already-correct)
+unescaping behavior.
+
+**Pre-sized buffers, not catch-and-retry on `ArgumentException`:** Both
+`Encoding.UTF8.GetChars` and `Utf8JsonReader.CopyString` throw when the
+destination span is too small rather than reporting a required size. Sizing
+the buffer to an upper bound (`reader.ValueSpan.Length`, confirmed always
+`>=` the eventual char count for both UTF-8 decoding and JSON-escape
+resolution) before writing avoids ever depending on that exception path,
+consistent with the project's rule against using exceptions for flow
+control.
+
+**`ReadPropertyValue` becomes an instance method:** it needs `this` to
+reach `_valueBuffer`. The existing comment on this method explains why
+`Utf8JsonReader` is taken *by value* rather than `ref` (a `ref
+Utf8JsonReader` parameter makes the ref struct return value
+ref-safety-inferred as escaping through that parameter, which fails to
+compile — `CS8168`/`CS8347`). That reasoning is about the parameter's own
+by-value-vs-by-ref shape, not about whether the method is `static`, so it is
+unaffected by this change and the comment does not need to be rewritten.
+
+**Splitting `ReadPropertyValue`'s switch arms into three helper methods:**
+each arm now needs two statements (reserve the buffer, then decode) instead
+of one expression, which no longer fits cleanly inside a switch
+*expression* arm. Extracting
+`NumberToCellData`/`ObjectOrArrayToCellData`/`StringToCellData` keeps the
+switch itself a flat, single-expression dispatch (unchanged structure from
+today) rather than converting it to a switch *statement* with a nested body
+per branch.
+
+**Why `PooledValueBuffer` (a reference-type wrapper), not a plain `char[]?`
+field:** see "Implementation Approach", step 1, for the full mechanics. In
+short: `JsonLinesRecordReader` is copied by value into
+`RecordProcessor.ProcessAsync`, and only the dispatcher's original copy is
+ever `Dispose()`d. A plain value-type field would let the `ProcessAsync`-side
+copy rent a buffer that nothing ever returns to the pool. Wrapping the
+buffer in a reference type, constructed once, gives every copy of the
+struct a shared identity for that state — the same technique the existing
+`_rowReader` field already relies on.
+
+**Why not `ref TReader` in `ProcessAsync` instead:** this would remove the
+copy at its source rather than working around it, but `ProcessAsync` is
+`async` and `await`s inside a loop; C# does not allow `ref`/`out`/`in`
+parameters on `async` methods. Not viable regardless of preference.
+
+**Why not the other two alternatives raised in review — moving disposal
+ownership into `RecordProcessor`, or converting `JsonLinesRecordReader` to a
+`class`:** moving disposal ownership to `RecordProcessor` requires changing
+`RecordProcessor.cs`, which breaks the Out-of-Scope boundary already agreed
+for this design. Converting the struct to a `class` removes the copy
+problem at its root, but affects every assumption downstream of `TReader :
+struct` across the batch pipeline — far beyond this issue's allocation-
+reduction scope.
+
+**Trade-offs accepted with `PooledValueBuffer`:**
+- It is itself a heap allocation — one per `JsonLinesRecordReader`
+  instance, paid once at construction. This does not reintroduce the
+  per-cell allocation this design removes, but it means the change trades
+  "many small allocations" for "one small allocation plus one wrapper
+  object," not literally zero allocations across the reader's lifetime.
+- `GetCellData` gains one extra pointer indirection per call
+  (`_valueBuffer.Reserve(...)` instead of a direct field read), negligible
+  next to the `string` allocation being removed.
+- This fix is scoped to `_valueBuffer` specifically. It does not prevent a
+  future change from adding another plain value-type field to
+  `JsonLinesRecordReader` that needs its own disposal and reintroducing the
+  same bug class; only converting the struct to a class would close that
+  off structurally, which is out of scope here.
+
+**Why `Reserve`, not `EnsureCapacity` or `Rent`:** `EnsureCapacity` is
+already a BCL naming convention (`List<T>.EnsureCapacity`,
+`StringBuilder.EnsureCapacity`) whose return value is the resulting `int`
+capacity, not the buffer itself — this method's shape doesn't match that
+convention and would be misleading. `Rent` matches `ArrayPool<T>.Rent`'s
+shape (`int -> T[]`) but implies a fresh rent on every call, which is
+misleading here since the method reuses the existing buffer whenever it's
+already large enough. `Reserve` was chosen to read as "secure and hand back
+a buffer of at least this size" without either implication. `Arrange` was
+also considered and rejected: this project's test methodology (`.claude/rules/testing.md`)
+uses `// Arrange` as a fixed vocabulary term for the AAA pattern, and reusing
+it as a production method name in the same codebase would be confusing.
+
+**Why `PooledValueBuffer` owns its own `_disposed` flag, rather than
+relying on `JsonLinesRecordReader`'s:** any struct copy could in principle
+call `Dispose()` (the same reasoning that motivates the wrapper's existence
+in the first place), so the wrapper's idempotency must not depend on which
+copy calls it, or on the calling struct's own disposal bookkeeping.
+
+**Why no `BitOperations.RoundUpToPowerOf2`:** an earlier draft rounded the
+requested size up to the next power of two before calling
+`ArrayPool<char>.Shared.Rent`. `RoundUpToPowerOf2(uint)` returns `0` when
+the input exceeds the largest representable power of two, which would turn
+an extremely large token into an invalid `Rent(0)` call. `Rent` already
+buckets its internal pools by power-of-two size, so rounding up before
+calling it is redundant — `ArrayPool<char>.Shared.Rent(Math.Max(MinimumSize,
+minimumLength))` achieves the same doubling-growth behavior without the
+overflow risk.
+
+### Consequences
+
+- `GetCellData`'s output is unchanged for every existing test case; only
+  the backing storage of `CellData.Value` changes (pooled buffer instead of
+  an independently-GC-managed `string`).
+- `CellData.Value`'s "valid only until the next `GetCellData` call"
+  constraint moves from an accepted-but-inert observation (in
+  `docs/design_batch_cell_typed_channel.md`'s Consequences — each `string`
+  was independently valid regardless of subsequent calls, so nothing could
+  actually break it) to a load-bearing invariant: reusing the same buffer
+  means a stale `CellData` handed to a caller that violates the contract
+  would observe corrupted data. All current call sites were audited and
+  consume the value synchronously before the next call, so this is not a
+  behavior change today, but it is now something a future change to
+  `RecordProcessor` or a writer must not break — hence documenting it
+  explicitly (see "Implementation Approach", step 5).
+- `JsonLinesRecordReader` remains a single-consumer, sequential-access
+  struct, matching its existing contract; the pooled buffer does not change
+  its thread-safety posture (it was never safe to share across concurrent
+  calls).
+- One rented `char[]` buffer lives for the lifetime of a `JsonLinesRecordReader`
+  instance (from first non-`Boolean`/`Null` cell read until `Dispose()`),
+  instead of a fresh `string` per cell being independently collected by the
+  GC. This trades a bounded, reused allocation for an unbounded stream of
+  small ones — the intended effect of this change.
+- One `PooledValueBuffer` object is allocated per `JsonLinesRecordReader`
+  instance, once, at construction — see "Trade-offs accepted with
+  `PooledValueBuffer`" above.
+- `GetCellData` and its new helper methods stay `readonly`; no existing
+  caller or interface signature changes as a result of this design (see
+  "Implementation Approach", step 3).
+
+### Test Plan
+
+In addition to `JsonLinesRecordReaderTests.cs`'s existing per-token-type
+coverage (unaffected — same expected `Value`/`Presence`/`Encoding` per
+case), add:
+
+- Reading two or more columns from the same row in sequence, asserting each
+  `CellData.Value.ToString()` is correct at the point it's read — the
+  actual `RecordProcessor` consumption pattern, exercised directly against
+  buffer reuse.
+- A String value long enough to force growth past the initial 256-char
+  buffer, asserting the grown buffer still produces the correct value.
+- A JSON string containing escape sequences (e.g. an embedded quote and a
+  `\n`), asserting the resolved text, not the raw escaped source.
+- An empty JSON string (`""`), asserting `PooledValueBuffer.Reserve`'s
+  `Math.Max(MinimumSize, minimumLength)` floor is exercised without error.
+- Copying the reader (`var copy = reader;`), disposing the *original*, then
+  calling `GetCellData` on the *copy* — the copy's own `_disposed` field is
+  still `false` (it's a separate struct copy), so `JsonLinesRecordReader`'s
+  own `ThrowIfDisposed()` does not catch this; the call must still throw
+  `ObjectDisposedException` via `PooledValueBuffer.Reserve`'s own guard,
+  since the *shared* `PooledValueBuffer` was disposed by the original.
+  (Calling `GetCellData` after `Dispose()` on the *same* instance is not a
+  sufficient test here — that path is already caught by
+  `JsonLinesRecordReader.ThrowIfDisposed()` before `Reserve` is ever
+  reached.)
+- A zero-allocation regression test: call `GetCellData` once to warm up the
+  buffer (forcing the initial `Reserve`), snapshot
+  `GC.GetAllocatedBytesForCurrentThread()`, call `GetCellData` again for a
+  Number/Object/Array/String cell, and assert the snapshot is unchanged.
+- The new `JsonLinesRecordReaderBenchmarks.cs`: representative Number,
+  String, Object, and Array columns benchmarked with `[MemoryDiagnoser]`,
+  confirming zero managed allocation after warm-up for `GetCellData`.
+  Benchmark methods return a scalar (e.g. `cell.Value.Length`) rather than
+  `CellData` itself, since `CellData` is a `ref struct` and BenchmarkDotNet
+  benchmark methods cannot return `ref struct` types. `[GlobalSetup]` warms
+  up the reader (forcing the initial `Reserve`) before measurement begins,
+  so measured `Allocated` reflects steady-state per-cell cost, not
+  first-call setup cost. `[GlobalCleanup]` calls the benchmark reader's
+  `Dispose()` and cleans up its temporary input file — `Dispose()` is the
+  only path that returns the rented `char[]` to `ArrayPool<char>.Shared`,
+  so skipping cleanup would permanently remove each instance's warmed-up
+  buffer from the shared pool for the process lifetime.

--- a/src/App/Cli/CsvRecordReader.cs
+++ b/src/App/Cli/CsvRecordReader.cs
@@ -46,7 +46,7 @@ internal struct CsvRecordReader : IRecordReader
 
     public readonly void ThrowIfDisposed()
     {
-        ObjectDisposedException.ThrowIf(_disposed, this);
+        ObjectDisposedException.ThrowIf(_disposed, typeof(CsvRecordReader));
     }
 
     public readonly bool EvaluateFilters()

--- a/src/App/Cli/CsvRecordWriter.cs
+++ b/src/App/Cli/CsvRecordWriter.cs
@@ -88,7 +88,7 @@ internal struct CsvRecordWriter : IRecordWriter
 
     public readonly void ThrowIfDisposed()
     {
-        ObjectDisposedException.ThrowIf(_disposed, this);
+        ObjectDisposedException.ThrowIf(_disposed, typeof(CsvRecordWriter));
     }
 
     public void Dispose()

--- a/src/App/Cli/IRecordReader.cs
+++ b/src/App/Cli/IRecordReader.cs
@@ -4,5 +4,15 @@ internal interface IRecordReader : IDisposable
 {
     ValueTask<bool> MoveNextAsync(CancellationToken ct);
     bool EvaluateFilters();
+
+    /// <summary>
+    /// Gets the cell data at the specified output column index for the current row.
+    /// </summary>
+    /// <remarks>
+    /// The returned <see cref="CellData.Value"/> span is valid only until the next
+    /// <see cref="GetCellData"/> call on this reader, and becomes invalid once this
+    /// reader is disposed. Callers must consume the value before invoking this method
+    /// again or disposing the reader.
+    /// </remarks>
     CellData GetCellData(int outputColumnIndex);
 }

--- a/src/App/Cli/JsonLinesRecordReader.PooledValueBuffer.cs
+++ b/src/App/Cli/JsonLinesRecordReader.PooledValueBuffer.cs
@@ -14,7 +14,6 @@ internal partial struct JsonLinesRecordReader
         private char[]? _buffer;
         private bool _disposed;
 
-        // Wired in Step 2 (ReadPropertyValue replacement); unused in this scaffold step.
         public char[] Reserve(int minimumLength)
         {
             ObjectDisposedException.ThrowIf(_disposed, this);

--- a/src/App/Cli/JsonLinesRecordReader.PooledValueBuffer.cs
+++ b/src/App/Cli/JsonLinesRecordReader.PooledValueBuffer.cs
@@ -1,0 +1,52 @@
+using System.Buffers;
+
+namespace Refedle.App.Cli;
+
+internal partial struct JsonLinesRecordReader
+{
+    // Wraps the rented ArrayPool<char> buffer in a reference type, assigned once in the
+    // constructor, so every struct copy shares one buffer identity and one disposal path
+    // (mirrors _rowReader). See docs/design_jsonlines_cell_value_zero_alloc.md step 1.
+    private sealed class PooledValueBuffer : IDisposable
+    {
+        private const int MinimumSize = 256;
+
+        private char[]? _buffer;
+        private bool _disposed;
+
+        // Wired in Step 2 (ReadPropertyValue replacement); unused in this scaffold step.
+        public char[] Reserve(int minimumLength)
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
+
+            if (_buffer is not null && _buffer.Length >= minimumLength)
+            {
+                return _buffer;
+            }
+
+            if (_buffer is not null)
+            {
+                ArrayPool<char>.Shared.Return(_buffer);
+            }
+
+            _buffer = ArrayPool<char>.Shared.Rent(Math.Max(MinimumSize, minimumLength));
+            return _buffer;
+        }
+
+        public void Dispose()
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            if (_buffer is not null)
+            {
+                ArrayPool<char>.Shared.Return(_buffer);
+                _buffer = null;
+            }
+
+            _disposed = true;
+        }
+    }
+}

--- a/src/App/Cli/JsonLinesRecordReader.cs
+++ b/src/App/Cli/JsonLinesRecordReader.cs
@@ -82,7 +82,7 @@ internal partial struct JsonLinesRecordReader : IRecordReader
 
     public readonly void ThrowIfDisposed()
     {
-        ObjectDisposedException.ThrowIf(_disposed, this);
+        ObjectDisposedException.ThrowIf(_disposed, typeof(JsonLinesRecordReader));
     }
 
     public readonly bool EvaluateFilters()

--- a/src/App/Cli/JsonLinesRecordReader.cs
+++ b/src/App/Cli/JsonLinesRecordReader.cs
@@ -163,6 +163,26 @@ internal partial struct JsonLinesRecordReader : IRecordReader
         };
     }
 
+    // Step 2 scaffolds: defined now and wired into ReadPropertyValue's branches in Step 2
+    // (see docs/design_jsonlines_cell_value_zero_alloc.md). Left uncalled in Step 1 so the
+    // existing string-backed branches keep their behavior and existing tests do not regress.
+#pragma warning disable IDE0051 // Wired into ReadPropertyValue's branches in Step 2
+    private readonly CellData NumberToCellData(Utf8JsonReader reader)
+    {
+        throw new NotImplementedException();
+    }
+
+    private readonly CellData ObjectOrArrayToCellData(Utf8JsonReader reader, JsonRawBytes containingBytes)
+    {
+        throw new NotImplementedException();
+    }
+
+    private readonly CellData StringToCellData(Utf8JsonReader reader)
+    {
+        throw new NotImplementedException();
+    }
+#pragma warning restore IDE0051
+
     public void Dispose()
     {
         if (_disposed)

--- a/src/App/Cli/JsonLinesRecordReader.cs
+++ b/src/App/Cli/JsonLinesRecordReader.cs
@@ -7,7 +7,7 @@ using Refedle.Engine.Models;
 
 namespace Refedle.App.Cli;
 
-internal struct JsonLinesRecordReader : IRecordReader
+internal partial struct JsonLinesRecordReader : IRecordReader
 {
     private readonly RowIndexer _rowIndexer;
     private readonly Memory<byte>[] _columnNameUtf8Bytes;
@@ -19,6 +19,7 @@ internal struct JsonLinesRecordReader : IRecordReader
     private int _batchIndex;
     private JsonRawBytes _currentLineBytes;
     private bool _disposed;
+    private readonly PooledValueBuffer _valueBuffer;
 
     public JsonLinesRecordReader(RowIndexer rowIndexer, RowReader rowReader, TableSchema inputSchema, BatchOutputSchema outputSchema)
     {
@@ -38,6 +39,7 @@ internal struct JsonLinesRecordReader : IRecordReader
         _batchIndex = -1;
         _currentLineBytes = default;
         _disposed = false;
+        _valueBuffer = new PooledValueBuffer();
     }
 
     public ValueTask<bool> MoveNextAsync(CancellationToken ct)
@@ -170,6 +172,9 @@ internal struct JsonLinesRecordReader : IRecordReader
 
         _rowReader?.Dispose();
         _rowReader = null;
+
+        _valueBuffer.Dispose();
+
         _disposed = true;
     }
 }

--- a/src/App/Cli/JsonLinesRecordReader.cs
+++ b/src/App/Cli/JsonLinesRecordReader.cs
@@ -143,45 +143,45 @@ internal partial struct JsonLinesRecordReader : IRecordReader
     // Split out to stay under the Sonar cyclomatic-complexity limit (S1541). Passed by value,
     // not by ref, so it owns a copy isolated from the caller's state (ref also fails to
     // compile: CS8168/CS8347); the resulting small, stack-only copy per call is an accepted cost.
-    private static CellData ReadPropertyValue(Utf8JsonReader reader, JsonRawBytes containingBytes)
+    private readonly CellData ReadPropertyValue(Utf8JsonReader reader, JsonRawBytes containingBytes)
     {
         return reader.TokenType switch
         {
             JsonTokenType.Null => new CellData([], CellPresence.Null),
-            JsonTokenType.Number =>
-                new CellData(Encoding.UTF8.GetString(reader.ValueSpan), CellPresence.Value, CellEncoding.Raw),
-            JsonTokenType.StartObject or JsonTokenType.StartArray =>
-                new CellData(
-                    Encoding.UTF8.GetString(JsonByteExtractor.ExtractValueBytes(ref reader, containingBytes).Span),
-                    CellPresence.Value,
-                    CellEncoding.Raw),
-            JsonTokenType.String =>
-                new CellData(reader.GetString(), CellPresence.Value, CellEncoding.PlainText),
+            JsonTokenType.Number => NumberToCellData(reader),
+            JsonTokenType.StartObject or JsonTokenType.StartArray => ObjectOrArrayToCellData(reader, containingBytes),
+            JsonTokenType.String => StringToCellData(reader),
             JsonTokenType.True => new CellData("true", CellPresence.Value, CellEncoding.Boolean),
             JsonTokenType.False => new CellData("false", CellPresence.Value, CellEncoding.Boolean),
             _ => new CellData([], CellPresence.Invalid),
         };
     }
 
-    // Step 2 scaffolds: defined now and wired into ReadPropertyValue's branches in Step 2
-    // (see docs/design_jsonlines_cell_value_zero_alloc.md). Left uncalled in Step 1 so the
-    // existing string-backed branches keep their behavior and existing tests do not regress.
-#pragma warning disable IDE0051 // Wired into ReadPropertyValue's branches in Step 2
+    // Decoded into the pooled buffer shared across GetCellData calls (valid only until the
+    // next call). ValueSpan.Length is a safe char-count upper bound: multi-byte UTF-8 and
+    // JSON escapes both use more source bytes than the chars they resolve to.
     private readonly CellData NumberToCellData(Utf8JsonReader reader)
     {
-        throw new NotImplementedException();
+        var bytes = reader.ValueSpan;
+        var buffer = _valueBuffer.Reserve(bytes.Length);
+        var charsWritten = Encoding.UTF8.GetChars(bytes, buffer);
+        return new CellData(buffer.AsSpan(0, charsWritten), CellPresence.Value, CellEncoding.Raw);
     }
 
     private readonly CellData ObjectOrArrayToCellData(Utf8JsonReader reader, JsonRawBytes containingBytes)
     {
-        throw new NotImplementedException();
+        var bytes = JsonByteExtractor.ExtractValueBytes(ref reader, containingBytes).Span;
+        var buffer = _valueBuffer.Reserve(bytes.Length);
+        var charsWritten = Encoding.UTF8.GetChars(bytes, buffer);
+        return new CellData(buffer.AsSpan(0, charsWritten), CellPresence.Value, CellEncoding.Raw);
     }
 
     private readonly CellData StringToCellData(Utf8JsonReader reader)
     {
-        throw new NotImplementedException();
+        var buffer = _valueBuffer.Reserve(reader.ValueSpan.Length);
+        var charsWritten = reader.CopyString(buffer);
+        return new CellData(buffer.AsSpan(0, charsWritten), CellPresence.Value, CellEncoding.PlainText);
     }
-#pragma warning restore IDE0051
 
     public void Dispose()
     {

--- a/src/App/Cli/JsonLinesRecordWriter.cs
+++ b/src/App/Cli/JsonLinesRecordWriter.cs
@@ -162,7 +162,7 @@ internal partial struct JsonLinesRecordWriter : IRecordWriter
 
     public readonly void ThrowIfDisposed()
     {
-        ObjectDisposedException.ThrowIf(_disposed, this);
+        ObjectDisposedException.ThrowIf(_disposed, typeof(JsonLinesRecordWriter));
     }
 
     public void Dispose()

--- a/src/App/GlobalSuppressions.cs
+++ b/src/App/GlobalSuppressions.cs
@@ -198,6 +198,14 @@ using System.Diagnostics.CodeAnalysis;
     Scope = "type",
     Target = "~T:Refedle.App.Cli.JsonLinesRecordWriter",
     Justification = "JsonLinesRecordWriter is a struct designed for monomorphization as per ADR. It implements IRecordWriter which inherits from IDisposable and IAsyncDisposable, but CA1001 analyzer may be confused by structs or specific field types.")]
+
+// Cli.JsonLinesRecordReader
+[assembly: SuppressMessage(
+    "Design",
+    "CA1001:Types that own disposable fields should be disposable",
+    Scope = "type",
+    Target = "~T:Refedle.App.Cli.JsonLinesRecordReader",
+    Justification = "JsonLinesRecordReader is a struct designed for monomorphization (RecordProcessor.ProcessAsync<TReader, TWriter>). It implements IRecordReader (which inherits IDisposable) and disposes _valueBuffer in Dispose(), but the CA1001 analyzer is confused by structs — same false positive as JsonLinesRecordWriter.")]
 [assembly: SuppressMessage(
     "Reliability",
     "CA1849:Call async methods when in an async method",

--- a/tests/Refedle.Tests/App/Cli/CsvRecordReaderTests.cs
+++ b/tests/Refedle.Tests/App/Cli/CsvRecordReaderTests.cs
@@ -38,4 +38,30 @@ public sealed class CsvRecordReaderTests
             File.Delete(filePath);
         }
     }
+
+    [Fact]
+    public async Task ThrowIfDisposed_AfterDispose_ThrowsWithConcreteTypeName()
+    {
+        // Arrange
+        var filePath = Path.GetTempFileName();
+        try
+        {
+            await File.WriteAllTextAsync(filePath, "value\nhello\n");
+            var sepReader = await Sep.New(',').Reader().FromFileAsync(filePath);
+            var outputSchema = new BatchOutputSchema([new BatchOutputColumn("value", "value")], []);
+            var recordReader = new CsvRecordReader(sepReader, outputSchema);
+            recordReader.Dispose();
+
+            // Act
+            Action act = () => recordReader.ThrowIfDisposed();
+
+            // Assert
+            var exception = act.Should().Throw<ObjectDisposedException>().Which;
+            exception.ObjectName.Should().Be(typeof(CsvRecordReader).FullName);
+        }
+        finally
+        {
+            File.Delete(filePath);
+        }
+    }
 }

--- a/tests/Refedle.Tests/App/Cli/CsvRecordWriterTests.cs
+++ b/tests/Refedle.Tests/App/Cli/CsvRecordWriterTests.cs
@@ -82,6 +82,23 @@ public sealed class CsvRecordWriterTests
         output.Should().Be($"{value}\n");
     }
 
+    [Fact]
+    public void ThrowIfDisposed_AfterDispose_ThrowsWithConcreteTypeName()
+    {
+        // Arrange
+        using var stream = new MemoryStream();
+        using var streamWriter = new StreamWriter(stream, new UTF8Encoding(false), leaveOpen: true) { NewLine = "\n" };
+        var writer = new CsvRecordWriter(streamWriter, _outputSchema);
+        writer.Dispose();
+
+        // Act
+        Action act = () => writer.ThrowIfDisposed();
+
+        // Assert
+        var exception = act.Should().Throw<ObjectDisposedException>().Which;
+        exception.ObjectName.Should().Be(typeof(CsvRecordWriter).FullName);
+    }
+
     private static async Task<string> WriteSingleCellAndReadAsync(CellPresence presence, string value = "", CellEncoding encoding = CellEncoding.PlainText)
     {
         using var stream = new MemoryStream();

--- a/tests/Refedle.Tests/App/Cli/JsonLinesRecordReaderBenchmarks.cs
+++ b/tests/Refedle.Tests/App/Cli/JsonLinesRecordReaderBenchmarks.cs
@@ -1,0 +1,71 @@
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Jobs;
+using Refedle.App.Cli;
+
+namespace Refedle.Tests.App.Cli;
+
+/// <summary>
+/// Benchmarks for JsonLinesRecordReader.GetCellData. Validates zero-allocation
+/// per cell access across representative token types (Number, String, Object, Array).
+/// </summary>
+[MemoryDiagnoser]
+[SimpleJob(RuntimeMoniker.NativeAot80)]
+public sealed class JsonLinesRecordReaderBenchmarks
+{
+    // Skeleton placeholders: read/written for the first time in Setup/Cleanup
+    // during Step 2, at which point these suppressions are removed.
+#pragma warning disable CA1823, IDE0044, IDE0052
+    private string _tempFilePath = string.Empty;
+#pragma warning restore CA1823, IDE0044, IDE0052
+
+#pragma warning disable CS0169, CA1823, IDE0051, CS0649
+    private JsonLinesRecordReader _reader;
+#pragma warning restore CS0169, CA1823, IDE0051, CS0649
+
+    /// <summary>
+    /// Writes a representative JSON Lines row, builds the reader, advances to the
+    /// first row, and warms up the pooled buffer so measured Allocated reflects
+    /// steady-state per-cell cost rather than first-call setup.
+    /// </summary>
+    [GlobalSetup]
+    public void Setup()
+    {
+        throw new NotImplementedException();
+    }
+
+    /// <summary>
+    /// Disposes the reader (returning the rented buffer to ArrayPool) and deletes
+    /// the temporary input file.
+    /// </summary>
+    [GlobalCleanup]
+    public void Cleanup()
+    {
+        throw new NotImplementedException();
+    }
+
+    /// <summary>
+    /// Reads a Number cell via GetCellData. Returns the value length as a scalar
+    /// since CellData is a ref struct and benchmark methods cannot return ref
+    /// struct types.
+    /// </summary>
+    [Benchmark]
+    public int ReadCell_Number() => throw new NotImplementedException();
+
+    /// <summary>
+    /// Reads a String cell via GetCellData. Returns the value length as a scalar.
+    /// </summary>
+    [Benchmark]
+    public int ReadCell_String() => throw new NotImplementedException();
+
+    /// <summary>
+    /// Reads an Object cell via GetCellData. Returns the value length as a scalar.
+    /// </summary>
+    [Benchmark]
+    public int ReadCell_Object() => throw new NotImplementedException();
+
+    /// <summary>
+    /// Reads an Array cell via GetCellData. Returns the value length as a scalar.
+    /// </summary>
+    [Benchmark]
+    public int ReadCell_Array() => throw new NotImplementedException();
+}

--- a/tests/Refedle.Tests/App/Cli/JsonLinesRecordReaderBenchmarks.cs
+++ b/tests/Refedle.Tests/App/Cli/JsonLinesRecordReaderBenchmarks.cs
@@ -1,46 +1,72 @@
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Jobs;
 using Refedle.App.Cli;
+using Refedle.Engine;
+using Refedle.Engine.IO.JsonLines;
+using Refedle.Engine.Models;
+using Refedle.Engine.Types;
 
 namespace Refedle.Tests.App.Cli;
 
 /// <summary>
-/// Benchmarks for JsonLinesRecordReader.GetCellData. Validates zero-allocation
-/// per cell access across representative token types (Number, String, Object, Array).
+/// Benchmarks for JsonLinesRecordReader.GetCellData. Measures per-cell managed
+/// allocation across representative token types (Number, String, Object, Array);
+/// zero allocation is the target once GetCellData is backed by a pooled buffer.
 /// </summary>
 [MemoryDiagnoser]
 [SimpleJob(RuntimeMoniker.NativeAot80)]
 public sealed class JsonLinesRecordReaderBenchmarks
 {
-    // Skeleton placeholders: read/written for the first time in Setup/Cleanup
-    // during Step 2, at which point these suppressions are removed.
-#pragma warning disable CA1823, IDE0044, IDE0052
-    private string _tempFilePath = string.Empty;
-#pragma warning restore CA1823, IDE0044, IDE0052
+    private const string NumberColumn = "number";
+    private const string StringColumn = "string";
+    private const string ObjectColumn = "object";
+    private const string ArrayColumn = "array";
 
-#pragma warning disable CS0169, CA1823, IDE0051, CS0649
+    // A representative single JSON Lines row exercising the four token types GetCellData
+    // branches on. Phase A: each branch allocates a string per cell; this benchmark
+    // visualizes that per-call cost (it does not reach zero until Phase B).
+    private const string JsonLine =
+        """{"number":1.50,"string":"hello","object":{"a":1},"array":[1,2,3]}""";
+
+    private string _tempFilePath = string.Empty;
     private JsonLinesRecordReader _reader;
-#pragma warning restore CS0169, CA1823, IDE0051, CS0649
 
     /// <summary>
     /// Writes a representative JSON Lines row, builds the reader, advances to the
-    /// first row, and warms up the pooled buffer so measured Allocated reflects
-    /// steady-state per-cell cost rather than first-call setup.
+    /// first row, and warms up each token-type branch so measured Allocated reflects
+    /// steady-state per-cell cost rather than first-call setup. After Phase B this
+    /// warm-up also forces the initial pooled-buffer Reserve.
     /// </summary>
     [GlobalSetup]
     public void Setup()
     {
-        throw new NotImplementedException();
+        _tempFilePath = Path.GetTempFileName();
+        File.WriteAllText(_tempFilePath, JsonLine);
+
+        var rowIndexer = new RowIndexer(_tempFilePath);
+        rowIndexer.BuildIndex();
+        var rowReader = new RowReader(_tempFilePath);
+        var (inputSchema, outputSchema) = BuildSchemas();
+        _reader = new JsonLinesRecordReader(rowIndexer, rowReader, inputSchema, outputSchema);
+        _ = _reader.MoveNextAsync(default).AsTask().GetAwaiter().GetResult();
+
+        // Warm up each branch in Setup so the measured Allocated excludes first-call
+        // cost: JIT today, and (post-Phase-B) the one-time pooled-buffer rent.
+        _ = _reader.GetCellData(0).Value.Length;
+        _ = _reader.GetCellData(1).Value.Length;
+        _ = _reader.GetCellData(2).Value.Length;
+        _ = _reader.GetCellData(3).Value.Length;
     }
 
     /// <summary>
-    /// Disposes the reader (returning the rented buffer to ArrayPool) and deletes
-    /// the temporary input file.
+    /// Disposes the reader (returning any rented buffer to ArrayPool after Phase B) and
+    /// deletes the temporary input file.
     /// </summary>
     [GlobalCleanup]
     public void Cleanup()
     {
-        throw new NotImplementedException();
+        _reader.Dispose();
+        File.Delete(_tempFilePath);
     }
 
     /// <summary>
@@ -49,23 +75,47 @@ public sealed class JsonLinesRecordReaderBenchmarks
     /// struct types.
     /// </summary>
     [Benchmark]
-    public int ReadCell_Number() => throw new NotImplementedException();
+    public int ReadCell_Number() => _reader.GetCellData(0).Value.Length;
 
     /// <summary>
     /// Reads a String cell via GetCellData. Returns the value length as a scalar.
     /// </summary>
     [Benchmark]
-    public int ReadCell_String() => throw new NotImplementedException();
+    public int ReadCell_String() => _reader.GetCellData(1).Value.Length;
 
     /// <summary>
     /// Reads an Object cell via GetCellData. Returns the value length as a scalar.
     /// </summary>
     [Benchmark]
-    public int ReadCell_Object() => throw new NotImplementedException();
+    public int ReadCell_Object() => _reader.GetCellData(2).Value.Length;
 
     /// <summary>
     /// Reads an Array cell via GetCellData. Returns the value length as a scalar.
     /// </summary>
     [Benchmark]
-    public int ReadCell_Array() => throw new NotImplementedException();
+    public int ReadCell_Array() => _reader.GetCellData(3).Value.Length;
+
+    private static (TableSchema InputSchema, BatchOutputSchema OutputSchema) BuildSchemas()
+    {
+        var inputSchema = new TableSchema
+        {
+            SourceFormat = DataFormat.JsonLines,
+            Columns =
+            [
+                new ColumnSchema { Name = NumberColumn, Type = ColumnType.Text, ColumnIndex = 0 },
+                new ColumnSchema { Name = StringColumn, Type = ColumnType.Text, ColumnIndex = 1 },
+                new ColumnSchema { Name = ObjectColumn, Type = ColumnType.Text, ColumnIndex = 2 },
+                new ColumnSchema { Name = ArrayColumn, Type = ColumnType.Text, ColumnIndex = 3 },
+            ],
+        };
+        var outputSchema = new BatchOutputSchema(
+            [
+                new BatchOutputColumn(NumberColumn, NumberColumn),
+                new BatchOutputColumn(StringColumn, StringColumn),
+                new BatchOutputColumn(ObjectColumn, ObjectColumn),
+                new BatchOutputColumn(ArrayColumn, ArrayColumn),
+            ],
+            []);
+        return (inputSchema, outputSchema);
+    }
 }

--- a/tests/Refedle.Tests/App/Cli/JsonLinesRecordReaderTests.GetCellData.PooledBuffer.cs
+++ b/tests/Refedle.Tests/App/Cli/JsonLinesRecordReaderTests.GetCellData.PooledBuffer.cs
@@ -1,38 +1,34 @@
 using AwesomeAssertions;
 using Refedle.App.Cli;
-using Refedle.Engine;
 using Refedle.Engine.IO.JsonLines;
-using Refedle.Engine.Models;
-using Refedle.Engine.Types;
 
 namespace Refedle.Tests.App.Cli;
 
 public sealed partial class JsonLinesRecordReaderTests
 {
-    private const string ColumnName = "value";
-
     [Fact]
-    public async Task GetCellData_NumberToken_ReturnsValueRaw()
+    public async Task GetCellData_MultipleColumnsReadSequentially_KeepsEachValueValidWhenRead()
     {
         // Arrange
         var filePath = Path.GetTempFileName();
         try
         {
-            File.WriteAllText(filePath, """{"value":1.50}""");
+            File.WriteAllText(filePath, """{"number":1.50,"text":"hello"}""");
             var rowIndexer = new RowIndexer(filePath);
             rowIndexer.BuildIndex();
             using var rowReader = new RowReader(filePath);
-            var (inputSchema, outputSchema) = BuildSchemas();
+            var (inputSchema, outputSchema) = BuildSchemas(["number", "text"]);
             using var reader = new JsonLinesRecordReader(rowIndexer, rowReader, inputSchema, outputSchema);
             await reader.MoveNextAsync(default);
 
-            // Act
-            var cell = reader.GetCellData(0);
+            // Act — consume each cell immediately (the RecordProcessor pattern) so buffer
+            // reuse across calls cannot corrupt a value before it is read.
+            var first = reader.GetCellData(0).Value.ToString();
+            var second = reader.GetCellData(1).Value.ToString();
 
             // Assert
-            cell.Presence.Should().Be(CellPresence.Value);
-            cell.Encoding.Should().Be(CellEncoding.Raw);
-            cell.Value.ToString().Should().Be("1.50");
+            first.Should().Be("1.50");
+            second.Should().Be("hello");
         }
         finally
         {
@@ -41,18 +37,26 @@ public sealed partial class JsonLinesRecordReaderTests
     }
 
     [Fact]
-    public async Task GetCellData_ObjectToken_ReturnsValueRaw()
+    public async Task GetCellData_StringExceedingInitialBuffer_ReturnsFullValue()
     {
         // Arrange
+        var longValue = new string('x', 300); // > MinimumSize (256), forces buffer growth
         var filePath = Path.GetTempFileName();
         try
         {
-            File.WriteAllText(filePath, """{"value":{"a":1}}""");
+            var content = """{"value":"hi"}""" + "\n" + $$"""{"value":"{{longValue}}"}""";
+            File.WriteAllText(filePath, content);
             var rowIndexer = new RowIndexer(filePath);
             rowIndexer.BuildIndex();
             using var rowReader = new RowReader(filePath);
             var (inputSchema, outputSchema) = BuildSchemas();
             using var reader = new JsonLinesRecordReader(rowIndexer, rowReader, inputSchema, outputSchema);
+
+            // Establish the initial 256-char buffer with the short first row.
+            await reader.MoveNextAsync(default);
+            _ = reader.GetCellData(0).Value.Length;
+
+            // Advance to the long row, which exceeds the initial buffer and forces growth.
             await reader.MoveNextAsync(default);
 
             // Act
@@ -60,8 +64,8 @@ public sealed partial class JsonLinesRecordReaderTests
 
             // Assert
             cell.Presence.Should().Be(CellPresence.Value);
-            cell.Encoding.Should().Be(CellEncoding.Raw);
-            cell.Value.ToString().Should().Be("""{"a":1}""");
+            cell.Encoding.Should().Be(CellEncoding.PlainText);
+            cell.Value.ToString().Should().Be(longValue);
         }
         finally
         {
@@ -70,42 +74,14 @@ public sealed partial class JsonLinesRecordReaderTests
     }
 
     [Fact]
-    public async Task GetCellData_ArrayToken_ReturnsValueRaw()
+    public async Task GetCellData_StringWithEscapeSequences_ReturnsResolvedText()
     {
         // Arrange
         var filePath = Path.GetTempFileName();
         try
         {
-            File.WriteAllText(filePath, """{"value":[1,2,3]}""");
-            var rowIndexer = new RowIndexer(filePath);
-            rowIndexer.BuildIndex();
-            using var rowReader = new RowReader(filePath);
-            var (inputSchema, outputSchema) = BuildSchemas();
-            using var reader = new JsonLinesRecordReader(rowIndexer, rowReader, inputSchema, outputSchema);
-            await reader.MoveNextAsync(default);
-
-            // Act
-            var cell = reader.GetCellData(0);
-
-            // Assert
-            cell.Presence.Should().Be(CellPresence.Value);
-            cell.Encoding.Should().Be(CellEncoding.Raw);
-            cell.Value.ToString().Should().Be("[1,2,3]");
-        }
-        finally
-        {
-            File.Delete(filePath);
-        }
-    }
-
-    [Fact]
-    public async Task GetCellData_StringToken_ReturnsValuePlainText()
-    {
-        // Arrange
-        var filePath = Path.GetTempFileName();
-        try
-        {
-            File.WriteAllText(filePath, """{"value":"hello"}""");
+            // Raw JSON escapes (\n, \"); CopyString must resolve them, not return them verbatim.
+            File.WriteAllText(filePath, """{"value":"line1\n\"quoted\""}""");
             var rowIndexer = new RowIndexer(filePath);
             rowIndexer.BuildIndex();
             using var rowReader = new RowReader(filePath);
@@ -119,7 +95,7 @@ public sealed partial class JsonLinesRecordReaderTests
             // Assert
             cell.Presence.Should().Be(CellPresence.Value);
             cell.Encoding.Should().Be(CellEncoding.PlainText);
-            cell.Value.ToString().Should().Be("hello");
+            cell.Value.ToString().Should().Be("line1\n\"quoted\"");
         }
         finally
         {
@@ -128,13 +104,14 @@ public sealed partial class JsonLinesRecordReaderTests
     }
 
     [Fact]
-    public async Task GetCellData_BooleanToken_ReturnsValueBoolean()
+    public async Task GetCellData_EmptyString_ReturnsEmptyValueWithoutError()
     {
         // Arrange
         var filePath = Path.GetTempFileName();
         try
         {
-            File.WriteAllText(filePath, """{"value":true}""");
+            // Empty string exercises Reserve's Math.Max(MinimumSize, 0) floor without error.
+            File.WriteAllText(filePath, """{"value":""}""");
             var rowIndexer = new RowIndexer(filePath);
             rowIndexer.BuildIndex();
             using var rowReader = new RowReader(filePath);
@@ -147,8 +124,8 @@ public sealed partial class JsonLinesRecordReaderTests
 
             // Assert
             cell.Presence.Should().Be(CellPresence.Value);
-            cell.Encoding.Should().Be(CellEncoding.Boolean);
-            cell.Value.ToString().Should().Be("true");
+            cell.Encoding.Should().Be(CellEncoding.PlainText);
+            cell.Value.ToString().Should().Be(string.Empty);
         }
         finally
         {
@@ -157,13 +134,82 @@ public sealed partial class JsonLinesRecordReaderTests
     }
 
     [Fact]
-    public async Task GetCellData_FalseToken_ReturnsValueBoolean()
+    public async Task GetCellData_AfterDisposingOriginalCopy_ThrowsObjectDisposedException()
     {
         // Arrange
         var filePath = Path.GetTempFileName();
         try
         {
-            File.WriteAllText(filePath, """{"value":false}""");
+            File.WriteAllText(filePath, """{"value":1.50}""");
+            var rowIndexer = new RowIndexer(filePath);
+            rowIndexer.BuildIndex();
+            using var rowReader = new RowReader(filePath);
+            var (inputSchema, outputSchema) = BuildSchemas();
+            var reader = new JsonLinesRecordReader(rowIndexer, rowReader, inputSchema, outputSchema);
+            await reader.MoveNextAsync(default);
+
+            // The copy keeps its own _disposed=false but shares the reference-type buffer, so
+            // only Reserve's guard (not the copy's ThrowIfDisposed) catches the disposed shared
+            // buffer. Disposing the same instance instead would be caught too early to test it.
+            var copy = reader;
+            reader.Dispose();
+
+            // Act
+            Action act = () => { _ = copy.GetCellData(0); };
+
+            // Assert
+            act.Should().Throw<ObjectDisposedException>();
+        }
+        finally
+        {
+            File.Delete(filePath);
+        }
+    }
+
+    [Fact]
+    public async Task GetCellData_AfterWarmUp_AllocatesZeroBytes()
+    {
+        // Arrange
+        var filePath = Path.GetTempFileName();
+        try
+        {
+            File.WriteAllText(filePath, """{"value":1.50}""");
+            var rowIndexer = new RowIndexer(filePath);
+            rowIndexer.BuildIndex();
+            using var rowReader = new RowReader(filePath);
+            var (inputSchema, outputSchema) = BuildSchemas();
+            using var reader = new JsonLinesRecordReader(rowIndexer, rowReader, inputSchema, outputSchema);
+            await reader.MoveNextAsync(default);
+
+            // Warm up so the one-time pooled-buffer Reserve happens before measurement.
+            _ = reader.GetCellData(0).Value.Length;
+
+            // Act — steady-state GetCellData reuses the buffer and must allocate nothing.
+            // Same thread throughout: MoveNextAsync completes synchronously, so no await hop.
+            var before = GC.GetAllocatedBytesForCurrentThread();
+            var cell = reader.GetCellData(0);
+            var after = GC.GetAllocatedBytesForCurrentThread();
+
+            // Assert
+            (after - before).Should().Be(0);
+            cell.Presence.Should().Be(CellPresence.Value);
+            cell.Value.Length.Should().Be("1.50".Length);
+        }
+        finally
+        {
+            File.Delete(filePath);
+        }
+    }
+
+    [Fact]
+    public async Task GetCellData_StringWithUtf8Characters_ReturnsFullText()
+    {
+        // Arrange
+        var value = "日本語😀"; // CJK characters plus a surrogate-pair emoji
+        var filePath = Path.GetTempFileName();
+        try
+        {
+            File.WriteAllText(filePath, $$"""{"value":"{{value}}"}""");
             var rowIndexer = new RowIndexer(filePath);
             rowIndexer.BuildIndex();
             using var rowReader = new RowReader(filePath);
@@ -176,8 +222,8 @@ public sealed partial class JsonLinesRecordReaderTests
 
             // Assert
             cell.Presence.Should().Be(CellPresence.Value);
-            cell.Encoding.Should().Be(CellEncoding.Boolean);
-            cell.Value.ToString().Should().Be("false");
+            cell.Encoding.Should().Be(CellEncoding.PlainText);
+            cell.Value.ToString().Should().Be(value);
         }
         finally
         {
@@ -185,14 +231,16 @@ public sealed partial class JsonLinesRecordReaderTests
         }
     }
 
-    [Fact]
-    public async Task GetCellData_NullToken_ReturnsNullPresence()
+    [Theory]
+    [InlineData("""{"text":"日本語😀"}""")]
+    [InlineData("""["日本語😀"]""")]
+    public async Task GetCellData_RawStructuredValueWithUtf8_ReturnsFullRawText(string rawValue)
     {
         // Arrange
         var filePath = Path.GetTempFileName();
         try
         {
-            File.WriteAllText(filePath, """{"value":null}""");
+            File.WriteAllText(filePath, $$"""{"value":{{rawValue}}}""");
             var rowIndexer = new RowIndexer(filePath);
             rowIndexer.BuildIndex();
             using var rowReader = new RowReader(filePath);
@@ -204,79 +252,13 @@ public sealed partial class JsonLinesRecordReaderTests
             var cell = reader.GetCellData(0);
 
             // Assert
-            cell.Presence.Should().Be(CellPresence.Null);
+            cell.Presence.Should().Be(CellPresence.Value);
+            cell.Encoding.Should().Be(CellEncoding.Raw);
+            cell.Value.ToString().Should().Be(rawValue);
         }
         finally
         {
             File.Delete(filePath);
         }
-    }
-
-    [Fact]
-    public async Task GetCellData_MissingProperty_ReturnsMissingPresence()
-    {
-        // Arrange
-        var filePath = Path.GetTempFileName();
-        try
-        {
-            File.WriteAllText(filePath, """{"other":1}""");
-            var rowIndexer = new RowIndexer(filePath);
-            rowIndexer.BuildIndex();
-            using var rowReader = new RowReader(filePath);
-            var (inputSchema, outputSchema) = BuildSchemas();
-            using var reader = new JsonLinesRecordReader(rowIndexer, rowReader, inputSchema, outputSchema);
-            await reader.MoveNextAsync(default);
-
-            // Act
-            var cell = reader.GetCellData(0);
-
-            // Assert
-            cell.Presence.Should().Be(CellPresence.Missing);
-        }
-        finally
-        {
-            File.Delete(filePath);
-        }
-    }
-
-    [Fact]
-    public async Task GetCellData_MalformedJson_ReturnsInvalidPresence()
-    {
-        // Arrange
-        var filePath = Path.GetTempFileName();
-        try
-        {
-            File.WriteAllText(filePath, "not valid json");
-            var rowIndexer = new RowIndexer(filePath);
-            rowIndexer.BuildIndex();
-            using var rowReader = new RowReader(filePath);
-            var (inputSchema, outputSchema) = BuildSchemas();
-            using var reader = new JsonLinesRecordReader(rowIndexer, rowReader, inputSchema, outputSchema);
-            await reader.MoveNextAsync(default);
-
-            // Act
-            var cell = reader.GetCellData(0);
-
-            // Assert
-            cell.Presence.Should().Be(CellPresence.Invalid);
-        }
-        finally
-        {
-            File.Delete(filePath);
-        }
-    }
-
-    private static (TableSchema InputSchema, BatchOutputSchema OutputSchema) BuildSchemas() =>
-        BuildSchemas([ColumnName]);
-
-    private static (TableSchema InputSchema, BatchOutputSchema OutputSchema) BuildSchemas(IReadOnlyList<string> columnNames)
-    {
-        var inputSchema = new TableSchema
-        {
-            SourceFormat = DataFormat.JsonLines,
-            Columns = [.. columnNames.Select((name, index) => new ColumnSchema { Name = name, Type = ColumnType.Text, ColumnIndex = index })],
-        };
-        var outputSchema = new BatchOutputSchema([.. columnNames.Select(name => new BatchOutputColumn(name, name))], []);
-        return (inputSchema, outputSchema);
     }
 }

--- a/tests/Refedle.Tests/App/Cli/JsonLinesRecordReaderTests.cs
+++ b/tests/Refedle.Tests/App/Cli/JsonLinesRecordReaderTests.cs
@@ -266,6 +266,34 @@ public sealed partial class JsonLinesRecordReaderTests
         }
     }
 
+    [Fact]
+    public void ThrowIfDisposed_AfterDispose_ThrowsWithConcreteTypeName()
+    {
+        // Arrange
+        var filePath = Path.GetTempFileName();
+        try
+        {
+            File.WriteAllText(filePath, """{"value":1.50}""");
+            var rowIndexer = new RowIndexer(filePath);
+            rowIndexer.BuildIndex();
+            using var rowReader = new RowReader(filePath);
+            var (inputSchema, outputSchema) = BuildSchemas();
+            var reader = new JsonLinesRecordReader(rowIndexer, rowReader, inputSchema, outputSchema);
+            reader.Dispose();
+
+            // Act
+            Action act = () => reader.ThrowIfDisposed();
+
+            // Assert
+            var exception = act.Should().Throw<ObjectDisposedException>().Which;
+            exception.ObjectName.Should().Be(typeof(JsonLinesRecordReader).FullName);
+        }
+        finally
+        {
+            File.Delete(filePath);
+        }
+    }
+
     private static (TableSchema InputSchema, BatchOutputSchema OutputSchema) BuildSchemas() =>
         BuildSchemas([ColumnName]);
 

--- a/tests/Refedle.Tests/App/Cli/JsonLinesRecordReaderTests.cs
+++ b/tests/Refedle.Tests/App/Cli/JsonLinesRecordReaderTests.cs
@@ -266,6 +266,72 @@ public sealed class JsonLinesRecordReaderTests
         }
     }
 
+    [Fact]
+    public void GetCellData_MultipleColumnsReadSequentially_KeepsEachValueValidWhenRead()
+    {
+        // Arrange
+
+        // Act
+
+        // Assert
+        Assert.Fail("Not implemented");
+    }
+
+    [Fact]
+    public void GetCellData_StringExceedingInitialBuffer_ReturnsFullValue()
+    {
+        // Arrange
+
+        // Act
+
+        // Assert
+        Assert.Fail("Not implemented");
+    }
+
+    [Fact]
+    public void GetCellData_StringWithEscapeSequences_ReturnsResolvedText()
+    {
+        // Arrange
+
+        // Act
+
+        // Assert
+        Assert.Fail("Not implemented");
+    }
+
+    [Fact]
+    public void GetCellData_EmptyString_ReturnsEmptyValueWithoutError()
+    {
+        // Arrange
+
+        // Act
+
+        // Assert
+        Assert.Fail("Not implemented");
+    }
+
+    [Fact]
+    public void GetCellData_AfterDisposingOriginalCopy_ThrowsObjectDisposedException()
+    {
+        // Arrange
+
+        // Act
+
+        // Assert
+        Assert.Fail("Not implemented");
+    }
+
+    [Fact]
+    public void GetCellData_AfterWarmUp_AllocatesZeroBytes()
+    {
+        // Arrange
+
+        // Act
+
+        // Assert
+        Assert.Fail("Not implemented");
+    }
+
     private static (TableSchema InputSchema, BatchOutputSchema OutputSchema) BuildSchemas()
     {
         var inputSchema = new TableSchema

--- a/tests/Refedle.Tests/App/Cli/JsonLinesRecordWriterTests.cs
+++ b/tests/Refedle.Tests/App/Cli/JsonLinesRecordWriterTests.cs
@@ -138,4 +138,20 @@ public sealed class JsonLinesRecordWriterTests
         var output = Encoding.UTF8.GetString(stream.ToArray());
         output.Should().Be("{\"value\":\"\"}\n");
     }
+
+    [Fact]
+    public void ThrowIfDisposed_AfterDispose_ThrowsWithConcreteTypeName()
+    {
+        // Arrange
+        using var stream = new MemoryStream();
+        var writer = new JsonLinesRecordWriter(stream, _outputSchema);
+        writer.Dispose();
+
+        // Act
+        Action act = () => writer.ThrowIfDisposed();
+
+        // Assert
+        var exception = act.Should().Throw<ObjectDisposedException>().Which;
+        exception.ObjectName.Should().Be(typeof(JsonLinesRecordWriter).FullName);
+    }
 }

--- a/tests/Refedle.Tests/GlobalSuppressions.cs
+++ b/tests/Refedle.Tests/GlobalSuppressions.cs
@@ -41,3 +41,11 @@ using System.Diagnostics.CodeAnalysis;
     Scope = "member",
     Target = "~M:Refedle.Tests.App.Views.JsonLinesTableSourceTests.Dispose_DisposesRowByteCache",
     Justification = "Ownership transferred to source")]
+
+// JsonLinesRecordReaderBenchmarks
+[assembly: SuppressMessage(
+    "Reliability",
+    "CA2000:Dispose objects before losing scope",
+    Scope = "member",
+    Target = "~M:Refedle.Tests.App.Cli.JsonLinesRecordReaderBenchmarks.Setup",
+    Justification = "RowReader ownership is transferred to JsonLinesRecordReader; disposed via _reader.Dispose() in Cleanup.")]


### PR DESCRIPTION
## Summary
- Replace the per-cell heap-allocated `string` in `JsonLinesRecordReader.GetCellData` (Number/Object/Array/String) with an `ArrayPool<char>`-backed buffer reused across calls, via a new `PooledValueBuffer` wrapper.
- Fix an unrelated existing bug found while adding the zero-allocation regression test: `ThrowIfDisposed()` boxed the struct's `this` when calling `ObjectDisposedException.ThrowIf`, adding ~104 bytes per call. Fixed across all four `IRecordReader`/`IRecordWriter` struct implementations (`CsvRecordReader`, `CsvRecordWriter`, `JsonLinesRecordReader`, `JsonLinesRecordWriter`) using the `typeof(T)` overload.
- `GetCellData_AfterWarmUp_AllocatesZeroBytes` now passes: a warm `GetCellData` call allocates exactly 0 bytes.

Closes #275

## Test plan
- [x] `dotnet format` — no changes
- [x] `dotnet build` — 0 warnings, 0 errors
- [x] `dotnet test` — 1590/1590 passed, 0 skipped