### PR TITLE
fix: exclude benchmark project from solution-wide publish

### DIFF
--- a/benchmarks/Refedle.Benchmarks/Refedle.Benchmarks.csproj
+++ b/benchmarks/Refedle.Benchmarks/Refedle.Benchmarks.csproj
@@ -6,6 +6,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
+    <IsPublishable>false</IsPublishable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <!-- Zero-Warning Policy -->
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>


### PR DESCRIPTION
## Summary
- Add `IsPublishable=false` to `Refedle.Benchmarks.csproj`
- Fixes `NETSDK1151` raised when running `dotnet publish` across the whole solution, caused by the benchmark project referencing the self-contained AOT `Refedle.App` without matching `SelfContained`

## Test plan
- [x] `dotnet publish` (solution-wide) completes without error
- [x] `dotnet format` — no changes
- [x] `dotnet build` — 0 warnings, 0 errors
- [x] `dotnet test` — 1548 passed